### PR TITLE
fix(editor): guard stale selectedAnnotation to stop iOS tap crash

### DIFF
--- a/js/editor/canvas-events.js
+++ b/js/editor/canvas-events.js
@@ -259,6 +259,19 @@ export function ueSetupCanvasEvents() {
   // WHY: Extracted from handleDown to reduce cognitive complexity (S3776).
   // Returns true if the event was fully handled (caller should return early).
   function handleSelectDown(x, y) {
+    // WHY stale-selection guard: ueState.selectedAnnotation can outlive the
+    // annotation it points to — ueRemoveAnnotation only clears selection on
+    // an EXACT (pageIndex,index) match, and rebuildAnnotationMapping doesn't
+    // touch selection at all. Without this guard the next tap crashes inside
+    // ueGetResizeHandle (Sentry JAVASCRIPT-4). Clear the stale ref so the
+    // tap can still hit whatever's actually under it via ueFindAnnotationAt.
+    if (ueState.selectedAnnotation) {
+      const stale = !ueState.annotations[ueState.selectedAnnotation.pageIndex]?.[ueState.selectedAnnotation.index];
+      if (stale) {
+        ueState.selectedAnnotation = null;
+        ueHideConfirmButton();
+      }
+    }
     // Check resize handle on already-selected annotation
     if (ueState.selectedAnnotation) {
       const anno = ueState.annotations[ueState.selectedAnnotation.pageIndex][ueState.selectedAnnotation.index];

--- a/js/editor/canvas-utils.js
+++ b/js/editor/canvas-utils.js
@@ -95,8 +95,15 @@ export function drawRotatedThumbnail(sourceCanvas, rotation) {
 }
 
 // Check if (x, y) is on a resize handle of the given annotation
+// WHY !anno guard: ueState.selectedAnnotation can become stale when another
+// annotation on the same page is removed (ueRemoveAnnotation only clears
+// selection on EXACT match), or when pages get reordered/deleted via
+// rebuildAnnotationMapping which doesn't touch selectedAnnotation. Without
+// this guard, the first canvas tap after such a stale state would crash
+// with "undefined is not an object (evaluating 'anno.locked')" — Sentry
+// JAVASCRIPT-4 on iPad/iPhone production users.
 export function ueGetResizeHandle(anno, x, y) {
-  if (anno.locked) return null;
+  if (!anno || anno.locked) return null;
   const handleSize = 12;
 
   let corners;

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -494,3 +494,44 @@ test.describe('clear page annotations confirm', () => {
     expect(page1).toBe(1);
   });
 });
+
+// Sentry JAVASCRIPT-4: production crash on iOS, "TypeError: undefined is not
+// an object (evaluating 'anno.locked')" inside ueGetResizeHandle. Root cause:
+// ueRemoveAnnotation only clears selectedAnnotation on EXACT match, and
+// rebuildAnnotationMapping never touches it — so the selected index can
+// outlive the annotation it points to. Next tap → handleSelectDown derefs
+// undefined → crash.
+test.describe('stale selectedAnnotation does not crash on tap', () => {
+  test('regression: tapping with stale selection clears it without throwing', async ({ page }) => {
+    const errors = watchForJsErrors(page);
+    await page.goto('/');
+    await loadSamplePdf(page);
+
+    // Production state: user is in 'select' mode with an annotation selected.
+    await page.evaluate(() => window.ueSetTool('select'));
+    // Seed a whiteout, point selection at it, then yank the annotation out
+    // from under the selection — mimics the "ueRemoveAnnotation cleared the
+    // wrong slot" hazard.
+    await page.evaluate(() => {
+      window.ueAddAnnotation(0, { type: 'whiteout', x: 20, y: 20, width: 60, height: 40 });
+      window.ueState.selectedAnnotation = { pageIndex: 0, index: 0 };
+      // Wipe annotations directly — bypasses ueRemoveAnnotation's exact-match
+      // clearing logic, leaving selectedAnnotation pointing at undefined.
+      window.ueState.annotations[0] = [];
+    });
+
+    // Single tap on the canvas — pre-fix, this throws inside ueGetResizeHandle.
+    await page.evaluate(() => {
+      const canvas = document.querySelector('.ue-page-slot canvas');
+      const rect = canvas.getBoundingClientRect();
+      const opts = { bubbles: true, cancelable: true, clientX: rect.left + 100, clientY: rect.top + 100, button: 0 };
+      canvas.dispatchEvent(new MouseEvent('mousedown', opts));
+      canvas.dispatchEvent(new MouseEvent('mouseup', opts));
+    });
+
+    expect(errors).toEqual([]);
+    // Stale selection must be cleared so subsequent interactions behave normally
+    const sel = await page.evaluate(() => window.ueState.selectedAnnotation);
+    expect(sel).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes **Sentry JAVASCRIPT-4** — production crash on iOS 16.5.1, release \`2026.06.01.1\`, 3 events in 1 minute, **\"high\" Seer actionability**.

\`\`\`
TypeError: undefined is not an object (evaluating 'anno.locked')
  at ueGetResizeHandle (js/editor/canvas-utils.js:99)
  at handleSelectDown (js/editor/canvas-events.js:265)
  at handleDown (js/editor/canvas-events.js:329)
\`\`\`

## Root cause

\`ueState.selectedAnnotation\` can outlive the annotation it points to:

1. **\`ueRemoveAnnotation\`** only clears selection on an **exact** \`(pageIndex, index)\` match. Removing a sibling at a lower index shifts the array and the selection ends up dangling past the end → [annotations.js:134-141](js/editor/annotations.js#L134-L141).
2. **\`rebuildAnnotationMapping\`** (page reorder/delete) doesn't touch selection at all → [page-manager.js:323-335](js/editor/page-manager.js#L323-L335).

Next canvas tap → \`handleSelectDown\` derefs \`undefined\` → crash.

## This patch — defense in depth at both consumption sites

- **\`ueGetResizeHandle\`** ([canvas-utils.js:99](js/editor/canvas-utils.js#L99)) returns \`null\` when \`anno\` is falsy. Matches the guard the cursor-update path already had at line 107.
- **\`handleSelectDown\`** ([canvas-events.js:261](js/editor/canvas-events.js#L261)) detects the stale ref BEFORE dereferencing, clears it, hides the orphan confirm button, then falls through to the existing \"click on annotation\" check.

## What this does NOT fix (logged to backlog)

The true root cause — \`ueRemoveAnnotation\` should decrement selection index when removing an earlier sibling, and \`rebuildAnnotationMapping\` should reindex selection through page references — is queued in [backlog.md](backlog.md). This PR stops the crash today; the proper fix can land cleanly later.

## Test plan

- [x] 1 new regression spec seeds a stale selection by wiping annotations directly, then verifies a tap produces no JS error and clears the dangling ref
- [x] All 19 smoke + regression specs green
- [x] No lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)