### PR TITLE
feat(editor): auto-switch to Pilih after whiteout + text actions

### DIFF
--- a/js/editor/canvas-events.js
+++ b/js/editor/canvas-events.js
@@ -435,6 +435,14 @@ export function ueSetupCanvasEvents() {
         }));
         track('editor_action', { action: 'whiteout' });
         ueRedrawAnnotations();
+        // WHY auto-switch: After a tool's action completes, the user almost
+        // always wants to verify/move/zoom — not draw another whiteout
+        // immediately. Keeping whiteout sticky meant one stray tap on the
+        // canvas would spawn a new annotation. Text/signature/paraf already
+        // do this; whiteout was the holdout.
+        // WHY window.*: signatures.js does the same dance and we already
+        // accept the circular-import workaround there.
+        if (typeof window.ueSetTool === 'function') window.ueSetTool('select');
       }
     } else if (ueState.currentTool === 'text') {
       // WHY: Inline editing on first creation (UX audit finding H1). The modal-per-text

--- a/js/editor/inline-editor.js
+++ b/js/editor/inline-editor.js
@@ -78,6 +78,14 @@ export function ueCreateInlineTextEditor(anno, opts = {}) {
     }
   };
 
+  // WHY: After an isNew annotation closes (saved OR abandoned), drop the user
+  // into select mode. Otherwise the next canvas tap immediately spawns another
+  // empty annotation — a trap where Escape doesn't really cancel because the
+  // tool stays armed. Matches signature/whiteout post-action behavior.
+  const switchToSelectIfNew = () => {
+    if (isNew && typeof window.ueSetTool === 'function') window.ueSetTool('select');
+  };
+
   const saveEdit = () => {
     if (saved) return;
     saved = true;
@@ -91,6 +99,7 @@ export function ueCreateInlineTextEditor(anno, opts = {}) {
       removeOrphan();
       ueRedrawAnnotations();
       editor.remove();
+      switchToSelectIfNew();
       return;
     }
 
@@ -110,14 +119,11 @@ export function ueCreateInlineTextEditor(anno, opts = {}) {
         bold: !!anno.bold,
         italic: !!anno.italic,
       };
-      // Match the post-create behavior the modal flow had: drop the user into
-      // select mode so the newly created text can be moved/resized without
-      // accidentally spawning another annotation on the next click.
-      if (typeof window.ueSetTool === 'function') window.ueSetTool('select');
     }
 
     ueRedrawAnnotations();
     editor.remove();
+    switchToSelectIfNew();
   };
 
   const cancelEdit = () => {
@@ -130,6 +136,7 @@ export function ueCreateInlineTextEditor(anno, opts = {}) {
     if (isNew) removeOrphan();
     ueRedrawAnnotations();
     editor.remove();
+    switchToSelectIfNew();
   };
 
   editor.addEventListener('keydown', (e) => {

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -583,3 +583,94 @@ test.describe('stale selectedAnnotation does not crash on tap', () => {
     expect(sel).toBeNull();
   });
 });
+
+// UX request (Jun 2026): tools used to stay sticky after one use. Whiteout
+// and text in particular trapped users — finishing a whiteout drag would
+// arm the next stray tap to paint another box. Signature/paraf already
+// auto-switched (signatures.js:70). This suite locks in parity.
+test.describe('auto-switch to select after tool completion', () => {
+  async function drawWhiteoutRect(page, pageIndex, x1, y1, x2, y2) {
+    await page.evaluate(({ p, ax1, ay1, ax2, ay2 }) => {
+      const canvas = document.querySelectorAll('.ue-page-slot canvas')[p];
+      const rect = canvas.getBoundingClientRect();
+      const down = { bubbles: true, cancelable: true, clientX: rect.left + ax1, clientY: rect.top + ay1, button: 0 };
+      const move = { bubbles: true, cancelable: true, clientX: rect.left + ax2, clientY: rect.top + ay2, button: 0 };
+      canvas.dispatchEvent(new MouseEvent('mousedown', down));
+      canvas.dispatchEvent(new MouseEvent('mousemove', move));
+      canvas.dispatchEvent(new MouseEvent('mouseup', move));
+    }, { p: pageIndex, ax1: x1, ay1: y1, ax2: x2, ay2: y2 });
+  }
+
+  test('whiteout: tool switches to select after a valid drag', async ({ page }) => {
+    await page.goto('/');
+    await loadSamplePdf(page);
+
+    await page.evaluate(() => window.ueSetTool('whiteout'));
+    await drawWhiteoutRect(page, 0, 50, 50, 150, 100);
+
+    const annoCount = await page.evaluate(() => window.ueState.annotations[0]?.length || 0);
+    const tool = await page.evaluate(() => window.ueState.currentTool);
+    expect(annoCount).toBe(1);
+    expect(tool).toBe('select');
+  });
+
+  test('whiteout: tiny no-op drag does NOT switch tool', async ({ page }) => {
+    // Invariant: switching only when the action actually completed. Width<=5
+    // means the user clicked but didn't really draw — keep them in whiteout.
+    await page.goto('/');
+    await loadSamplePdf(page);
+
+    await page.evaluate(() => window.ueSetTool('whiteout'));
+    await drawWhiteoutRect(page, 0, 50, 50, 52, 52);
+
+    const annoCount = await page.evaluate(() => window.ueState.annotations[0]?.length || 0);
+    const tool = await page.evaluate(() => window.ueState.currentTool);
+    expect(annoCount).toBe(0);
+    expect(tool).toBe('whiteout');
+  });
+
+  test('text: inline Escape cancel returns to select tool', async ({ page }) => {
+    await page.goto('/');
+    await loadSamplePdf(page);
+
+    await page.evaluate(() => window.ueSetTool('text'));
+    await page.evaluate(() => {
+      const canvas = document.querySelector('.ue-page-slot canvas');
+      const rect = canvas.getBoundingClientRect();
+      const opts = { bubbles: true, cancelable: true, clientX: rect.left + 100, clientY: rect.top + 100, button: 0 };
+      canvas.dispatchEvent(new MouseEvent('mousedown', opts));
+      canvas.dispatchEvent(new MouseEvent('mouseup', opts));
+    });
+    await page.waitForSelector('#inline-text-editor');
+    await page.locator('#inline-text-editor').focus();
+    await page.keyboard.press('Escape');
+    await page.waitForSelector('#inline-text-editor', { state: 'detached' });
+
+    const tool = await page.evaluate(() => window.ueState.currentTool);
+    expect(tool).toBe('select');
+  });
+
+  test('text: empty save (Enter on blank) returns to select tool', async ({ page }) => {
+    await page.goto('/');
+    await loadSamplePdf(page);
+
+    await page.evaluate(() => window.ueSetTool('text'));
+    await page.evaluate(() => {
+      const canvas = document.querySelector('.ue-page-slot canvas');
+      const rect = canvas.getBoundingClientRect();
+      const opts = { bubbles: true, cancelable: true, clientX: rect.left + 100, clientY: rect.top + 100, button: 0 };
+      canvas.dispatchEvent(new MouseEvent('mousedown', opts));
+      canvas.dispatchEvent(new MouseEvent('mouseup', opts));
+    });
+    await page.waitForSelector('#inline-text-editor');
+    await page.locator('#inline-text-editor').focus();
+    // Press Enter without typing anything
+    await page.keyboard.press('Enter');
+    await page.waitForSelector('#inline-text-editor', { state: 'detached' });
+
+    const annoCount = await page.evaluate(() => window.ueState.annotations[0]?.length || 0);
+    const tool = await page.evaluate(() => window.ueState.currentTool);
+    expect(annoCount).toBe(0);
+    expect(tool).toBe('select');
+  });
+});


### PR DESCRIPTION
## Summary

User report: \"everytime people finished doing anything, the tools still sticks. mainly this concern is for teks dan whiteout\"

Signature and paraf already auto-switched to **Pilih** after placement (signatures.js:70). The rule was inconsistent — this patch makes whiteout and text follow the same pattern.

## What changes

| Tool | Before | After |
|---|---|---|
| Whiteout (valid drag) | Stays in whiteout | → **Pilih** |
| Whiteout (tiny no-op drag) | Stays | Stays (didn't actually act) |
| Text inline Escape cancel | Stays in text | → **Pilih** |
| Text inline empty save (Enter on blank) | Stays in text | → **Pilih** |
| Text inline blur with empty text | Stays in text | → **Pilih** |
| Text inline save with content | Already switched | Already switched |
| Signature/Paraf placement | Already switched | Already switched |

## Discovery workflow

A 5-agent workflow (90s, 208K tokens) audited every tool-completion path in canvas-events.js, inline-editor.js, signatures.js, and the modal tools. \"Gaps\" it flagged that are NOT fixed by this PR (intentional or N/A):

- Paraf apply-to-all session — stays in paraf on purpose (PR #56 design)
- Watermark/page-number modals — one-shot applies, not armed canvas tools
- Text modal \"Tambah Teks\" — dead code in practice after #54, already switches via tools.js:92

## Test plan

- [x] 4 new regression specs (whiteout valid, whiteout tiny no-op, text Escape, text empty-save) all pass
- [x] All 22 smoke + regression specs green
- [x] No lint errors
- [ ] Manual: select Whiteout → drag a box → toolbar returns to Pilih
- [ ] Manual: select Teks → click canvas → press Escape → toolbar returns to Pilih

🤖 Generated with [Claude Code](https://claude.com/claude-code)