### PR TITLE
fix(editor): rename "Hapus Semua" + add confirm guard (C3)

### DIFF
--- a/index.html
+++ b/index.html
@@ -583,7 +583,7 @@
                 </button>
                 <button class="ft-more-item ft-more-item--danger" role="menuitem" onclick="ueClearPageAnnotations(); closeFloatingMore()">
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/></svg>
-                  Hapus Semua
+                  Hapus Edit Halaman Ini
                 </button>
               </div>
             </div>
@@ -715,7 +715,7 @@
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/>
               </svg>
-              Hapus Semua
+              Hapus Edit Halaman Ini
             </button>
           </div>
         </div>

--- a/js/editor/undo-redo.js
+++ b/js/editor/undo-redo.js
@@ -173,14 +173,20 @@ async function ueRestorePages(pagesData) {
 // CONVENIENCE
 // ============================================================
 
-// Clear page annotations
+// WHY: Clears edits on the CURRENT page only, not the whole document.
+// UX audit (C3): previous label "Hapus Semua" was ambiguous — users feared
+// it would wipe every page. Confirm() guards against accidental clears
+// since the action is undoable but still surprising on mobile thumb taps.
 export function ueClearPageAnnotations() {
   if (ueState.selectedPage < 0) return;
   if (ueState.annotations[ueState.selectedPage].length === 0) return;
+
+  const pageNum = ueState.selectedPage + 1;
+  if (!confirm(`Hapus semua edit di Halaman ${pageNum}? Halaman lain tidak terpengaruh.`)) return;
 
   ueSaveEditUndoState();
   ueState.annotations[ueState.selectedPage] = [];
   ueState.selectedAnnotation = null;
   ueRedrawAnnotations();
-  showToast('Semua edit di halaman ini dihapus', 'success');
+  showToast(`Edit di Halaman ${pageNum} dihapus`, 'success');
 }

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -281,3 +281,46 @@ test.describe('export pipeline', () => {
     expect(errors).toEqual([]);
   });
 });
+
+// UX audit C3: "Hapus Semua" (renamed to "Hapus Edit Halaman Ini") used to
+// fire instantly with no guard — one stray thumb tap wiped the page. Confirm
+// now intercepts; cancel must preserve annotations.
+test.describe('clear page annotations confirm', () => {
+  // WHY: createWhiteoutAnnotation is not on window — inline the shape here.
+  async function seedWhiteoutAnnotation(page, pageIndex, x = 10) {
+    await page.evaluate(({ p, ax }) => {
+      window.ueAddAnnotation(p, { type: 'whiteout', x: ax, y: 10, width: 50, height: 30 });
+    }, { p: pageIndex, ax: x });
+  }
+
+  test('cancel preserves annotations', async ({ page }) => {
+    await page.goto('/');
+    await loadSamplePdf(page);
+    await seedWhiteoutAnnotation(page, 0);
+
+    page.once('dialog', (dialog) => dialog.dismiss());
+    await page.evaluate(() => window.ueClearPageAnnotations());
+
+    const count = await page.evaluate(() => window.ueState.annotations[0].length);
+    expect(count).toBe(1);
+  });
+
+  test('accept clears current page only', async ({ page }) => {
+    await page.goto('/');
+    await loadSamplePdf(page);
+    await seedWhiteoutAnnotation(page, 0);
+    // Seed page 1 to prove it's untouched
+    await seedWhiteoutAnnotation(page, 1, 20);
+
+    page.once('dialog', (dialog) => {
+      expect(dialog.message()).toContain('Halaman 1');
+      return dialog.accept();
+    });
+    await page.evaluate(() => window.ueClearPageAnnotations());
+
+    const page0 = await page.evaluate(() => window.ueState.annotations[0].length);
+    const page1 = await page.evaluate(() => window.ueState.annotations[1].length);
+    expect(page0).toBe(0);
+    expect(page1).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

UX audit finding **C3** — the final item on the audit roadmap.

The "Hapus Semua" button in the floating-toolbar Lainnya menu (and now the mobile Lainnya menu via #57) clears edits on the **current page only**. But:

1. The label sounded like it would wipe every page in the document.
2. The action fired instantly — one stray thumb tap and your edits were gone.

Yes, undo restores them, but the UX is "scare the user, then make them recover" instead of "make the destructive action obvious + ask first".

**Changes:**
- Both buttons renamed to **"Hapus Edit Halaman Ini"** — scope is now visible in the label.
- \`ueClearPageAnnotations()\` wraps the mutation in \`confirm()\` with explicit page number and the reassurance that other pages are untouched.
- Two regression specs verify cancel preserves annotations and accept clears only the current page.

## Note on base branch

Branched off \`refactor/mobile-toolbar-dedupe\` (#57) because PR6 introduces a second "Hapus Semua" instance in the mobile dropdown. This avoids a textual conflict at merge time. Merge #57 first.

## Test plan
- [x] All 10 smoke + regression specs green (\`npx playwright test smoke\`)
- [x] No new lint errors
- [ ] CI green
- [ ] Manual: confirm dialog appears, cancel keeps annotations, accept clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)