### PR TITLE
fix(editor): null-guard signature preview when no page selected (Sentry JS-6)

### DIFF
--- a/js/editor/signatures.js
+++ b/js/editor/signatures.js
@@ -80,10 +80,18 @@ export async function uePlaceSignature(x, y) {
 }
 
 // Draw signature preview at cursor
+// WHY canvas null guard: if the user opens the signature/paraf modal from
+// the top toolbar without having tapped a page first (selectedPage stays
+// -1), then moves the mouse over a page canvas, handleMove invokes this
+// preview with pendingSignature+signatureImage truthy but ueGetCurrentCanvas
+// returning null. The preview is a non-essential decoration — bail out
+// silently so the eventual click-to-place can still resolve the right page
+// via the event target. Closes Sentry JAVASCRIPT-6.
 export function ueDrawSignaturePreview(x, y) {
   if (!state.signatureImage) return;
 
   const canvas = ueGetCurrentCanvas();
+  if (!canvas) return;
   const ctx = canvas.getContext('2d');
 
   const img = new Image();

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -711,3 +711,37 @@ test.describe('Ganti File preserves rendering', () => {
     expect(annoCount).toBe(0);
   });
 });
+
+// Sentry JAVASCRIPT-6: TypeError: Cannot read properties of null (reading
+// 'getContext') in ueDrawSignaturePreview. Trigger: user opens paraf modal
+// before tapping a page (selectedPage stays -1), then moves the mouse over
+// a canvas while pendingSignature + signatureImage are set.
+test.describe('signature preview survives no-page-selected', () => {
+  test('regression: mousemove with pending signature and no selected page does not throw', async ({ page }) => {
+    const errors = watchForJsErrors(page);
+    await page.goto('/');
+    await loadSamplePdf(page);
+
+    // Mimic the production state: user picked paraf via top toolbar, never
+    // tapped a page first. Push signatureImage + pendingSignature directly,
+    // null out selectedPage to repro JAVASCRIPT-6's preconditions.
+    await page.evaluate(() => {
+      window.state.signatureImage = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAeImBZsAAAAASUVORK5CYII=';
+      window.ueState.pendingSignature = true;
+      window.ueState.pendingSubtype = 'paraf';
+      window.ueState.selectedPage = -1;
+      window.ueSetTool('paraf');
+    });
+
+    // Mousemove over the first canvas — pre-fix this throws inside
+    // ueDrawSignaturePreview because ueGetCurrentCanvas returns null.
+    await page.evaluate(() => {
+      const canvas = document.querySelector('.ue-page-slot canvas');
+      const rect = canvas.getBoundingClientRect();
+      const opts = { bubbles: true, cancelable: true, clientX: rect.left + 80, clientY: rect.top + 80, button: 0 };
+      canvas.dispatchEvent(new MouseEvent('mousemove', opts));
+    });
+
+    expect(errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes Sentry **JAVASCRIPT-6**:

\`\`\`
TypeError: Cannot read properties of null (reading 'getContext')
  at ueDrawSignaturePreview (signatures.js:87)
  at handleMove           (canvas-events.js:357)
\`\`\`

Caught by the new breadcrumb pipeline (PR #62) — \`app_section: unified-editor\`, \`form_factor: desktop\`, release \`2026.06.02.1\`. Triggered by the user while testing 32 minutes ago.

## Trigger flow

1. User opens the editor (\`selectedPage\` defaults to -1)
2. Clicks paraf/signature in the **top toolbar** (not after tapping a page) → draws → hits **Gunakan**
3. State becomes: \`pendingSignature: true\`, \`signatureImage\` set, \`selectedPage: -1\`
4. Mouse moves over a canvas → \`handleMove\` enters preview branch
5. \`ueDrawSignaturePreview\` calls \`ueGetCurrentCanvas()\` which returns \`null\` (because \`pageCanvases[-1]\` is undefined)
6. \`canvas.getContext('2d')\` crashes

## Fix

Add a null guard in \`ueDrawSignaturePreview\`. The preview is purely cosmetic — \`uePlaceSignature\` already guards \`pageIndex < 0\` at line 16, so the actual placement path was always safe. When the user clicks, \`handleDown\` resolves the right page from the event target, so the eventual click still places the signature correctly.

## Test plan

- [x] New regression spec mimics the production state (\`pendingSignature: true\`, \`selectedPage: -1\`) and fires mousemove. Pre-fix: throws. Post-fix: silent no-op.
- [x] All 26 smoke + regression specs green
- [x] No lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)