### PR TITLE
feat(paraf): "Tempel di semua halaman" checkbox (H7)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1291,6 +1291,10 @@
     <div class="signature-box">
       <h3>Buat Paraf</h3>
       <canvas id="paraf-canvas" class="signature-canvas"></canvas>
+      <label class="paraf-apply-all-label" for="paraf-apply-all">
+        <input type="checkbox" id="paraf-apply-all">
+        <span>Tempel di semua halaman</span>
+      </label>
       <div class="signature-actions">
         <button class="btn btn-secondary" onclick="clearParaf()">Hapus</button>
         <button class="btn btn-ghost" onclick="closeParafModal()">Batal</button>

--- a/js/editor/signatures.js
+++ b/js/editor/signatures.js
@@ -52,7 +52,18 @@ export async function uePlaceSignature(x, y) {
   ueState.pendingSignatureWidth = null;
   ueState.pendingSubtype = null;
 
+  // WHY: Paraf modal's "Tempel di semua halaman" checkbox is captured into
+  // ueState.pendingApplyToAllPages — act on it now, then clear. Skips the
+  // legacy "place one → click placed paraf → click Semua Hal." discovery path.
+  // Audit finding H7.
+  const applyAllNow = ueState.pendingApplyToAllPages && subtype === 'paraf' && ueState.pages.length > 1;
+  ueState.pendingApplyToAllPages = false;
+
   ueRedrawAnnotations();
+  if (applyAllNow) {
+    ueApplyToAllPages(ueState.selectedAnnotation);
+    return;
+  }
   ueShowConfirmButton(newAnno, ueState.selectedAnnotation);
 
   // WHY window.*: signatures ↔ tools circular import. tools imports signature modal openers.

--- a/js/lib/state.js
+++ b/js/lib/state.js
@@ -164,6 +164,12 @@ export function getDefaultUeState() {
     signaturePreviewPos: null,
     pendingSignatureWidth: null,
     pendingSubtype: null,
+    // WHY: When the user checks "Tempel di semua halaman" before pressing Gunakan
+    // in the paraf modal, the very next paraf placement also clones onto every
+    // other page. Without this flag, the user had to discover post-placement
+    // that selecting the paraf surfaces a "Semua Hal." button — UX audit
+    // finding H7. Cleared after the first placement.
+    pendingApplyToAllPages: false,
     resizeHandle: null,
     resizeStartInfo: null,
     // --- Interaction ---

--- a/js/pdf-tools/signature-modal.js
+++ b/js/pdf-tools/signature-modal.js
@@ -217,6 +217,12 @@ export function openParafModal() {
 
   openModal('paraf-modal');
 
+  // WHY: Reset the apply-to-all checkbox on each open. Without this, a leftover
+  // tick from a previous session would silently clone the next paraf onto every
+  // page — destructive and hard to discover. Audit finding H7.
+  const applyAllEl = document.getElementById('paraf-apply-all');
+  if (applyAllEl) applyAllEl.checked = false;
+
   setTimeout(() => {
     const canvas = document.getElementById('paraf-canvas');
     setupCanvasDPR(canvas);
@@ -247,13 +253,21 @@ export function useParaf() {
     makeWhiteTransparent(tempCanvas, 240);
     state.signatureImage = optimizeSignatureImage(tempCanvas);
 
+    // WHY: Capture "Tempel di semua halaman" intent here so the next placement
+    // can act on it without re-querying the DOM. Audit finding H7.
+    const applyAllEl = document.getElementById('paraf-apply-all');
+    ueState.pendingApplyToAllPages = !!applyAllEl?.checked;
+
     closeParafModal();
     window.ueSetTool('paraf');
     ueState.pendingSignature = true;
     ueState.signaturePreviewPos = null;
     ueState.pendingSignatureWidth = PARAF_DEFAULT_WIDTH;
     ueState.pendingSubtype = 'paraf';
-    showToast('Klik pada PDF untuk menempatkan paraf', 'success');
+    const msg = ueState.pendingApplyToAllPages
+      ? 'Klik di halaman pertama — paraf akan disalin ke semua halaman'
+      : 'Klik pada PDF untuk menempatkan paraf';
+    showToast(msg, 'success');
   } else {
     showToast('Buat paraf terlebih dahulu', 'error');
   }

--- a/style.css
+++ b/style.css
@@ -1328,6 +1328,25 @@ a:hover {
   margin-top: var(--space-lg);
 }
 
+/* Paraf "apply to all pages" checkbox — sits between the canvas and action buttons
+   so power users (notaris) discover the bulk-apply before placing.
+   UX audit finding H7. */
+.paraf-apply-all-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-top: var(--space-md);
+  font-size: 0.9375rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.paraf-apply-all-label input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
 /* Signature Tabs */
 .signature-tabs {
   display: flex;

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -330,6 +330,68 @@ test.describe('signature modal', () => {
   });
 });
 
+test.describe('paraf modal', () => {
+  // UX audit H7 — "Tempel di semua halaman" checkbox in the paraf modal lets
+  // Pak Hadi paraf a 20-page deed in one click. Before, the apply-to-all
+  // button only surfaced after placing one and selecting it.
+  test('checked + place clones paraf onto every page', async ({ page }) => {
+    await page.goto('/');
+    await loadSamplePdf(page);
+
+    // Prepare a paraf image without actually drawing on the canvas
+    await page.evaluate(() => {
+      // Stub a 1×1 PNG as the paraf image to skip the SignaturePad/canvas path
+      window.state.signatureImage = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAeImBZsAAAAASUVORK5CYII=';
+      window.ueState.pendingSignature = true;
+      window.ueState.pendingSignatureWidth = window.ueState.pendingSignatureWidth || 80;
+      window.ueState.pendingSubtype = 'paraf';
+      window.ueState.pendingApplyToAllPages = true; // the audit-finding behavior
+      window.ueSetTool('paraf');
+    });
+
+    // Place once at page 0
+    await page.evaluate(async () => {
+      const canvas = document.querySelectorAll('.ue-page-slot canvas')[0];
+      const rect = canvas.getBoundingClientRect();
+      const opts = { bubbles: true, cancelable: true, clientX: rect.left + 60, clientY: rect.top + 60, button: 0 };
+      canvas.dispatchEvent(new MouseEvent('mousedown', opts));
+      canvas.dispatchEvent(new MouseEvent('mouseup', opts));
+      // wait for the async signature image load + place
+      await new Promise(r => setTimeout(r, 300));
+    });
+
+    await page.waitForFunction(() =>
+      (window.ueState.annotations[0] || []).some(a => a.subtype === 'paraf') &&
+      (window.ueState.annotations[1] || []).some(a => a.subtype === 'paraf')
+    );
+
+    // Both pages now have a paraf
+    const counts = await page.evaluate(() => ({
+      p0: (window.ueState.annotations[0] || []).filter(a => a.subtype === 'paraf').length,
+      p1: (window.ueState.annotations[1] || []).filter(a => a.subtype === 'paraf').length,
+      flag: window.ueState.pendingApplyToAllPages,
+    }));
+    expect(counts.p0).toBe(1);
+    expect(counts.p1).toBe(1);
+    // Flag must reset after one use so the next paraf isn't silently cloned
+    expect(counts.flag).toBe(false);
+  });
+
+  test('opening paraf modal resets the apply-all checkbox to unchecked', async ({ page }) => {
+    await page.goto('/');
+    await loadSamplePdf(page);
+
+    await page.evaluate(() => {
+      const cb = document.getElementById('paraf-apply-all');
+      if (cb) cb.checked = true; // simulate leftover state from prior open
+      window.openParafModal();
+    });
+
+    const isChecked = await page.evaluate(() => document.getElementById('paraf-apply-all')?.checked);
+    expect(isChecked).toBe(false);
+  });
+});
+
 test.describe('export pipeline', () => {
   test('regression #2: failed font fetch is NOT retried per annotation', async ({ page }) => {
     // WHY counter is local + reset before download: CSS @font-face also pulls


### PR DESCRIPTION
## Summary

UX audit finding **H7**. Paraf-to-all-pages bulk action existed but was discovery-dependent — Pak Hadi had to place a paraf, click on the placed paraf to surface "Semua Hal.", then press it. If he didn't know that sequence, he'd manually paraf 20 pages.

Now surfaces as a checkbox **before** placement: tick it, draw, Gunakan, click once. Done.

## Behaviour

| Step | What happens |
|------|--------------|
| Open paraf modal | Checkbox is reset to unchecked (no stale tick) |
| Tick "Tempel di semua halaman" + Gunakan | Flag captured into \`ueState.pendingApplyToAllPages\` |
| First click on any page | Paraf placed there, then cloned + locked onto every other page; flag clears |
| Success toast | "Klik di halaman pertama — paraf akan disalin ke semua halaman" |

Existing post-placement "Semua Hal." button still works — this just gives Pak Hadi a discoverable up-front path.

## Test plan
- [x] All 13 smoke specs green
- [x] Lint clean
- [x] Manually verified the checkbox renders cleanly between the canvas and action row
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)