### PR TITLE
chore(audit): cleanup drift + spaghetti — 5 cheap wins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,10 +83,13 @@ pdflokal/
 │   └── vendor/               # Self-hosted libs (2.6 MB), zero CDN deps
 ├── fonts/              # Self-hosted fonts (268KB, Latin charset)
 ├── docs/               # Design + reference docs
-│   ├── architecture.md # SSOT patterns diagram (scattered vs centralized)
+│   ├── architecture.md       # SSOT patterns diagram (scattered vs centralized)
 │   ├── editor-redesign.md
-│   ├── patterns.md     # Code patterns and examples
-│   └── security.md     # Security headers, CSP, library details
+│   ├── future-architecture.md # PageRenderer plan + reactive state notes
+│   ├── patterns.md           # Code patterns and examples
+│   ├── security.md           # Security headers, CSP, library details
+│   ├── strengths.md          # WHY vanilla JS / WHY no framework / AI-first
+│   └── system-flow.md        # End-to-end user flow + data flow
 └── images/
 ```
 
@@ -262,12 +265,11 @@ Hero + dropzone (opens editor), PDF tool cards (Editor, Merge, Split, PDF-to-Ima
 | `ueReorderPages(fromIndex, insertAt)` | page-manager.js | **SSOT** reorder pages with annotation mapping rebuild |
 | `ueGetCurrentCanvas()` | canvas-utils.js | Get selected page's canvas |
 | `ueGetCoords(e, canvas, dpr)` | canvas-utils.js | Mouse/touch -> canvas coords |
-| `getCanvasAndCoords(e)` | canvas-events.js | Event delegation helper |
 | `makeWhiteTransparent(canvas, threshold)` | utils.js | White pixels -> transparent |
 | `setupCanvasDPR(canvas)` | utils.js | Scale canvas for devicePixelRatio |
 | `createPageRenderer()` | page-rendering.js | **SSOT** create PageRenderer singleton (called by initUnifiedEditor) |
 | `destroyPageRenderer()` | page-rendering.js | **SSOT** destroy PageRenderer + cleanup (called by ueReset) |
-| `setupFileInput(inputId, opts)` | init.js | DRY file input handler factory |
+| `setupFileInput(inputId, opts)` | init-file-handling.js (internal) | DRY file input handler factory used by `initFileInputs()` |
 | `safeLocalGet(key)` / `safeLocalSet(key, val)` | utils.js | Private browsing-safe localStorage |
 | `trapFocus(modalEl)` / `releaseFocus(modalEl)` | utils.js | Modal focus trap + restore on close |
 | `registerImage(dataUrl)` / `getRegisteredImage(id)` | state.js | Shared image registry (undo optimization) |

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ PDFLokal adalah tool PDF gratis untuk pengguna Indonesia. Semua proses berjalan 
 ## Fitur
 
 ### PDF Tools
-- **Editor PDF** — Unified editor with whiteout, text (5 fonts, bold/italic, color), signatures (upload with background removal, draw, auto-lock, double-click to unlock), paraf/initials, watermark, page numbers, password protection
+- **Editor PDF** — Unified editor with whiteout, text (5 fonts, bold/italic, color), signatures (upload with background removal, draw, place → Konfirmasi to lock, double-click to unlock), paraf/initials, watermark, page numbers, password protection
+- **Tema gelap / terang** — Theme toggle stored per-device
 - **Gabung PDF** — Merge multiple PDFs and images with drag-drop reordering
 - **Split PDF** — Extract selected pages as a separate PDF
 - **Kompres PDF** — Reduce file size by compressing embedded images
@@ -79,10 +80,10 @@ npx serve .
 - **[pdf-lib](https://pdf-lib.js.org/)** — PDF manipulation (self-hosted)
 - **[PDF.js](https://mozilla.github.io/pdf.js/)** — PDF rendering with Web Worker (self-hosted)
 - **[Signature Pad](https://github.com/szimek/signature_pad)** — Digital signatures (self-hosted)
-- **[fontkit](https://github.com/foliojs/fontkit)** — Custom font embedding (self-hosted)
+- **[fontkit](https://github.com/foliojs/fontkit)** — Embeds Montserrat + Carlito into exported PDFs (self-hosted)
 - **[pdf-encrypt-lite](https://github.com/nicholasohjj/pdf-encrypt-lite)** — PDF password encryption (CDN)
 - **Canvas API** — Image processing
-- **Self-hosted fonts** — Montserrat, Carlito, Plus Jakarta Sans (268KB)
+- **Self-hosted fonts** — UI font Plus Jakarta Sans + annotation fonts Montserrat / Carlito (268KB)
 
 ### Project Structure
 ```

--- a/js/editor/pdf-export.js
+++ b/js/editor/pdf-export.js
@@ -131,7 +131,6 @@ async function embedCustomFont(newDoc, fontCache, fontName, bold) {
     clearTimeout(timeoutId);
     const fontBytes = await fontResponse.arrayBuffer();
     fontCache[fontName] = await newDoc.embedFont(fontBytes);
-    console.log('[PDF Export] Embedded font:', fontName, `(${(fontBytes.byteLength / 1024).toFixed(1)}KB)`);
     return fontCache[fontName];
   } catch (err) {
     console.error('[PDF Export] Failed to load font:', fontName, err);

--- a/js/editor/sidebar.js
+++ b/js/editor/sidebar.js
@@ -7,6 +7,7 @@ import { ueState } from '../lib/state.js';
 import { on } from '../lib/events.js';
 import { getThumbnailSource, drawRotatedThumbnail } from './canvas-utils.js';
 import { showToast, showFullscreenLoading, hideFullscreenLoading } from '../lib/utils.js';
+import { ueSaveUndoState } from './undo-redo.js';
 
 // WHY: Subscribe to pages:changed so thumbnails auto-refresh when pages are
 // added/removed/reordered. Replaces manual ueRenderThumbnails() calls scattered
@@ -171,8 +172,7 @@ function ueSetupSidebarDragDrop() {
     const item = e.target.closest('.ue-thumbnail');
     if (!item) return;
 
-    // Use window.* to avoid circular import with undo-redo
-    window.ueSaveUndoState();
+    ueSaveUndoState();
     draggedItem = item;
     draggedIndex = Number.parseInt(item.dataset.index);
     item.classList.add('dragging');

--- a/js/editor/tools.js
+++ b/js/editor/tools.js
@@ -11,6 +11,7 @@ import { ueRedrawAnnotations, ueAddAnnotation } from './annotations.js';
 import { ueSaveEditUndoState } from './undo-redo.js';
 import { track } from '../lib/analytics.js';
 import { ueUpdateStatus } from './page-rendering.js';
+import { ueBuildFinalPDF } from './pdf-export.js';
 
 // Tool selection
 export function ueSetTool(tool) {
@@ -173,8 +174,7 @@ export async function applyEditorProtect() {
   }
 
   try {
-    // ueBuildFinalPDF lives in pdf-export.js; tools ↔ pdf-export is circular.
-    const pdfBytes = await window.ueBuildFinalPDF();
+    const pdfBytes = await ueBuildFinalPDF();
     const pdfDoc = await PDFLib.PDFDocument.load(pdfBytes);
 
     const protectedBytes = await pdfDoc.save({

--- a/style.css
+++ b/style.css
@@ -1258,26 +1258,6 @@ a:hover {
   transform: scale(1.05);
 }
 
-/* Hero Download Button */
-.btn--download-hero {
-  padding: var(--space-md) var(--space-xl);
-  font-weight: 600;
-  font-size: 1rem;
-}
-
-.btn--download-hero:not(:disabled).has-signatures {
-  animation: gentle-pulse 2s infinite;
-}
-
-@keyframes gentle-pulse {
-  0%, 100% {
-    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.4);
-  }
-  50% {
-    box-shadow: 0 0 0 8px rgba(59, 130, 246, 0);
-  }
-}
-
 /* Legacy .editor-canvas-wrapper and .editor-canvas removed — unified editor uses .ue-page-slot canvas */
 
 /* Signature Pad */
@@ -2142,11 +2122,6 @@ a:hover {
   margin-top: var(--space-lg);
 }
 
-/* Annotation Selection Handles */
-.annotation-selected {
-  outline: 2px solid var(--accent-primary);
-  outline-offset: 2px;
-}
 
 /* Canvas Cursors */
 .ue-page-canvas.tool-select { cursor: default; }
@@ -2189,13 +2164,6 @@ a:hover {
     display: none !important;
   }
 
-  /* Download button on mobile */
-  .btn--download-hero {
-    padding: var(--space-sm) var(--space-lg);
-    font-size: 0.875rem;
-    width: 100%;
-    justify-content: center;
-  }
 }
 
 /* Drop Hint Component - For file upload areas */
@@ -2646,12 +2614,6 @@ a:hover {
 .btn-sm {
   padding: var(--space-xs) var(--space-sm);
   font-size: 0.8125rem;
-}
-
-.btn-icon {
-  padding: var(--space-xs);
-  width: 28px;
-  height: 28px;
 }
 
 /* ============================================================


### PR DESCRIPTION
## Summary

Closes the no-risk subset of today's deep audit (75 agents, 27 verified findings across drift + spaghetti dimensions).

## Code (4 cleanups)

- **3 dead CSS classes deleted** — `.annotation-selected`, `.btn--download-hero` (2 blocks + orphaned `gentle-pulse` keyframe), `.btn-icon`. Zero references across HTML/JS — confirmed via grep before deletion.
- **2 lying WHY comments rewritten as direct imports** — \`sidebar.js\` claimed circular import with undo-redo (no such cycle exists); \`tools.js\` claimed circular import with pdf-export (no such cycle exists). Both \`window.*\` calls replaced with direct imports. Misleading docs erode trust in the *real* circular bridges — keeping the truthful ones (sidebar↔page-rendering, signatures↔tools, page-rendering↔canvas-events) as the template.
- **Production \`console.log\` removed** — every embedded font during PDF export was logging to user devtools.

## Docs (4 alignments)

- **CLAUDE.md Common Helpers table** — phantom \`getCanvasAndCoords\` row removed (real internal name is \`getCanvasAndIndex\`, not exported); \`setupFileInput\` corrected to \`init-file-handling.js\` (was wrongly attributed to \`init.js\`).
- **CLAUDE.md docs/ file tree** — added 3 missing entries (\`future-architecture.md\`, \`strengths.md\`, \`system-flow.md\`) that CLAUDE.md itself links to.
- **README.md** — signature flow now correctly states \"place → Konfirmasi → dblclick\" instead of fictional \"auto-lock\"; clarified fontkit embeds Montserrat/Carlito only; added dark-mode bullet.
- **MEMORY.md** — relaxed stale \"all files <450 lines\" claim (4 editor modules now run 500-680).

## Deferred to future PRs

- Canvas-events.js rewrite (491 lines, 378-line single function)
- Drag-reorder refactor in page-manager.js
- \`ueClearPendingSignature()\` / \`ueSetPendingSignature()\` SSOT helpers for the 4-field, 3-module pending-signature state

These are higher-effort, higher-risk; this PR is the cheap-win subset.

## Test plan
- [x] All 25 smoke + regression specs green
- [x] No new lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)