### PR TITLE
feat(editor): inline text + last-used formatting (H1 + H2)

### DIFF
--- a/js/editor/canvas-events.js
+++ b/js/editor/canvas-events.js
@@ -3,7 +3,7 @@
  * Canvas event handling (mouse, touch, drag, resize, double-click)
  */
 
-import { ueState, state, DOUBLE_TAP_DELAY, DOUBLE_TAP_DISTANCE, createWhiteoutAnnotation } from '../lib/state.js';
+import { ueState, state, DOUBLE_TAP_DELAY, DOUBLE_TAP_DISTANCE, createWhiteoutAnnotation, createTextAnnotation } from '../lib/state.js';
 import { showToast } from '../lib/utils.js';
 import { ueGetCoords, ueGetResizeHandle, getTextBounds } from './canvas-utils.js';
 import { ueRedrawAnnotations, ueFindAnnotationAt, ueAddAnnotation } from './annotations.js';
@@ -424,8 +424,23 @@ export function ueSetupCanvasEvents() {
         ueRedrawAnnotations();
       }
     } else if (ueState.currentTool === 'text') {
-      ueState.pendingTextPosition = { x: startX, y: startY };
-      window.ueOpenTextModal();
+      // WHY: Inline editing on first creation (UX audit finding H1). The modal-per-text
+      // flow forced Sari to do 8 modal cycles for an 8-field contract; inline is the
+      // industry-standard pattern. We drop an empty annotation with lastTextOptions
+      // (filled style or factory defaults), then open the same inline editor used
+      // for double-click edits. Format defaults are remembered across annotations
+      // via ueState.lastTextOptions (finding H2).
+      ueSaveEditUndoState();
+      const newIndex = ueAddAnnotation(pageIndex, createTextAnnotation({
+        text: '',
+        x: startX,
+        y: startY,
+        ...ueState.lastTextOptions,
+      }));
+      ueState.selectedAnnotation = { pageIndex, index: newIndex };
+      const newAnno = ueState.annotations[pageIndex][newIndex];
+      track('editor_action', { action: 'text_inline' });
+      ueCreateInlineTextEditor(newAnno, { isNew: true });
     } else if ((ueState.currentTool === 'signature' || ueState.currentTool === 'paraf') && state.signatureImage) {
       uePlaceSignature(startX, startY);
     }

--- a/js/editor/inline-editor.js
+++ b/js/editor/inline-editor.js
@@ -5,10 +5,18 @@
 
 import { ueState, mobileState, buildCanvasFont } from '../lib/state.js';
 import { ueGetCurrentCanvas, getTextBounds } from './canvas-utils.js';
-import { ueRedrawAnnotations } from './annotations.js';
+import { ueRedrawAnnotations, ueRemoveAnnotation } from './annotations.js';
 import { uePushAnnotationSnapshot } from './undo-redo.js';
 
-export function ueCreateInlineTextEditor(anno) {
+// WHY: opts.isNew = true when the annotation was just created via canvas click
+// (inline-on-first-create flow). Differs from the dblclick-on-existing path in
+// two ways:
+//   1. If user cancels (Escape) or saves with empty text, we remove the orphan
+//      annotation — there was no original text to preserve.
+//   2. On save, we capture the formatting back into ueState.lastTextOptions so
+//      the next text annotation reuses it.
+export function ueCreateInlineTextEditor(anno, opts = {}) {
+  const isNew = !!opts.isNew;
   const existing = document.getElementById('inline-text-editor');
   if (existing) existing.remove();
 
@@ -58,15 +66,54 @@ export function ueCreateInlineTextEditor(anno) {
   const originalText = anno.text;
   let saved = false;
 
+  const removeOrphan = () => {
+    // Find the orphan annotation by reference (page index may have changed if
+    // pages were reordered during the edit, though unlikely) and remove it.
+    for (const [pageKey, list] of Object.entries(ueState.annotations)) {
+      const idx = list.indexOf(anno);
+      if (idx >= 0) {
+        ueRemoveAnnotation(Number(pageKey), idx);
+        return;
+      }
+    }
+  };
+
   const saveEdit = () => {
     if (saved) return;
     saved = true;
     const newText = editor.innerText.trim();
     delete anno._editing;
 
+    // WHY: When a click-to-create annotation gets no text, leaving it would
+    // pollute the document with invisible empty annotations and the undo
+    // stack would have a wasted snapshot. Treat empty-on-save like cancel.
+    if (isNew && !newText) {
+      removeOrphan();
+      ueRedrawAnnotations();
+      editor.remove();
+      return;
+    }
+
     if (newText && newText !== originalText) {
       uePushAnnotationSnapshot(JSON.parse(JSON.stringify(ueState.annotations)));
       anno.text = newText;
+    }
+
+    // WHY: Capture this annotation's formatting so the next text creation
+    // reuses it. Sari fills 8 contract fields once-and-for-all in Helvetica
+    // 12pt → all 8 land in Helvetica 12pt without re-picking.
+    if (isNew) {
+      ueState.lastTextOptions = {
+        fontSize: anno.fontSize,
+        color: anno.color,
+        fontFamily: anno.fontFamily,
+        bold: !!anno.bold,
+        italic: !!anno.italic,
+      };
+      // Match the post-create behavior the modal flow had: drop the user into
+      // select mode so the newly created text can be moved/resized without
+      // accidentally spawning another annotation on the next click.
+      if (typeof window.ueSetTool === 'function') window.ueSetTool('select');
     }
 
     ueRedrawAnnotations();
@@ -79,6 +126,8 @@ export function ueCreateInlineTextEditor(anno) {
     // commit ~100-300ms later and pollute the undo stack.
     saved = true;
     delete anno._editing;
+    // Click-to-create annotations have no "original" state to preserve — drop them.
+    if (isNew) removeOrphan();
     ueRedrawAnnotations();
     editor.remove();
   };

--- a/js/lib/state.js
+++ b/js/lib/state.js
@@ -183,6 +183,18 @@ export const ueState = {
   devicePixelRatio: 1,    // Set on init, updated on render
   eventsSetup: false,     // Guard: true after event delegation attached (one-time setup)
   pageObserver: null,     // IntersectionObserver — needs .disconnect() side effect on reset
+  // WHY: Remembers the formatting of the last-typed text annotation so the next
+  // text annotation picks up the same style. Without this, every annotation
+  // would reset to Helvetica/16pt/black and Sari would re-pick the same font
+  // 8 times to fill a contract. Persists across file loads in the same session,
+  // hence outside getDefaultUeState. (UX audit finding H2.)
+  lastTextOptions: {
+    fontSize: 16,
+    color: '#000000',
+    fontFamily: 'Helvetica',
+    bold: false,
+    italic: false,
+  },
 };
 
 // ============================================================

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -40,14 +40,18 @@ async function getPageCanvasBox(page, pageIndex) {
   return await handle.boundingBox();
 }
 
-// WHY: Adds a text annotation via the canonical text-tool → modal → confirm
-// flow. Keeps each test free of UI plumbing.
+// WHY: Adds a text annotation via the canonical text-tool → inline-edit → Enter
+// flow that ships in PR2 (UX audit H1/H2). To pick a non-default fontFamily,
+// poke lastTextOptions before clicking — that's the same lever the user gets,
+// since with inline editing the modal isn't part of first creation anymore.
 async function addTextAnnotation(page, pageIndex, { x, y, text, fontFamily }) {
+  if (fontFamily) {
+    await page.evaluate((ff) => { window.ueState.lastTextOptions.fontFamily = ff; }, fontFamily);
+  }
   // WHY: Dispatch the mousedown/mouseup pair directly on the canvas and call
   // ueSetTool via the window bridge — both bypass focus/scroll quirks that
   // make page.mouse.click + page.keyboard.press unreliable for a tall canvas
-  // with a sticky overlay toolbar and a modal that owns focus between
-  // iterations.
+  // with a sticky overlay toolbar.
   await page.evaluate(() => window.ueSetTool('text'));
   await page.waitForFunction(() => window.ueState?.currentTool === 'text');
   await page.evaluate(({ p, cx, cy }) => {
@@ -59,19 +63,11 @@ async function addTextAnnotation(page, pageIndex, { x, y, text, fontFamily }) {
     canvas.dispatchEvent(new MouseEvent('mousedown', opts));
     canvas.dispatchEvent(new MouseEvent('mouseup', opts));
   }, { p: pageIndex, cx: x, cy: y });
-  await page.waitForFunction(() => {
-    const m = document.getElementById('text-input-modal');
-    return m && m.classList.contains('active');
-  });
-  await page.locator('#text-input-field').fill(text);
-  if (fontFamily) {
-    await page.locator('#modal-font-family').selectOption(fontFamily);
-  }
-  await page.evaluate(() => window.ueConfirmText());
-  await page.waitForFunction(() => {
-    const m = document.getElementById('text-input-modal');
-    return !m || !m.classList.contains('active');
-  });
+  await page.waitForSelector('#inline-text-editor');
+  await page.locator('#inline-text-editor').focus();
+  await page.keyboard.type(text);
+  await page.keyboard.press('Enter');
+  await page.waitForSelector('#inline-text-editor', { state: 'detached' });
 }
 
 // WHY: Same reasoning as addTextAnnotation — dispatch events directly so we
@@ -266,6 +262,53 @@ test.describe('escape cascade', () => {
     await page.keyboard.press('Escape');
 
     await expect(page.locator('body')).not.toHaveClass(/editor-active/);
+  });
+});
+
+test.describe('inline text on first creation', () => {
+  // UX audit H1/H2 — first creation goes straight into the inline editor with
+  // last-used formatting, no modal in between.
+  test('Escape on empty new annotation removes the orphan', async ({ page }) => {
+    await page.goto('/');
+    await loadSamplePdf(page);
+
+    await page.evaluate(() => window.ueSetTool('text'));
+    await page.evaluate(() => {
+      const canvas = document.querySelector('.ue-page-slot canvas');
+      const rect = canvas.getBoundingClientRect();
+      const opts = { bubbles: true, cancelable: true, clientX: rect.left + 100, clientY: rect.top + 100, button: 0 };
+      canvas.dispatchEvent(new MouseEvent('mousedown', opts));
+      canvas.dispatchEvent(new MouseEvent('mouseup', opts));
+    });
+    await page.waitForSelector('#inline-text-editor');
+
+    // Annotation must exist while editing
+    expect(await page.evaluate(() => window.ueState.annotations[0]?.length)).toBe(1);
+
+    await page.locator('#inline-text-editor').focus();
+    await page.keyboard.press('Escape');
+    await page.waitForSelector('#inline-text-editor', { state: 'detached' });
+
+    // Orphan must be gone after cancel
+    expect(await page.evaluate(() => window.ueState.annotations[0]?.length || 0)).toBe(0);
+    await expect(page.locator('body')).toHaveClass(/editor-active/);
+  });
+
+  test('successful save updates lastTextOptions for the next annotation', async ({ page }) => {
+    await page.goto('/');
+    await loadSamplePdf(page);
+    await page.evaluate(() => { window.ueState.lastTextOptions.fontFamily = 'Carlito'; });
+    await addTextAnnotation(page, 0, { x: 80, y: 80, text: 'first' });
+
+    // The created annotation must reflect the lastTextOptions we forced
+    const first = await page.evaluate(() => window.ueState.annotations[0][0]);
+    expect(first.fontFamily).toBe('Carlito');
+
+    // And lastTextOptions is now sticky for the next click — verified by
+    // creating a second annotation without specifying fontFamily.
+    await addTextAnnotation(page, 0, { x: 80, y: 160, text: 'second' });
+    const second = await page.evaluate(() => window.ueState.annotations[0][1]);
+    expect(second.fontFamily).toBe('Carlito');
   });
 });
 


### PR DESCRIPTION
## Summary

UX audit findings **H1 + H2** combined — they target the same flow.

**Before:** every new text annotation forced a full-page modal. Sari's 8-field contract = 8 modal cycles. Font/size/color reset every time.

**After:** Text-tool click drops an empty annotation at click point, opens the existing inline editor on it. Enter saves and remembers the formatting via \`ueState.lastTextOptions\` so the next click reuses the same style. Escape on an empty new annotation removes the orphan.

## Behaviour matrix

| Action | Before | After |
|--------|--------|-------|
| Click + Text tool | opens modal | drops empty anno, inline editor opens |
| Enter on inline | n/a | saves + tool→select + lastTextOptions captured |
| Escape on inline (new + empty) | n/a | removes orphan, no annotation kept |
| Escape on inline (edit existing) | cancels, keeps original | unchanged |
| Next click + Text | resets to default | inherits previous formatting |

Existing modal at \`#text-input-modal\` stays in code, just not reached from canvas click. A follow-up may add a per-annotation format bar for one-off style overrides.

## Test plan
- [x] All 10 smoke specs green
- [x] All 3 golden visual specs green
- [x] Lint clean
- [x] Manually verified via Playwright MCP: inline editor opens at click point, Enter saves, tool auto-switches to select, annotation visible
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)