### PR TITLE
fix(editor): Escape closes overlay, not the whole editor (C1)

### DIFF
--- a/js/keyboard.js
+++ b/js/keyboard.js
@@ -4,7 +4,30 @@
  */
 
 import { state, ueState } from './lib/state.js';
-import { showHome, openModal, closeModal } from './lib/navigation.js';
+import { showHome, openModal, closeModal, closeAllModals, hasOpenModal } from './lib/navigation.js';
+
+// WHY: Escape needs to dismiss any open dropdown before falling through to "exit editor".
+// These are the dropdown IDs that can be open inside the editor — kept here as a small
+// list because each is opened/closed by hand-rolled toggle functions, not via openModal().
+// If a new dropdown is added in the editor, add its ID here too.
+const EDITOR_DROPDOWN_IDS = ['ft-more-dropdown', 'mobile-tools-dropdown', 'more-tools-dropdown'];
+
+function closeOpenEditorDropdown() {
+  for (const id of EDITOR_DROPDOWN_IDS) {
+    const el = document.getElementById(id);
+    if (el?.classList.contains('active')) {
+      el.classList.remove('active');
+      return true;
+    }
+  }
+  // File menu in editor header uses `.open`, not `.active`
+  const fileDropdown = document.getElementById('editor-file-dropdown');
+  if (fileDropdown?.classList.contains('open')) {
+    fileDropdown.classList.remove('open');
+    return true;
+  }
+  return false;
+}
 
 // WHY: Editor functions accessed via window.* bridges (set by editor/index.js)
 // instead of static import. Static import of editor/index.js pulled in 15 sub-modules
@@ -61,11 +84,18 @@ function handleEscapeKey(isTyping) {
   // signature name field), Escape is the local widget's own cancel gesture — must not
   // bubble up to "navigate home" or close the surrounding workspace.
   if (isTyping) return;
-  const shortcutsModal = document.getElementById('shortcuts-modal');
-  if (shortcutsModal?.classList.contains('active')) {
-    closeShortcutsModal();
+
+  // WHY (cascade): Escape dismisses the topmost overlay, not the editor itself.
+  // Before the cascade existed, Escape from any modal/dropdown fell straight through
+  // to showHome() and wiped the user's in-progress edits. Documented in
+  // memory/ux-audit-2026-05-30.md (finding C1).
+  // Order: open modal -> open dropdown -> finally exit editor as a last resort.
+  if (hasOpenModal()) {
+    closeAllModals();
     return;
   }
+  if (closeOpenEditorDropdown()) return;
+
   if (state.currentTool) showHome();
 }
 

--- a/js/lib/navigation.js
+++ b/js/lib/navigation.js
@@ -87,6 +87,17 @@ export function closeAllModals() {
   navHistory.currentModal = null;
 }
 
+// WHY: handleEscapeKey in keyboard.js needs to know whether ANY overlay is open
+// before falling through to "exit editor". Without this check, Escape from a
+// modal/dropdown would kick the user back to the homepage and lose all work.
+// Keep MODAL_IDS the single source of truth — never duplicate the list elsewhere.
+export function hasOpenModal() {
+  if (MODAL_IDS.some(id => document.getElementById(id)?.classList.contains('active'))) {
+    return true;
+  }
+  return !!document.getElementById('ue-gabungkan-modal')?.classList.contains('active');
+}
+
 // ============================================================
 // NAVIGATION
 // ============================================================
@@ -306,6 +317,7 @@ window.pushModalState = pushModalState;
 window.openModal = openModal;
 window.closeModal = closeModal;
 window.closeAllModals = closeAllModals;
+window.hasOpenModal = hasOpenModal;
 window.showHome = showHome;
 window.showTool = showTool;
 window.setupWorkspaceDropZone = setupWorkspaceDropZone;

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -222,6 +222,53 @@ test.describe('inline text editor', () => {
   });
 });
 
+test.describe('escape cascade', () => {
+  // WHY: Companion to regression #1 but for the OTHER escape path. Before this
+  // fix, Escape from any modal/dropdown that wasn't `shortcuts-modal` fell
+  // through to showHome() and wiped the user's annotations. Documented in
+  // memory/ux-audit-2026-05-30.md (finding C1).
+  test('regression: Escape from signature modal closes only the modal', async ({ page }) => {
+    await page.goto('/');
+    await loadSamplePdf(page);
+    await addTextAnnotation(page, 0, { x: 100, y: 100, text: 'do-not-lose' });
+
+    await page.evaluate(() => window.ueOpenSignatureModal());
+    await page.waitForFunction(() => document.getElementById('signature-modal')?.classList.contains('active'));
+
+    await page.keyboard.press('Escape');
+
+    await page.waitForFunction(() => !document.getElementById('signature-modal')?.classList.contains('active'));
+    await expect(page.locator('body')).toHaveClass(/editor-active/);
+    const text = await page.evaluate(() => window.ueState.annotations[0][0]?.text);
+    expect(text).toBe('do-not-lose');
+  });
+
+  test('regression: Escape from Lainnya dropdown closes only the dropdown', async ({ page }) => {
+    await page.goto('/');
+    await loadSamplePdf(page);
+    await addTextAnnotation(page, 0, { x: 100, y: 100, text: 'still-here' });
+
+    await page.locator('#ft-more-btn').click();
+    await page.waitForFunction(() => document.getElementById('ft-more-dropdown')?.classList.contains('active'));
+
+    await page.keyboard.press('Escape');
+
+    await page.waitForFunction(() => !document.getElementById('ft-more-dropdown')?.classList.contains('active'));
+    await expect(page.locator('body')).toHaveClass(/editor-active/);
+    const text = await page.evaluate(() => window.ueState.annotations[0][0]?.text);
+    expect(text).toBe('still-here');
+  });
+
+  test('Escape with no overlay open still exits editor', async ({ page }) => {
+    await page.goto('/');
+    await loadSamplePdf(page);
+
+    await page.keyboard.press('Escape');
+
+    await expect(page.locator('body')).not.toHaveClass(/editor-active/);
+  });
+});
+
 test.describe('export pipeline', () => {
   test('regression #2: failed font fetch is NOT retried per annotation', async ({ page }) => {
     // WHY counter is local + reset before download: CSS @font-face also pulls


### PR DESCRIPTION
## Summary

UX audit finding **C1** — the single most damaging bug in the product.

**Before:** Escape from any modal/dropdown except \`shortcuts-modal\` fell straight through to \`showHome()\` and wiped the user's in-progress annotations. Every persona in the May 30 audit hit this — reproduced 3 times in a single session.

**After:** [js/keyboard.js](js/keyboard.js#L59-L80) cascades — close open modal → close open dropdown → only then exit editor.

| Layer | Closes |
|-------|--------|
| 1. Modal | signature, paraf, signature-bg, text-input, watermark, pagenum, protect, shortcuts, gabungkan |
| 2. Dropdown | Lainnya (ft-more), mobile-tools, more-tools, editor-file |
| 3. Fallback | exit editor (only when nothing else is open) |

Adds \`hasOpenModal()\` to navigation.js so \`MODAL_IDS\` stays SSOT. Adds 3 regression specs (escape from signature modal, escape from Lainnya dropdown, baseline exit when no overlay open).

## Test plan
- [x] All 14 specs green locally (\`npx playwright test\`)
- [x] Lint clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)