### PR TITLE
fix(editor): defensive guards on Hapus Edit + sidebar thumbs (Sentry JS-7, JS-8)

### DIFF
--- a/js/editor/sidebar.js
+++ b/js/editor/sidebar.js
@@ -90,8 +90,15 @@ export function ueRenderThumbnails() {
   ueState.pages.forEach((page, index) => {
     const item = document.createElement('div');
     const sourceCanvas = getThumbnailSource(index);
-    const canvasWidth = sourceCanvas ? sourceCanvas.width : page.canvas.width;
-    const canvasHeight = sourceCanvas ? sourceCanvas.height : page.canvas.height;
+    // WHY ?. on page.canvas: closes Sentry JAVASCRIPT-8. After a drag-reorder
+    // pages:changed fires which calls ueRenderThumbnails — but on rare cases
+    // (likely a page whose placeholder canvas object was never seeded because
+    // it came from a code path that bypassed createPageInfo) we hit a page
+    // with neither sourceCanvas nor page.canvas. Skip the thumbnail rather
+    // than crash the whole sidebar re-render.
+    const canvasWidth = sourceCanvas ? sourceCanvas.width : page.canvas?.width;
+    const canvasHeight = sourceCanvas ? sourceCanvas.height : page.canvas?.height;
+    if (!canvasWidth || !canvasHeight) return;
     const isLandscape = canvasWidth > canvasHeight;
     item.className = 'ue-thumbnail' + (index === ueState.selectedPage ? ' selected' : '') + (isLandscape ? ' landscape' : ' portrait');
     item.draggable = true;

--- a/js/editor/undo-redo.js
+++ b/js/editor/undo-redo.js
@@ -179,7 +179,11 @@ async function ueRestorePages(pagesData) {
 // since the action is undoable but still surprising on mobile thumb taps.
 export function ueClearPageAnnotations() {
   if (ueState.selectedPage < 0) return;
-  if (ueState.annotations[ueState.selectedPage].length === 0) return;
+  // WHY ?.length: closes Sentry JAVASCRIPT-7. annotations[selectedPage] can be
+  // undefined when the index map gets out of sync (e.g. selection survives a
+  // page-reorder or delete that didn't reseat the per-page bucket). Treat the
+  // missing bucket as "nothing to clear".
+  if (!ueState.annotations[ueState.selectedPage]?.length) return;
 
   const pageNum = ueState.selectedPage + 1;
   if (!confirm(`Hapus semua edit di Halaman ${pageNum}? Halaman lain tidak terpengaruh.`)) return;


### PR DESCRIPTION
## Summary

Closes **Sentry JAVASCRIPT-7** and **JAVASCRIPT-8** — two unrelated null-deref crashes both surfaced in the last few hours.

## JAVASCRIPT-7 — Hapus Edit Halaman Ini

\`\`\`
TypeError: Cannot read properties of undefined (reading 'length')
  at undo-redo.js:182  if (ueState.annotations[ueState.selectedPage].length === 0) return;
\`\`\`

\`annotations[selectedPage]\` is undefined when the index map is out of sync with the active page (e.g. selection survived a reorder/delete that didn't reseat the per-page bucket). Guard becomes \`!ueState.annotations[ueState.selectedPage]?.length\`.

This is a regression I introduced in PR #59 (the C3 rename + confirm). The pre-#59 code had the same shape but the function was only reached from a confirmed-loaded state.

## JAVASCRIPT-8 — sidebar thumbnail re-render after drag-reorder

\`\`\`
TypeError: Cannot read properties of undefined (reading 'canvas')
  at sidebar.js:93  const canvasWidth = sourceCanvas ? sourceCanvas.width : page.canvas.width;
\`\`\`

After a drag-reorder \`pages:changed\` fires \`ueRenderThumbnails\`. A page in the array has neither \`sourceCanvas\` (from \`getThumbnailSource\`) nor \`page.canvas\` (the placeholder). Optional-chain + skip the thumbnail row rather than crash the whole sidebar.

## Root causes deferred to backlog

Both fixes are defensive. The real questions:
- **JS-7**: \`ueState.annotations\` integrity after page operations — same class as the existing stale-selectedAnnotation backlog item
- **JS-8**: which code path creates a page without seating the placeholder canvas? (Undo restore that bypasses \`createPageInfo\`, or a Gabungkan-modal split/extract path?)

## Test plan
- [x] All 29 smoke + regression specs green
- [x] No new lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)