### PR TITLE
feat: keyboard shortcuts for zoom (+/- keys)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1545,6 +1545,9 @@
           <div class="shortcut-item"><kbd>Ctrl</kbd><kbd>Z</kbd> <span>Undo</span></div>
           <div class="shortcut-item"><kbd>Ctrl</kbd><kbd>Y</kbd> <span>Redo</span></div>
           <div class="shortcut-item"><kbd>Del</kbd> <span>Hapus anotasi</span></div>
+          <div class="shortcut-item"><kbd>+ / =</kbd> <span>Perbesar</span></div>
+          <div class="shortcut-item"><kbd>-</kbd> <span>Perkecil</span></div>
+          <div class="shortcut-item"><kbd>0</kbd> <span>Reset Zoom</span></div>
         </div>
       </div>
       <div class="shortcuts-modal-actions">

--- a/js/keyboard.js
+++ b/js/keyboard.js
@@ -8,7 +8,10 @@ import { showHome } from './lib/navigation.js';
 import {
   ueDownload, ueUndoAnnotation, ueRedoAnnotation, ueSaveEditUndoState,
   ueSetTool, ueOpenSignatureModal, ueOpenParafModal, ueRotateCurrentPage,
-  ueRedrawAnnotations, ueSelectPage
+  ueRedrawAnnotations, ueSelectPage,
+  ueZoomIn,
+  ueZoomOut,
+  ueZoomReset
 } from './editor/index.js';
 
 // ============================================================
@@ -91,6 +94,14 @@ export function setupKeyboardShortcuts() {
       if (e.key === '?' || (e.shiftKey && key === '/')) {
         e.preventDefault();
         openShortcutsModal();
+      }
+      
+      if (e.key === '=' || (e.key === '=' && e.shiftKey) || e.key === '+') {
+        ueZoomIn();
+      } else if (e.key === '-') {
+        ueZoomOut();
+      } else if (e.key === '0'){
+        ueZoomReset()
       }
     }
   });


### PR DESCRIPTION
## What does this PR do?

<!-- Brief description of the change. Link to issue if applicable: Fixes #123 -->
- Added Keyboard shortcuts for zooming during editing.
- Update the shortcuts modal in index.html (#shortcuts-modal) to show the new shortcuts
- Fixes #37 

## Type of change

- [ ] Bug fix
- [  yes ] New feature
- [ ] Refactoring (no behavior change)
- [ ] Documentation
- [ ] Other: <!-- describe -->

## Checklist

### Required

- [ yes ] **100% client-side** — no server calls, no external APIs with user data
- [ yes ] **UI text in Indonesian** — informal "kamu" tone, not "anda"
- [ yes ] **No new dependencies** added (or justified why one is needed)
- [ yes ] Tested with `npx serve` + hard refresh (Ctrl+Shift+R)
- [ yes ] No console errors in browser DevTools

### If you changed JS modules

- [ ] New exports added to barrel `index.js`
- [ ] `window.*` bridge added (if function is used in HTML `onclick`)
- [ ] Used SSOT helpers where applicable:
  - [ ] `createPageInfo()` for page objects
  - [ ] `create*Annotation()` factories for annotations
  - [ ] `openModal()` / `closeModal()` for modal open/close
  - [ ] `isPDF()` / `isImage()` for file type checks
  - [ ] `loadPdfDocument()` instead of raw `pdfjsLib.getDocument()`
- [ ] New state fields added to `getDefaultUeState()` (if applicable)

### If you changed UI/layout

- [ ] Tested on desktop (>900px)
- [ ] Tested on mobile (<=900px)
- [ ] Modals have `role="dialog" aria-modal="true" aria-label="..."`
- [ ] Interactive elements have keyboard support

### Testing done

<!-- Describe what you tested. Be specific about browsers and devices. -->

Tested in chrome browser. 
After uploading a pdf file, clicking on 
`+` (Shift+= / direct `+` present in numlock panel), `=` increases the Zoom
`-` decreases the zoom
`0` resets the zoom.

Also tested when in text editing mode, typing of these keyboard shortcuts is adding them to the text area, instead of performing Zoom operations.

<img width="1920" height="1080" alt="Screenshot (3)" src="https://github.com/user-attachments/assets/798c9bbe-c500-4411-b383-8de305cd8c90" />


## Screenshots / recordings (if UI change)

<!-- Paste before/after screenshots or screen recordings -->

<img width="1920" height="1080" alt="Screenshot (5)" src="https://github.com/user-attachments/assets/4530c320-8ebf-44d4-a190-b078254e87f0" />

---

<details>
<summary>AI contributor notes</summary>

If you used an AI assistant (Claude, ChatGPT, Copilot, etc.) to help with this PR:

- **AI tool used:** <!-- e.g., Claude Code, GitHub Copilot -->
- **What the AI did:** <!-- e.g., "wrote the implementation", "helped debug", "reviewed code" -->
- **Human review:** <!-- e.g., "I reviewed all changes", "maintainer will review" -->

This is encouraged! We just want transparency.

</details>
