### PR TITLE
fix(signature): default modal tab to Gambar/draw (H4)

### DIFF
--- a/js/pdf-tools/signature-modal.js
+++ b/js/pdf-tools/signature-modal.js
@@ -14,8 +14,12 @@ export function openSignatureModal() {
 
   openModal('signature-modal');
 
-  // Default to upload tab
-  switchSignatureTab('upload');
+  // WHY: Default to draw tab (UX audit finding H4). On mobile especially,
+  // finger-drawn signatures are the primary intent — opening on Upload Foto
+  // forced an extra tap and read as "wrong app" to first-time signers.
+  // Desktop users with a "photo of signature on phone" workflow still get
+  // Upload Foto with one click.
+  switchSignatureTab('draw');
 
   setTimeout(() => {
     const canvas = document.getElementById('signature-canvas');

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -312,6 +312,24 @@ test.describe('inline text on first creation', () => {
   });
 });
 
+test.describe('signature modal', () => {
+  // UX audit H4 — Gambar (draw) is the default tab. Without this, opening
+  // the signature modal on mobile (where finger-draw is the primary intent)
+  // showed Upload Foto first and added an extra tap for the common case.
+  test('opens with Gambar (draw) tab active', async ({ page }) => {
+    await page.goto('/');
+    await loadSamplePdf(page);
+    await page.evaluate(() => window.ueOpenSignatureModal());
+    await page.waitForFunction(() => document.getElementById('signature-modal')?.classList.contains('active'));
+
+    const activeTab = await page.evaluate(() => {
+      const tabs = document.querySelectorAll('#signature-modal button[role="tab"]');
+      return Array.from(tabs).find(t => t.getAttribute('aria-selected') === 'true')?.textContent?.trim();
+    });
+    expect(activeTab).toBe('Gambar');
+  });
+});
+
 test.describe('export pipeline', () => {
   test('regression #2: failed font fetch is NOT retried per annotation', async ({ page }) => {
     // WHY counter is local + reset before download: CSS @font-face also pulls


### PR DESCRIPTION
## Summary
UX audit finding **H4**. Signature modal opened on Upload Foto, but on mobile (where finger-draw is the primary intent) that added an extra tap for the common case.

One-line behavior change in [js/pdf-tools/signature-modal.js:18](js/pdf-tools/signature-modal.js#L18). Adds a regression spec so a future refactor can't silently revert it.

## Test plan
- [x] All 12 smoke specs green
- [x] Lint clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)