### PR TITLE
Completely redesign PDF editor with major improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,28 +357,38 @@
       </div>
       <div class="editor-container">
         <div class="editor-toolbar">
-          <button class="editor-tool-btn" data-edit-tool="whiteout" onclick="setEditTool('whiteout')">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/></svg>
-            Whiteout
-          </button>
-          <button class="editor-tool-btn" data-edit-tool="text" onclick="setEditTool('text')">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 7V4h16v3M9 20h6M12 4v16"/></svg>
-            Tambah Teks
-          </button>
-          <button class="editor-tool-btn" data-edit-tool="signature" onclick="openSignatureModal()">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 19.5v.5a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v1.5"/><path d="m16 19-3-3 8-8 3 3-8 8Z"/></svg>
-            Tanda Tangan
-          </button>
-          <div class="control-group" id="text-controls" style="display:none; margin-left: auto;">
-            <select id="edit-font-size">
-              <option value="12">12pt</option>
-              <option value="14">14pt</option>
-              <option value="16" selected>16pt</option>
-              <option value="18">18pt</option>
-              <option value="24">24pt</option>
-              <option value="32">32pt</option>
-            </select>
-            <input type="color" id="edit-text-color" value="#000000" title="Warna teks">
+          <div class="editor-tool-group">
+            <button class="editor-tool-btn" data-edit-tool="select" onclick="setEditTool('select')" title="Pilih & Edit (V)">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 3l7.07 16.97 2.51-7.39 7.39-2.51L3 3z"/><path d="M13 13l6 6"/></svg>
+              Pilih
+            </button>
+            <button class="editor-tool-btn" data-edit-tool="whiteout" onclick="setEditTool('whiteout')" title="Whiteout (W)">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/></svg>
+              Whiteout
+            </button>
+            <button class="editor-tool-btn" data-edit-tool="text" onclick="setEditTool('text')" title="Tambah Teks (T)">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 7V4h16v3M9 20h6M12 4v16"/></svg>
+              Teks
+            </button>
+            <button class="editor-tool-btn" data-edit-tool="signature" onclick="openSignatureModal()" title="Tanda Tangan (S)">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 19.5v.5a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v1.5"/><path d="m16 19-3-3 8-8 3 3-8 8Z"/></svg>
+              Tanda Tangan
+            </button>
+          </div>
+          <div class="editor-tool-divider"></div>
+          <div class="editor-action-group">
+            <button class="editor-action-btn" onclick="undoEdit()" title="Undo (Ctrl+Z)">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 7v6h6"/><path d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6 2.3L3 13"/></svg>
+            </button>
+            <button class="editor-action-btn" onclick="redoEdit()" title="Redo (Ctrl+Y)">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>
+            </button>
+            <button class="editor-action-btn danger" onclick="clearCurrentPageAnnotations()" title="Hapus Semua di Halaman Ini">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/></svg>
+            </button>
+          </div>
+          <div class="editor-status" id="editor-status">
+            <span class="status-text">Pilih alat untuk mulai mengedit</span>
           </div>
         </div>
         <div class="editor-canvas-wrapper">
@@ -391,7 +401,6 @@
         </div>
       </div>
       <div class="action-bar">
-        <button class="btn btn-secondary" onclick="undoEdit()">↩ Undo</button>
         <button class="btn btn-primary btn-lg" id="edit-btn" disabled onclick="saveEditedPDF()">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           Download PDF
@@ -853,6 +862,46 @@
         <button class="btn btn-secondary" onclick="clearSignature()">Hapus</button>
         <button class="btn btn-ghost" onclick="closeSignatureModal()">Batal</button>
         <button class="btn btn-primary" onclick="useSignature()">Gunakan</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Text Input Modal -->
+  <div id="text-input-modal" class="edit-modal">
+    <div class="edit-modal-box">
+      <h3>Tambah Teks</h3>
+      <div class="edit-modal-content">
+        <textarea id="text-input-field" class="edit-text-input" placeholder="Masukkan teks..." rows="3"></textarea>
+        <div class="edit-text-options">
+          <div class="edit-option-group">
+            <label>Ukuran Font</label>
+            <select id="modal-font-size">
+              <option value="10">10pt</option>
+              <option value="12">12pt</option>
+              <option value="14">14pt</option>
+              <option value="16" selected>16pt</option>
+              <option value="18">18pt</option>
+              <option value="20">20pt</option>
+              <option value="24">24pt</option>
+              <option value="28">28pt</option>
+              <option value="32">32pt</option>
+              <option value="36">36pt</option>
+              <option value="48">48pt</option>
+            </select>
+          </div>
+          <div class="edit-option-group">
+            <label>Warna</label>
+            <input type="color" id="modal-text-color" value="#000000">
+          </div>
+        </div>
+        <div class="edit-text-preview">
+          <span id="text-preview-label">Preview:</span>
+          <div id="text-preview" class="text-preview-box"></div>
+        </div>
+      </div>
+      <div class="edit-modal-actions">
+        <button class="btn btn-ghost" onclick="closeTextModal()">Batal</button>
+        <button class="btn btn-primary" onclick="confirmTextInput()">Tambah Teks</button>
       </div>
     </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -1261,6 +1261,264 @@ a:hover {
   }
 }
 
+/* Enhanced PDF Editor Styles */
+.editor-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-md);
+  margin-bottom: var(--space-lg);
+  padding-bottom: var(--space-lg);
+  border-bottom: 1px solid var(--border-light);
+}
+
+.editor-tool-group {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.editor-tool-divider {
+  width: 1px;
+  height: 32px;
+  background: var(--border-light);
+}
+
+.editor-action-group {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.editor-action-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  color: var(--text-secondary);
+  transition: all var(--transition-fast);
+}
+
+.editor-action-btn:hover {
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+  background: var(--accent-light);
+}
+
+.editor-action-btn.danger:hover {
+  border-color: #dc2626;
+  color: #dc2626;
+  background: rgba(220, 38, 38, 0.1);
+}
+
+.editor-status {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.editor-status .status-text {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
+/* Text Input Modal */
+.edit-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.5);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.edit-modal.active {
+  display: flex;
+}
+
+.edit-modal-box {
+  background: var(--bg-secondary);
+  border-radius: var(--radius-lg);
+  padding: var(--space-xl);
+  max-width: 480px;
+  width: 90%;
+  box-shadow: var(--shadow-xl);
+}
+
+.edit-modal-box h3 {
+  margin-bottom: var(--space-lg);
+  font-size: 1.125rem;
+}
+
+.edit-modal-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.edit-text-input {
+  width: 100%;
+  padding: var(--space-md);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-md);
+  font-size: 1rem;
+  font-family: inherit;
+  resize: vertical;
+  min-height: 80px;
+  transition: border-color var(--transition-fast);
+}
+
+.edit-text-input:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+}
+
+.edit-text-options {
+  display: flex;
+  gap: var(--space-lg);
+  flex-wrap: wrap;
+}
+
+.edit-option-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.edit-option-group label {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.edit-option-group select,
+.edit-option-group input[type="color"] {
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-md);
+  background: var(--bg-primary);
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.edit-option-group input[type="color"] {
+  width: 50px;
+  height: 36px;
+  padding: 2px;
+}
+
+.edit-text-preview {
+  padding: var(--space-md);
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-md);
+}
+
+#text-preview-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  display: block;
+  margin-bottom: var(--space-xs);
+}
+
+.text-preview-box {
+  min-height: 40px;
+  padding: var(--space-sm);
+  background: white;
+  border-radius: var(--radius-sm);
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}
+
+.edit-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-md);
+  margin-top: var(--space-lg);
+}
+
+/* Annotation Selection Handles */
+.annotation-selected {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
+/* Canvas Cursors */
+.editor-canvas.tool-select { cursor: default; }
+.editor-canvas.tool-whiteout { cursor: crosshair; }
+.editor-canvas.tool-text { cursor: text; }
+.editor-canvas.tool-signature { cursor: copy; }
+.editor-canvas.dragging { cursor: grabbing; }
+.editor-canvas.resizing { cursor: nwse-resize; }
+
+/* Annotation Resize Handles (rendered via CSS overlay) */
+.resize-handle {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  background: var(--accent-primary);
+  border: 2px solid white;
+  border-radius: 2px;
+  cursor: nwse-resize;
+}
+
+.resize-handle.nw { top: -5px; left: -5px; cursor: nwse-resize; }
+.resize-handle.ne { top: -5px; right: -5px; cursor: nesw-resize; }
+.resize-handle.sw { bottom: -5px; left: -5px; cursor: nesw-resize; }
+.resize-handle.se { bottom: -5px; right: -5px; cursor: nwse-resize; }
+
+/* Mobile Responsive for Editor */
+@media (max-width: 768px) {
+  .editor-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-sm);
+  }
+
+  .editor-tool-group {
+    justify-content: center;
+  }
+
+  .editor-tool-divider {
+    display: none;
+  }
+
+  .editor-action-group {
+    justify-content: center;
+  }
+
+  .editor-status {
+    justify-content: center;
+    margin-left: 0;
+    margin-top: var(--space-sm);
+  }
+
+  .editor-tool-btn {
+    padding: var(--space-sm);
+    font-size: 0.75rem;
+  }
+
+  .editor-tool-btn svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  .edit-modal-box {
+    padding: var(--space-lg);
+  }
+
+  .edit-text-options {
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+}
+
 /* Utility Classes */
 .hidden { display: none !important; }
 .text-center { text-align: center; }


### PR DESCRIPTION
- Replace prompt() with modal dialog for text input with live preview
- Fix coordinate transformation for multi-page PDFs with per-page scaling
- Add selection tool to select, move, and delete existing annotations
- Add undo/redo system with 50-state history stack
- Add keyboard shortcuts (V=select, W=whiteout, T=text, S=signature, Ctrl+Z/Y)
- Add touch support for mobile devices
- Improve canvas rendering with devicePixelRatio for crisp high-DPI display
- Add adaptive signature sizing based on page scale
- Add visual selection handles with dashed border and corner resize handles
- Add status bar showing current tool instructions
- Add clear all annotations button for current page
- Add multi-line text support
- Improve coordinate mapping from canvas to PDF coordinates
- Add better error handling and user feedback