### PR TITLE
Add drag-and-drop visual indicator and edge placement

### DIFF
--- a/style.css
+++ b/style.css
@@ -1211,6 +1211,23 @@ a:hover {
   cursor: grabbing;
 }
 
+/* Drop indicator for drag and drop */
+.drop-indicator {
+  width: 4px;
+  height: 140px;
+  background: var(--accent-primary);
+  border-radius: 2px;
+  margin: 0 -2px;
+  box-shadow: 0 0 8px var(--accent-primary);
+  animation: pulse-indicator 0.8s ease-in-out infinite;
+  flex-shrink: 0;
+}
+
+@keyframes pulse-indicator {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
 .page-item .delete-btn {
   position: absolute;
   bottom: 24px;


### PR DESCRIPTION
UX improvements for Page Manager drag and drop:
- Visual drop indicator (pulsing blue line) shows where page will land
- Indicator appears on left or right side based on mouse position
- Drag to leftmost edge to place page first
- Drag to rightmost edge to place page last
- Smooth animation on the indicator for better visibility