### PR TITLE
fix(analytics): hostname allowlist on gtag config

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,18 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-    gtag('config', 'AW-17538923405');
-    gtag('config', 'G-0XJY0WLCZ1');
+    // WHY hostname allowlist: gtag has no automatic environment detection. Without
+    // this guard, every `npx serve` session, every Playwright test run, and every
+    // Vercel preview deploy pollutes the production GA4 property. Verified on
+    // Jun 9 2026: 1,086 of 1,621 weekly GA4 page_views came from http://localhost/
+    // (67% phantom data, mostly Playwright headless --isolated browser contexts).
+    // Vercel Analytics doesn't have this problem because its script (/_vercel/insights/
+    // script.js) only resolves on Vercel deployments; on localhost the script 404s.
+    // Allowlist > blocklist so a new dev hostname can never silently leak.
+    if (location.hostname === 'pdflokal.id' || location.hostname === 'www.pdflokal.id') {
+      gtag('config', 'AW-17538923405');
+      gtag('config', 'G-0XJY0WLCZ1');
+    }
   </script>
 
   <!-- SEO Meta Tags -->


### PR DESCRIPTION
## Summary

Adds a hostname allowlist before the `gtag('config', ...)` calls in index.html so the production GA4 property only receives data from real `pdflokal.id` / `www.pdflokal.id` traffic, not from every `npx serve` session, Playwright headless run, or Vercel preview deploy.

## The smoking gun

Discovered via GA4 MCP query while debugging why GA4 and Vercel Analytics disagreed wildly:

| Source | Weekly page_views (7 days) | Weekly visitors |
|---|---:|---:|
| GA4 (polluted) | 1,621 | 1,286 |
| Vercel Analytics | 649 | 356 |

GA4 breakdown by `pageLocation`:

| URL | events | users |
|---|---:|---:|
| **`http://localhost/`** | **1,086** | **1,086** |
| `https://www.pdflokal.id/` | 482 | 198 |
| `https://www.pdflokal.id/index.html` | 36 | 13 |
| `https://www.pdflokal.id/dukung.html` | 11 | 10 |

**67% of GA4's weekly page_views were from `http://localhost/`.** Mostly Playwright `--isolated` browser contexts spinning up fresh GA client_ids every test. With ~50 Playwright test runs in one day for the visual regression suite, that compounds fast.

This also distorted derived metrics — the page_view → file_loaded conversion I previously reported as 11.5% was actually ~69% once filtered to prod-only data. Funnel was healthy the whole time; we just couldn't see it.

## The fix

```js
if (location.hostname === 'pdflokal.id' || location.hostname === 'www.pdflokal.id') {
  gtag('config', 'AW-17538923405');
  gtag('config', 'G-0XJY0WLCZ1');
}
```

Allowlist > blocklist on purpose — a new dev/preview hostname added in the future can never silently leak.

Why this works: without `gtag('config', ...)`, no property is registered, so any later `gtag('event', ...)` calls (from `track()`) sit in `dataLayer` locally and never fire a network request.

## Why Vercel Analytics didn't have this problem

Vercel's script is served from `/_vercel/insights/script.js` — a relative path that only resolves on Vercel deployments. On localhost the script 404s, so the script never loads. Free dev protection from infrastructure, not from explicit code.

## Verified locally

After the fix, navigating to `http://localhost:5050/`:
- `location.hostname` = `localhost`
- `dataLayer.filter(a => a[0] === 'config').length` = **0**
- Network requests matching `google-analytics|googletagmanager|gtag|doubleclick` = **0**

## Trade-off

GA4 will not receive ANY data while developing or running Playwright tests. That's the intent. Local dev should use:
- Browser DevTools → Network tab to verify `dataLayer` and event firing manually
- A separate GA4 property if dev-mode telemetry is ever needed

## Test plan

- [x] Lint clean
- [x] 36/36 Playwright tests pass
- [x] Verified locally: zero analytics requests from localhost
- [ ] Smoke-test on production after merge: confirm events still flow into GA4 (should — only the hostname guard changed)

## What this does NOT fix

- Past GA4 data is still polluted (~67% phantom from before this PR). For trustable historical queries, filter `pageLocation` to start with `https://www.pdflokal.id/` or `https://pdflokal.id/`.
- After this merges, the cleanest data window starts from the deployment timestamp. Future GA4 MCP queries are trustable unfiltered from that point onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)