### PR TITLE
fix(editor): Ganti File now actually renders the new file

### DIFF
--- a/js/editor/lifecycle.js
+++ b/js/editor/lifecycle.js
@@ -8,7 +8,7 @@ import { on } from '../lib/events.js';
 import { showToast, showFullscreenLoading, hideFullscreenLoading, safeLocalGet, safeLocalSet } from '../lib/utils.js';
 import { initUnifiedEditorInput, ueAddFiles } from './file-loading.js';
 import { ueRenderThumbnails } from './sidebar.js';
-import { ueSetupScrollSync, ueUpdatePageCount, createPageRenderer, destroyPageRenderer } from './page-rendering.js';
+import { ueSetupScrollSync, ueUpdatePageCount, createPageRenderer } from './page-rendering.js';
 
 // WHY: Subscribe to pages:changed so page count auto-updates when pages change.
 // Replaces manual ueUpdatePageCount() calls scattered across modules.
@@ -16,12 +16,17 @@ on('pages:changed', () => ueUpdatePageCount());
 import { ueUpdateZoomDisplay } from './zoom-rotate.js';
 
 // Reset unified editor state
+// WHY no destroyPageRenderer: ueReset is called from within-editor flows
+// (Ganti File / ueReplaceFiles) that immediately add new files and need
+// the renderer alive to draw them. Destroying the singleton on every
+// reset left ueAddFiles silently no-op'ing all its render calls. The
+// renderer lifecycle is owned by showHome (entering/leaving the editor),
+// not by state reset.
 export function ueReset() {
   // Reset all value fields to defaults (SSOT — adding a field to getDefaultUeState is enough)
   Object.assign(ueState, getDefaultUeState());
 
   // Side-effect cleanup (not just value resets)
-  destroyPageRenderer();
   clearImageRegistry();
   ueState.zoomLevel = 1.0;
   ueUpdateZoomDisplay();

--- a/js/lib/navigation.js
+++ b/js/lib/navigation.js
@@ -286,6 +286,12 @@ export function resetState() {
   if (typeof window.ueReset === 'function') {
     window.ueReset();
   }
+  // WHY destroy here, not in ueReset: ueReset is shared between showHome and
+  // within-editor file replacement. The renderer must survive replacement so
+  // ueAddFiles can re-render — destroying belongs to leaving the editor.
+  if (typeof window.destroyPageRenderer === 'function') {
+    window.destroyPageRenderer();
+  }
 }
 
 // ============================================================

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -674,3 +674,40 @@ test.describe('auto-switch to select after tool completion', () => {
     expect(tool).toBe('select');
   });
 });
+
+// Regression: user reported "buka PDF, edit, ganti file, file baru ga keload".
+// Root cause: ueReset destroyed the PageRenderer singleton; ueAddFiles then
+// silently no-op'd all its render calls (the optional-chaining wrappers like
+// `renderer?.createPageSlots()` swallow null). Pages were in state but never
+// drawn — container stayed display:none.
+test.describe('Ganti File preserves rendering', () => {
+  test('replacing files after edits actually renders the new pages', async ({ page }) => {
+    await page.goto('/');
+    await loadSamplePdf(page);
+
+    // Make an edit so we're past the "just-loaded" state when replace fires
+    await page.evaluate(() => {
+      window.ueAddAnnotation(0, { type: 'whiteout', x: 10, y: 10, width: 30, height: 20 });
+    });
+
+    // Simulate "Ganti File" — set new files on the hidden input and dispatch
+    // the same change event the native picker would produce.
+    await page.evaluate(() => window.ueReplaceFiles());
+    await page.setInputFiles('#ue-replace-input', 'tests/fixtures/sample-2pages.pdf');
+
+    // Wait for pages container to come back to flex and slots to exist
+    await page.waitForFunction(() => {
+      const c = document.getElementById('ue-pages-container');
+      const slots = document.querySelectorAll('.ue-page-slot canvas');
+      return c && c.style.display === 'flex' && slots.length === 2;
+    }, { timeout: 5000 });
+
+    // Pages state must be re-populated from the new file (not stale)
+    const pageCount = await page.evaluate(() => window.ueState.pages.length);
+    expect(pageCount).toBe(2);
+
+    // Annotations from the previous file must be cleared
+    const annoCount = await page.evaluate(() => window.ueState.annotations[0]?.length || 0);
+    expect(annoCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

User report: "buka pdf, edit, ganti file, file baru ga keload."

### Root cause

`ueReset()` in `js/editor/lifecycle.js` called `destroyPageRenderer()`. Inside `ueReplaceFiles()` we ran `ueReset → ueAddFiles` back-to-back. Once the singleton was destroyed, every render call from `ueAddFiles` became a silent no-op — the wrappers like `renderer?.createPageSlots()` swallow null via optional chaining. Pages landed in `ueState.pages` but no slots were created, container stayed `display: none`, user saw a blank workspace.

```
ueReplaceFiles()
  → ueReset()                    # destroys PageRenderer ← bug
  → ueAddFiles(newFiles)
    → ueCreatePageSlots()        # renderer?. → null. silent no-op
    → ueSelectPage(0)            # renderer?. → null. silent no-op
    → (container stays hidden)
```

### Fix

State reset (`ueReset`) and singleton destruction (`destroyPageRenderer`) live at different altitudes — `ueReset` is shared between within-editor flows AND `showHome`, but destruction only makes sense when leaving the editor entirely. Moved `destroyPageRenderer()` to `resetState()` in `js/lib/navigation.js` (the `showHome` path); dropped it from `ueReset`. WHY comments added at both sites.

### Test plan

- [x] New regression spec (`Ganti File preserves rendering`) — pre-fix this hangs on the container check
- [x] All 26 smoke + regression specs green
- [x] No lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)