### PR TITLE
chore(ci): bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,10 +12,10 @@ jobs:
     outputs:
       runnable: ${{ steps.filter.outputs.runnable }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Pinned to commit SHA per GitHub Actions supply-chain guidance.
-      # SHA = dorny/paths-filter v3.0.2 release. Bump explicitly when needed.
-      - uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
+      # SHA = dorny/paths-filter v4.0.1 release. Bump explicitly when needed.
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
           filters: |
@@ -40,8 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -49,7 +49,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: pw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: |


### PR DESCRIPTION
## Summary
- Bump all five actions to majors that declare `using: node24` in their `action.yml`
- Silences the Node 20 deprecation warning we saw on run #7
- Deadline context: GitHub forces Node 24 on 2026-06-16, removes Node 20 on 2026-09-16

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v4 | v6 |
| actions/setup-node | v4 | v6 |
| actions/cache | v4 | v5 |
| actions/upload-artifact | v4 | v7 |
| dorny/paths-filter | v3 (SHA-pinned) | v4.0.1 (SHA-pinned) |

`node-version: 20` for the Playwright job stays — that's the Node version our tests run against, separate from the action runtime.

## Test plan
- [ ] CI runs green on this PR (proves the upgrade itself works)
- [ ] No new Node 20 deprecation warnings in the run log
- [ ] All 11 tests still pass (8 smoke + 3 golden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)