### PR TITLE
feat(editor): contextual text format bar + click-away commit fix

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -13,13 +13,24 @@ Running list of UI/UX findings + small fixes to pick up later. Append new items 
 
 ## Open
 
-- **[high]** User can't pick a font family for text annotations — [inline-editor.js](js/editor/inline-editor.js), [text-modal.js](js/pdf-tools/text-modal.js), [state.js CSS_FONT_MAP](js/lib/state.js)
-  - User report (Jun 10): font dropdown is either not visible in the inline text editor flow, or the selection doesn't actually apply to the annotation. Options exist in state (Helvetica, Times Roman, Courier, Montserrat, Carlito — confirmed in DOM during Jun 9 prod test) so this is a wiring/UI bug, not a missing feature.
-  - Investigation before fix: confirm whether the font picker is shown in BOTH the modal-first text creation AND the inline-text-on-first-click flow (PR #54). If only one path exposes it, that's the gap. Also check whether `applyEditorText` reads the font from the picker state at apply time.
+- **[high]** Rework the "Gabungkan Halaman" / page-manager modal — naming mismatch + the interaction can be much stronger — [page-manager.js](js/editor/page-manager.js), [index.html](index.html) (`#ue-gabungkan-modal`), [style.css](style.css) (`.ue-pm-*`)
+  - User note (Jul 1): page management should be one of PDFLokal's strongest points, and this modal underdelivers. Two separate problems:
+  - **(1) Naming is inconsistent AND wrong.** The button that opens it says **"Kelola Halaman"** (Manage Pages) but the modal title says **"Gabungkan Halaman"** (Merge Pages). The modal does far more than merge — reorder, rotate, delete, split, add PDF, add image. "Gabungkan" is a misnomer; the button's "Kelola Halaman" is the accurate label. Fix: rename the modal title (and ideally the internal `gabungkan`/`uePm` naming over time) to **"Kelola Halaman"** so button and modal agree and the term matches what it actually does. Analytics event is `gabungkan_used` — keep or migrate deliberately so history isn't broken. Low-risk, ship-anytime part.
+  - **(2) The interaction itself.** My read after reading page-manager.js:
+    - **Three mental models crammed into one surface with no separation:** *add* content (Tambah PDF / Tambah Gambar), *arrange* content (drag-reorder + per-page rotate/delete), and *extract* content (Split PDF). The top row mixes add-actions and an extract-action; the grid is arrange. Nothing groups or sequences these.
+    - **Reorder has zero affordance.** Drag-to-reorder is the primary action but nothing tells the user pages are draggable (no grab cursor hint, no "seret untuk mengurutkan" caption). New users won't discover it.
+    - **"Split" is a heavy hidden mode switch.** Toggling Split flips the whole grid into checkbox-selection mode (drag disabled, click = select) — a mode-within-a-modal. Easy to get stuck in; the only exit is "Batal Split".
+    - **Rotate/delete are hover-only buttons** → invisible/unusable on touch (this modal IS used on mobile).
+    - **Redundant with the sidebar.** The sidebar thumbnails already do drag-reorder; this modal duplicates that plus more. Worth deciding: is the modal the "power" surface and the sidebar the "quick" one, or should they converge?
+  - Before designing: per project convention, look at how Stirling-PDF's page-organizer and Excalidraw/tldraw handle multi-item arrange/select/extract surfaces — don't invent blind. Then decide scope (rename-only vs full redesign) with the user.
 
-- **[high]** User can't bold (or italic) text annotations — [inline-editor.js](js/editor/inline-editor.js), [text-modal.js](js/pdf-tools/text-modal.js), [annotations.js drawTextAnnotation](js/editor/annotations.js)
-  - User report (Jun 10): bold/italic toggle is missing or non-functional. State factory `createTextAnnotation` supports `bold` + `italic` flags, and `buildCanvasFont` maps them to CSS, so the data model is ready — UI just isn't writing the flag, or render isn't reading it back at the right time.
-  - Investigation before fix: check whether the inline editor exposes B/I controls at all (might be modal-only), and whether `_editing` flag handling preserves bold/italic across modal→inline transitions and undo/redo cycles.
+- **[low]** Question the red outline around the active page (sidebar thumbnail + main canvas) — is it earning its keep? — [style.css](style.css) (search `.selected` / active-page rules), [sidebar.js ueHighlightThumbnail](js/editor/sidebar.js)
+  - User asked (Jul 1): why is there a red outline around the active page in both the sidebar and the canvas? What does it actually do for the user? If it has no real UI/UX benefit, just remove it.
+  - Investigation before touching: identify every rule/JS path that draws it — sidebar thumbnail `.selected` outline AND the main canvas red border seen in the screenshot. Note CLAUDE.md says the page-selection border is intentionally hidden on mobile (`.ue-page-slot.selected canvas` outline only at `min-width: 901px`), so this is desktop-only already. Decide whether "which page is active" is communicated well enough by the sidebar highlight + `Hal X/Y` indicator alone.
+  - Likely outcome: sidebar highlight is useful (shows selection); the thick red border around the whole main canvas page is the questionable one — it's loud and may not add info the user needs. Consider softening (thinner/neutral) or removing the canvas border while keeping the sidebar highlight.
+
+- **[low]** Retire the orphaned `text-input-modal` — [text-modal.js](js/pdf-tools/text-modal.js), [index.html](index.html) (`#text-input-modal`)
+  - The old text modal is now double-dead: nothing triggered `ueOpenTextModal()` even before the format bar, and the bar fully replaces its purpose. Dead code (modal DOM + text-modal.js + `ueConfirmText`/`getTextModalSettings` + window bridges + MODAL_IDS/close-map entries). Remove in a dedicated cleanup PR (touches navigation.js, init-ui.js, index.js bridges) so a regression is easy to bisect.
 
 - **[high]** Mobile fast-scroll sometimes jumps the viewport to page 1 — [page-rendering.js setupScrollSync](js/editor/page-rendering.js)
   - User report (Jun 9, Android Chrome): during the brief restore-from-cache flash (PR #66), occasionally the scroll position snaps back to page 1.
@@ -88,6 +99,11 @@ Running list of UI/UX findings + small fixes to pick up later. Append new items 
 ---
 
 ## Done
+
+- **[high×2]** Text annotations: can't pick font family + can't bold/italic (Jul 1) — [text-format-bar.js](js/editor/text-format-bar.js), [text-format-bar.spec.js](tests/text-format-bar.spec.js)
+  - Root cause (confirmed): PR #54 rerouted the Text tool to inline-on-first-click, bypassing the `text-input-modal` (which held the font/B/I/size/color controls). That modal was left **orphaned** — nothing called `ueOpenTextModal()` — so there was NO reachable UI to set font/bold/italic anywhere. Data model + render + export (`createTextAnnotation`, `buildCanvasFont`, `resolveFontName`) already supported the flags.
+  - Fix: new **contextual floating format bar** (Word/Figma/Canva feel). Appears (a) while the inline editor is open and (b) when a text annotation is selected with Pilih. Controls — font family, B, I, size ±/input, color — apply LIVE (mutate + redraw), persist to `lastTextOptions`, and push one undo snapshot per change-burst. Positioned `fixed` above the annotation, tracks it on scroll/drag/resize. Blur-save made cancellable + focus-guarded so focusing the bar's inputs doesn't tear down the editor mid-format.
+  - Verified: 2 harness tests (live font/B/I/size/color + persistence; restyle already-selected + deselect hides). Export confirmed to consume `fontFamily/bold/italic` end-to-end. Lint + 39 functional + 8 visual green (bar hidden by default → no baseline shift). Follow-up logged: retire the now-double-dead `text-input-modal`.
 
 - **[med]** Mobile: top of first page hidden under the fixed floating toolbar (Jul 1) — [style.css:3806](style.css#L3806), [mobile-toolbar-overlap.spec.js](tests/mobile-toolbar-overlap.spec.js)
   - User report (Android Chrome): after Ganti File to a full-bleed image, top ~21px of the page sat under the toolbar. Desktop unaffected.

--- a/index.html
+++ b/index.html
@@ -626,6 +626,27 @@
         </div>
       </div>
 
+      <!-- Contextual text format toolbar (Word/Figma/Canva-style). Shown while
+           editing or selecting a text annotation; positioned via text-format-bar.js. -->
+      <div id="text-format-bar" class="text-format-bar" role="toolbar" aria-label="Format teks" hidden>
+        <select id="tfb-font" class="tfb-font" aria-label="Jenis font" title="Font">
+          <option value="Helvetica">Helvetica</option>
+          <option value="Times-Roman">Times</option>
+          <option value="Courier">Courier</option>
+          <option value="Montserrat">Montserrat</option>
+          <option value="Carlito">Carlito</option>
+        </select>
+        <span class="tfb-sep"></span>
+        <button type="button" id="tfb-bold" class="tfb-btn" title="Tebal" aria-label="Tebal" aria-pressed="false"><strong>B</strong></button>
+        <button type="button" id="tfb-italic" class="tfb-btn" title="Miring" aria-label="Miring" aria-pressed="false"><em>I</em></button>
+        <span class="tfb-sep"></span>
+        <button type="button" id="tfb-size-dec" class="tfb-btn tfb-size-btn" title="Perkecil" aria-label="Perkecil ukuran">&minus;</button>
+        <input type="number" id="tfb-size" class="tfb-size" min="6" max="120" value="16" aria-label="Ukuran font">
+        <button type="button" id="tfb-size-inc" class="tfb-btn tfb-size-btn" title="Perbesar" aria-label="Perbesar ukuran">+</button>
+        <span class="tfb-sep"></span>
+        <input type="color" id="tfb-color" class="tfb-color" value="#000000" title="Warna teks" aria-label="Warna teks">
+      </div>
+
       <!-- Editor Bottom Bar (desktop) -->
       <div class="editor-bottom-bar" id="editor-bottom-bar">
         <div class="editor-bottom-left"></div>

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -23,6 +23,16 @@
 // Changelog data - Add new updates at the beginning of the array
 const changelogData = [
   {
+    title: "Atur Gaya Teks Sesukamu! ✍️",
+    description: "Nambah teks di PDF sekarang jauh lebih fleksibel. Kamu bisa pilih jenis font, bikin tebal atau miring, atur ukuran, dan ganti warna — semua langsung kelihatan hasilnya pas kamu ngetik. Mau ubah lagi nanti? Tinggal klik teksnya, menu formatnya muncul otomatis di atasnya. PDFLokal juga inget gaya terakhir yang kamu pakai, jadi ngisi banyak kolom jadi lebih cepat.",
+    date: "1 Juli 2026"
+  },
+  {
+    title: "Alat Paraf Baru! 🖋️",
+    description: "Sekarang ada alat khusus buat paraf (inisial). Gambar parafmu sekali, terus tempel ke semua halaman cuma dengan satu klik lewat tombol \"Semua Hal.\" — pas banget buat dokumen kontrak yang butuh paraf di tiap lembar.",
+    date: "30 Mei 2026"
+  },
+  {
     title: "Hubungi Kami! 💬",
     description: "Sekarang kamu bisa langsung ngobrol sama developer PDFLokal! Mau lapor bug, minta fitur baru, atau cuma mau bilang hai — tulis aja di <a href=\"https://forms.gle/KPDWVAuc91pVjuWq6\" target=\"_blank\">sini</a>. Anonim, gak perlu login.",
     date: "11 Maret 2026"

--- a/js/editor/annotations.js
+++ b/js/editor/annotations.js
@@ -138,6 +138,9 @@ export function ueRemoveAnnotation(pageIndex, annoIndex) {
       ueState.selectedAnnotation.pageIndex === pageIndex &&
       ueState.selectedAnnotation.index === annoIndex) {
     ueState.selectedAnnotation = null;
+    // The removed annotation may have been the format bar's target — hide it.
+    // window.* avoids an annotations ↔ text-format-bar import cycle.
+    window.hideTextFormatBar?.();
   }
 }
 

--- a/js/editor/canvas-events.js
+++ b/js/editor/canvas-events.js
@@ -8,7 +8,7 @@ import { showToast } from '../lib/utils.js';
 import { ueGetCoords, ueGetResizeHandle, getTextBounds } from './canvas-utils.js';
 import { ueRedrawAnnotations, ueFindAnnotationAt, ueAddAnnotation } from './annotations.js';
 import { ueSaveEditUndoState, uePushAnnotationSnapshot } from './undo-redo.js';
-import { ueCreateInlineTextEditor } from './inline-editor.js';
+import { ueCreateInlineTextEditor, commitActiveInlineTextEditor } from './inline-editor.js';
 import { showTextFormatBar, hideTextFormatBar, repositionTextFormatBar } from './text-format-bar.js';
 import { ueHighlightThumbnail } from './page-rendering.js';
 import { ueZoomIn, ueZoomOut } from './zoom-rotate.js';
@@ -335,6 +335,13 @@ export function ueSetupCanvasEvents() {
   }
 
   function handleDown({ x, y }) {
+    // WHY: If an inline text editor is open, this pointerdown ENDS the edit.
+    // Commit it synchronously and consume the click — do NOT fall through to
+    // tool handling. Otherwise, with the Text tool still armed, the matching
+    // mouseup would place a SECOND text box (the tool only switches to select
+    // on save, which is too late for the click that triggered the save).
+    if (commitActiveInlineTextEditor()) return;
+
     startX = x;
     startY = y;
 

--- a/js/editor/canvas-events.js
+++ b/js/editor/canvas-events.js
@@ -9,6 +9,7 @@ import { ueGetCoords, ueGetResizeHandle, getTextBounds } from './canvas-utils.js
 import { ueRedrawAnnotations, ueFindAnnotationAt, ueAddAnnotation } from './annotations.js';
 import { ueSaveEditUndoState, uePushAnnotationSnapshot } from './undo-redo.js';
 import { ueCreateInlineTextEditor } from './inline-editor.js';
+import { showTextFormatBar, hideTextFormatBar, repositionTextFormatBar } from './text-format-bar.js';
 import { ueHighlightThumbnail } from './page-rendering.js';
 import { ueZoomIn, ueZoomOut } from './zoom-rotate.js';
 import { track } from '../lib/analytics.js';
@@ -318,6 +319,9 @@ export function ueSetupCanvasEvents() {
       dragOffsetY = y - (anno.type === 'text' ? anno.y - anno.fontSize : anno.y);
       ueRedrawAnnotations();
       ueShowConfirmButton(anno, clicked);
+      // Text annotations get the contextual format bar; other types don't.
+      if (anno.type === 'text') showTextFormatBar(anno, clicked.pageIndex);
+      else hideTextFormatBar();
       return true;
     }
 
@@ -325,6 +329,7 @@ export function ueSetupCanvasEvents() {
     ueState.selectedAnnotation = null;
     ueState.lastLockedToastAnnotation = null;
     ueHideConfirmButton();
+    hideTextFormatBar();
     ueRedrawAnnotations();
     return false;
   }
@@ -368,6 +373,7 @@ export function ueSetupCanvasEvents() {
       hasMovedOrResized = true;
       ueRedrawAnnotations();
       ueUpdateConfirmButtonPosition(anno);
+      repositionTextFormatBar(); // no-op unless the bar targets this text anno
       return;
     }
 
@@ -378,6 +384,7 @@ export function ueSetupCanvasEvents() {
       hasMovedOrResized = true;
       ueRedrawAnnotations();
       ueUpdateConfirmButtonPosition(anno);
+      repositionTextFormatBar(); // no-op unless the bar targets this text anno
       return;
     }
 

--- a/js/editor/index.js
+++ b/js/editor/index.js
@@ -46,6 +46,8 @@ export { ueSetupCanvasEvents } from './canvas-events.js';
 
 export { ueCreateInlineTextEditor } from './inline-editor.js';
 
+export { showTextFormatBar, hideTextFormatBar, repositionTextFormatBar } from './text-format-bar.js';
+
 export {
   ueSetTool, ueOpenSignatureModal, ueOpenParafModal, ueOpenTextModal, ueConfirmText,
   ueOpenWatermarkModal, ueOpenPageNumModal,
@@ -175,6 +177,12 @@ window.ueOpenProtectModal = ueOpenProtectModal;
 window.closeEditorProtectModal = closeEditorProtectModal;
 window.applyEditorProtect = applyEditorProtect;
 window.editorGoHome = editorGoHome;
+
+// Text format bar — window bridges let page-rendering (selectPage) and
+// annotations (ueRemoveAnnotation) hide it without a new import cycle.
+import { hideTextFormatBar, repositionTextFormatBar } from './text-format-bar.js';
+window.hideTextFormatBar = hideTextFormatBar;
+window.repositionTextFormatBar = repositionTextFormatBar;
 
 // PDF export
 import { ueBuildFinalPDF, ueDownload } from './pdf-export.js';

--- a/js/editor/inline-editor.js
+++ b/js/editor/inline-editor.js
@@ -7,6 +7,7 @@ import { ueState, mobileState, buildCanvasFont } from '../lib/state.js';
 import { ueGetCurrentCanvas, getTextBounds } from './canvas-utils.js';
 import { ueRedrawAnnotations, ueRemoveAnnotation } from './annotations.js';
 import { uePushAnnotationSnapshot } from './undo-redo.js';
+import { showTextFormatBar, hideTextFormatBar } from './text-format-bar.js';
 
 // WHY: opts.isNew = true when the annotation was just created via canvas click
 // (inline-on-first-create flow). Differs from the dblclick-on-existing path in
@@ -98,6 +99,7 @@ export function ueCreateInlineTextEditor(anno, opts = {}) {
     if (isNew && !newText) {
       removeOrphan();
       ueRedrawAnnotations();
+      hideTextFormatBar();
       editor.remove();
       switchToSelectIfNew();
       return;
@@ -122,6 +124,7 @@ export function ueCreateInlineTextEditor(anno, opts = {}) {
     }
 
     ueRedrawAnnotations();
+    hideTextFormatBar();
     editor.remove();
     switchToSelectIfNew();
   };
@@ -135,6 +138,7 @@ export function ueCreateInlineTextEditor(anno, opts = {}) {
     // Click-to-create annotations have no "original" state to preserve — drop them.
     if (isNew) removeOrphan();
     ueRedrawAnnotations();
+    hideTextFormatBar();
     editor.remove();
     switchToSelectIfNew();
   };
@@ -158,11 +162,28 @@ export function ueCreateInlineTextEditor(anno, opts = {}) {
   // 300ms delay prevents premature save when user taps keyboard toolbar buttons.
   // Shorter delay causes text loss on slower devices.
   const blurDelay = mobileState.isTouch ? 300 : 100;
-  editor.addEventListener('blur', () => setTimeout(saveEdit, blurDelay));
+  let blurSaveTimer = null;
+  editor.addEventListener('blur', () => {
+    blurSaveTimer = setTimeout(() => {
+      // WHY: focusing the format bar's font/size/color controls blurs this
+      // contentEditable. Don't end the edit while the user is restyling — the
+      // bar returns focus after a discrete change (see refocus in text-format-bar).
+      const fb = document.getElementById('text-format-bar');
+      if (fb && !fb.hidden && fb.contains(document.activeElement)) return;
+      saveEdit();
+    }, blurDelay);
+  });
+  // Regaining focus (bar returned it after a font/size change) cancels the
+  // pending blur-save so editing continues seamlessly.
+  editor.addEventListener('focus', () => clearTimeout(blurSaveTimer));
 
   wrapper.style.position = 'relative';
   wrapper.appendChild(editor);
   editor.focus();
+
+  // Contextual format toolbar (font / bold / italic / size / color) anchored to
+  // this annotation while editing. Applies live and persists to lastTextOptions.
+  showTextFormatBar(anno);
 
   // On mobile, reposition editor when virtual keyboard resizes the viewport
   if (window.visualViewport && mobileState.isTouch) {

--- a/js/editor/inline-editor.js
+++ b/js/editor/inline-editor.js
@@ -9,6 +9,19 @@ import { ueRedrawAnnotations, ueRemoveAnnotation } from './annotations.js';
 import { uePushAnnotationSnapshot } from './undo-redo.js';
 import { showTextFormatBar, hideTextFormatBar } from './text-format-bar.js';
 
+// The current inline editor's commit (saveEdit) closure, or null when none is
+// open. Lets other modules (canvas-events) commit the edit synchronously.
+let activeInlineCommit = null;
+
+// Commit the open inline text edit right now (if any). Returns true if there was
+// an editor to commit. WHY: a canvas pointerdown that ends an edit must commit
+// synchronously and be consumed, so it can't also trigger tool actions.
+export function commitActiveInlineTextEditor() {
+  if (!activeInlineCommit) return false;
+  activeInlineCommit();
+  return true;
+}
+
 // WHY: opts.isNew = true when the annotation was just created via canvas click
 // (inline-on-first-create flow). Differs from the dblclick-on-existing path in
 // two ways:
@@ -90,6 +103,7 @@ export function ueCreateInlineTextEditor(anno, opts = {}) {
   const saveEdit = () => {
     if (saved) return;
     saved = true;
+    activeInlineCommit = null;
     const newText = editor.innerText.trim();
     delete anno._editing;
 
@@ -134,6 +148,7 @@ export function ueCreateInlineTextEditor(anno, opts = {}) {
     // via setTimeout(blurDelay). Without this guard, Escape-cancelled edits would still
     // commit ~100-300ms later and pollute the undo stack.
     saved = true;
+    activeInlineCommit = null;
     delete anno._editing;
     // Click-to-create annotations have no "original" state to preserve — drop them.
     if (isNew) removeOrphan();
@@ -142,6 +157,11 @@ export function ueCreateInlineTextEditor(anno, opts = {}) {
     editor.remove();
     switchToSelectIfNew();
   };
+
+  // WHY: lets a canvas pointerdown commit this edit synchronously and consume the
+  // click (see commitActiveInlineTextEditor). Prevents the "click-away creates a
+  // second text box" bug — the click that ends the edit must not also place text.
+  activeInlineCommit = saveEdit;
 
   editor.addEventListener('keydown', (e) => {
     if (e.key === 'Enter' && !e.shiftKey) {

--- a/js/editor/page-rendering.js
+++ b/js/editor/page-rendering.js
@@ -166,6 +166,8 @@ class PageRenderer {
     // ueHideConfirmButton lives in signatures.js; importing it here would create
     // a circular chain (page-rendering ↔ signatures via canvas-events).
     window.ueHideConfirmButton();
+    // Same reasoning — hide the text format bar via its window bridge.
+    window.hideTextFormatBar?.();
 
     ueState.selectedPage = index;
 

--- a/js/editor/text-format-bar.js
+++ b/js/editor/text-format-bar.js
@@ -1,0 +1,248 @@
+/*
+ * PDFLokal - editor/text-format-bar.js (ES Module)
+ *
+ * Contextual floating format toolbar for text annotations — the Word/Figma/Canva
+ * pattern. Appears anchored above a text annotation in two situations:
+ *   1. While the inline text editor is open (creating or editing text).
+ *   2. When a text annotation is selected with the Pilih (select) tool.
+ *
+ * Every control applies LIVE to the target annotation (mutate + redraw), so it's
+ * WYSIWYG. Changes also persist into ueState.lastTextOptions, so the next text
+ * annotation inherits the style — the same "last used" behaviour the inline flow
+ * already relied on (UX audit H2).
+ *
+ * WHY this exists: PR #54 rerouted the Text tool to inline-on-first-click, which
+ * bypassed the (now orphaned) text-input-modal — leaving NO reachable UI to pick
+ * a font family or toggle bold/italic. This bar restores that, inline.
+ */
+
+import { ueState, buildCanvasFont } from '../lib/state.js';
+import { getTextBounds } from './canvas-utils.js';
+import { ueRedrawAnnotations } from './annotations.js';
+import { uePushAnnotationSnapshot } from './undo-redo.js';
+
+// Current target: the annotation the bar is editing + the page it lives on.
+let target = null; // { anno, pageIndex }
+let wired = false;
+
+// WHY one snapshot per burst: clicking B, then I, then bumping size in quick
+// succession should collapse into a SINGLE undo entry, not one per click.
+// Mirrors the debounced-undo pattern used for arrow-nudge/inline edits.
+let snapshotPushedForBurst = false;
+let burstTimer = null;
+const BURST_MS = 800;
+
+const CHROME_TOP = 96; // header + toolbar height to avoid placing the bar under
+
+function bar() { return document.getElementById('text-format-bar'); }
+function byId(id) { return document.getElementById(id); }
+
+// Resolve which page an annotation reference lives on. Prefer the hint; fall
+// back to scanning (dblclick-edit doesn't thread a pageIndex through).
+function resolvePageIndex(anno, hint) {
+  if (typeof hint === 'number' && ueState.annotations[hint]?.includes(anno)) return hint;
+  for (const [key, list] of Object.entries(ueState.annotations)) {
+    if (list.includes(anno)) return Number(key);
+  }
+  return ueState.selectedPage;
+}
+
+function markChange() {
+  if (!snapshotPushedForBurst) {
+    uePushAnnotationSnapshot(JSON.parse(JSON.stringify(ueState.annotations)));
+    snapshotPushedForBurst = true;
+  }
+  clearTimeout(burstTimer);
+  burstTimer = setTimeout(() => { snapshotPushedForBurst = false; }, BURST_MS);
+}
+
+function persistLastOptions() {
+  if (!target) return;
+  const a = target.anno;
+  ueState.lastTextOptions = {
+    fontSize: a.fontSize,
+    color: a.color,
+    fontFamily: a.fontFamily,
+    bold: !!a.bold,
+    italic: !!a.italic,
+  };
+}
+
+// Keep the inline text editor's on-screen font/colour in sync when the user
+// restyles WHILE typing (so it's truly WYSIWYG, not "changes on commit").
+function syncInlineEditor() {
+  const editor = byId('inline-text-editor');
+  if (!editor || !target) return;
+  const a = target.anno;
+  const canvas = ueState.pageCanvases[target.pageIndex]?.canvas;
+  const dpr = ueState.devicePixelRatio || 1;
+  const scaleX = canvas ? canvas.getBoundingClientRect().width / (canvas.width / dpr) : 1;
+  editor.style.font = buildCanvasFont(a, a.fontSize * scaleX);
+  editor.style.color = a.color || '#000000';
+}
+
+// Apply the current target's state to the canvas + editor + persisted defaults.
+function applyChange() {
+  markChange();
+  ueRedrawAnnotations();
+  syncInlineEditor();
+  persistLastOptions();
+  // Confirm/delete buttons track the annotation; keep them aligned after resize.
+  if (typeof window.ueUpdateConfirmButtonPosition === 'function') {
+    window.ueUpdateConfirmButtonPosition(target?.anno);
+  }
+  repositionTextFormatBar();
+}
+
+function clampSize(n) {
+  if (Number.isNaN(n)) return 16;
+  return Math.min(120, Math.max(6, n));
+}
+
+// WHY: font <select> and the size <input> steal focus from the inline editor.
+// After a discrete change, hand focus back so the blur-save timer is cancelled
+// (inline-editor listens for focus) and typing/Enter keep working. Caret to end.
+function refocusInlineEditor() {
+  const ed = byId('inline-text-editor');
+  if (!ed) return;
+  ed.focus();
+  const range = document.createRange();
+  range.selectNodeContents(ed);
+  range.collapse(false);
+  const sel = window.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(range);
+}
+
+function wireOnce() {
+  if (wired) return;
+  wired = true;
+
+  byId('tfb-font').addEventListener('change', (e) => {
+    if (!target) return;
+    target.anno.fontFamily = e.target.value;
+    applyChange();
+    refocusInlineEditor();
+  });
+
+  byId('tfb-bold').addEventListener('click', () => {
+    if (!target) return;
+    target.anno.bold = !target.anno.bold;
+    byId('tfb-bold').setAttribute('aria-pressed', String(!!target.anno.bold));
+    byId('tfb-bold').classList.toggle('active', !!target.anno.bold);
+    applyChange();
+  });
+
+  byId('tfb-italic').addEventListener('click', () => {
+    if (!target) return;
+    target.anno.italic = !target.anno.italic;
+    byId('tfb-italic').setAttribute('aria-pressed', String(!!target.anno.italic));
+    byId('tfb-italic').classList.toggle('active', !!target.anno.italic);
+    applyChange();
+  });
+
+  const commitSize = (n) => {
+    if (!target) return;
+    const size = clampSize(n);
+    target.anno.fontSize = size;
+    byId('tfb-size').value = size;
+    applyChange();
+  };
+  byId('tfb-size').addEventListener('change', (e) => {
+    commitSize(Number.parseInt(e.target.value, 10));
+    refocusInlineEditor();
+  });
+  byId('tfb-size-dec').addEventListener('click', () => commitSize((target?.anno.fontSize || 16) - 1));
+  byId('tfb-size-inc').addEventListener('click', () => commitSize((target?.anno.fontSize || 16) + 1));
+
+  byId('tfb-color').addEventListener('input', (e) => {
+    if (!target) return;
+    target.anno.color = e.target.value;
+    applyChange();
+  });
+
+  // WHY mousedown preventDefault: clicking a bar control must NOT blur the inline
+  // text editor (blur queues saveEdit, which would tear the editor down mid-format).
+  bar().addEventListener('mousedown', (e) => {
+    if (e.target.tagName !== 'INPUT' && e.target.tagName !== 'SELECT') e.preventDefault();
+  });
+}
+
+// Load the bar's controls from the target annotation's current formatting.
+function populateFromTarget() {
+  const a = target.anno;
+  byId('tfb-font').value = a.fontFamily || 'Helvetica';
+  byId('tfb-size').value = a.fontSize || 16;
+  byId('tfb-color').value = a.color || '#000000';
+  byId('tfb-bold').classList.toggle('active', !!a.bold);
+  byId('tfb-bold').setAttribute('aria-pressed', String(!!a.bold));
+  byId('tfb-italic').classList.toggle('active', !!a.italic);
+  byId('tfb-italic').setAttribute('aria-pressed', String(!!a.italic));
+}
+
+// WHY position: fixed + viewport coords: the bar floats over everything and must
+// track the annotation as the user scrolls (Figma/Canva "glued" toolbar). We
+// recompute from the page canvas's on-screen rect each time.
+export function repositionTextFormatBar() {
+  const b = bar();
+  if (!b || !target || b.hidden) return;
+  const canvas = ueState.pageCanvases[target.pageIndex]?.canvas;
+  if (!canvas) { hideTextFormatBar(); return; }
+
+  const ctx = canvas.getContext('2d');
+  const bounds = getTextBounds(target.anno, ctx);
+  const rect = canvas.getBoundingClientRect();
+  const dpr = ueState.devicePixelRatio || 1;
+  const scaleX = rect.width / (canvas.width / dpr);
+  const scaleY = rect.height / (canvas.height / dpr);
+
+  const textLeft = rect.left + bounds.x * scaleX;
+  const textTop = rect.top + bounds.y * scaleY;
+  const textBottom = textTop + bounds.height * scaleY;
+
+  const bw = b.offsetWidth || 260;
+  const bh = b.offsetHeight || 40;
+  const gap = 8;
+
+  // Prefer above the text; drop below if it would collide with the top chrome.
+  let top = textTop - bh - gap;
+  if (top < CHROME_TOP) top = textBottom + gap;
+  // Keep on-screen vertically.
+  top = Math.min(top, window.innerHeight - bh - gap);
+  top = Math.max(top, CHROME_TOP);
+
+  let left = textLeft;
+  left = Math.min(left, window.innerWidth - bw - 8);
+  left = Math.max(left, 8);
+
+  b.style.left = left + 'px';
+  b.style.top = top + 'px';
+}
+
+const onScrollResize = () => repositionTextFormatBar();
+
+export function showTextFormatBar(anno, pageIndexHint) {
+  if (!anno || anno.type !== 'text') return;
+  const b = bar();
+  if (!b) return;
+
+  target = { anno, pageIndex: resolvePageIndex(anno, pageIndexHint) };
+  wireOnce();
+  populateFromTarget();
+
+  b.hidden = false;
+  repositionTextFormatBar();
+
+  window.addEventListener('scroll', onScrollResize, { passive: true });
+  window.addEventListener('resize', onScrollResize);
+  if (window.visualViewport) window.visualViewport.addEventListener('resize', onScrollResize);
+}
+
+export function hideTextFormatBar() {
+  const b = bar();
+  if (b) b.hidden = true;
+  target = null;
+  window.removeEventListener('scroll', onScrollResize);
+  window.removeEventListener('resize', onScrollResize);
+  if (window.visualViewport) window.visualViewport.removeEventListener('resize', onScrollResize);
+}

--- a/js/editor/tools.js
+++ b/js/editor/tools.js
@@ -7,6 +7,7 @@ import { ueState, createTextAnnotation } from '../lib/state.js';
 import { showToast, downloadBlob, getDownloadFilename } from '../lib/utils.js';
 import { openModal, closeModal, showHome } from '../lib/navigation.js';
 import { ueHideConfirmButton } from './signatures.js';
+import { hideTextFormatBar } from './text-format-bar.js';
 import { ueRedrawAnnotations, ueAddAnnotation } from './annotations.js';
 import { ueSaveEditUndoState } from './undo-redo.js';
 import { track } from '../lib/analytics.js';
@@ -20,6 +21,7 @@ export function ueSetTool(tool) {
   if (tool !== 'select') {
     ueState.selectedAnnotation = null;
     ueHideConfirmButton();
+    hideTextFormatBar();
   }
 
   if (tool !== 'signature' && tool !== 'paraf') {

--- a/style.css
+++ b/style.css
@@ -2918,6 +2918,99 @@ html[data-theme="dark"] .floating-toolbar {
   flex-shrink: 0;
 }
 
+/* ---- Contextual Text Format Bar (Word/Figma/Canva-style) ---- */
+/* WHY position:fixed + JS placement: floats above the target text annotation and
+   tracks it on scroll. z-index above the inline text editor (10000) so its
+   controls stay clickable while editing. */
+.text-format-bar {
+  position: fixed;
+  z-index: 10001;
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  padding: 4px 6px;
+  background: var(--bg, #fff);
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.14);
+}
+.text-format-bar[hidden] { display: none; }
+
+html[data-theme="dark"] .text-format-bar {
+  background: #1e1e1e;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+.tfb-font {
+  height: 28px;
+  max-width: 118px;
+  padding: 0 6px;
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.tfb-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  height: 28px;
+  padding: 0 7px;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  transition: background 0.15s, color 0.15s;
+}
+.tfb-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+.tfb-btn.active { background: var(--accent-primary); color: #fff; }
+.tfb-btn strong, .tfb-btn em { font-size: 0.9rem; line-height: 1; }
+.tfb-size-btn { font-size: 1rem; font-weight: 600; }
+
+.tfb-size {
+  width: 40px;
+  height: 28px;
+  text-align: center;
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 0.78rem;
+}
+
+.tfb-color {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
+  background: none;
+  cursor: pointer;
+}
+
+.tfb-sep {
+  width: 1px;
+  height: 18px;
+  background: var(--border-light);
+  margin: 0 2px;
+  flex-shrink: 0;
+}
+
+/* Mobile: slightly tighter so the bar fits narrow viewports. */
+@media (max-width: 900px) {
+  .text-format-bar { gap: 2px; padding: 3px 4px; }
+  .tfb-font { max-width: 92px; font-size: 0.72rem; }
+  .tfb-btn { min-width: 26px; height: 26px; }
+  .tfb-size { width: 34px; height: 26px; }
+  .tfb-color { width: 26px; height: 26px; }
+}
+
 /* Signature wrapper for tooltip positioning */
 .ft-signature-wrapper {
   position: relative;

--- a/tests/text-format-bar.spec.js
+++ b/tests/text-format-bar.spec.js
@@ -84,6 +84,30 @@ test.describe('text format bar', () => {
     await expect(page.locator('#text-format-bar')).toBeHidden();
   });
 
+  // Regression: creating a new text via the Text tool, then clicking elsewhere to
+  // finish, used to place a SECOND (empty) text box — the tool stayed 'text' and
+  // the click's mouseup created another annotation. The click that ends an edit
+  // must commit-and-consume, then revert to Pilih.
+  test('click-away after creating text commits and does NOT create a second box', async ({ page }) => {
+    await loadSample(page);
+    await createTextAndOpenBar(page, 'test', 90, 90);
+
+    // Click an empty area far from the new text.
+    await page.evaluate(() => {
+      const canvas = document.querySelectorAll('.ue-page-slot canvas')[0];
+      const rect = canvas.getBoundingClientRect();
+      const opts = { bubbles: true, cancelable: true, clientX: rect.left + rect.width * 0.7, clientY: rect.top + rect.height * 0.7, button: 0 };
+      canvas.dispatchEvent(new MouseEvent('mousedown', opts));
+      canvas.dispatchEvent(new MouseEvent('mouseup', opts));
+    });
+
+    await page.waitForSelector('#inline-text-editor', { state: 'detached' });
+    expect(await page.evaluate(() => window.ueState.currentTool)).toBe('select');
+    expect(await page.evaluate(() => window.ueState.annotations[0].length)).toBe(1);
+    expect(await page.evaluate(() => window.ueState.annotations[0][0].text)).toBe('test');
+    await expect(page.locator('#text-format-bar')).toBeHidden();
+  });
+
   test('restyles an already-selected text annotation (select tool)', async ({ page }) => {
     await loadSample(page);
     await createTextAndOpenBar(page, 'Dunia');

--- a/tests/text-format-bar.spec.js
+++ b/tests/text-format-bar.spec.js
@@ -1,0 +1,130 @@
+/*
+ * PDFLokal — contextual text format bar.
+ *
+ * Backlog (Jun 10): after PR #54 rerouted the Text tool to inline-on-first-click,
+ * the font-family / bold / italic controls (which lived in the now-orphaned
+ * text-input-modal) became unreachable. This suite verifies the replacement:
+ * a Word/Figma/Canva-style floating bar that applies formatting live and works
+ * both while typing and when a text annotation is later selected.
+ */
+import { test, expect } from '@playwright/test';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SAMPLE_PDF = path.join(__dirname, 'fixtures', 'sample-2pages.pdf');
+
+async function loadSample(page) {
+  await page.goto('/');
+  await page.setInputFiles('#file-input', SAMPLE_PDF);
+  await page.waitForFunction(() => document.body.classList.contains('editor-active'));
+  await page.waitForFunction(() => window.ueState?.pages?.length === 2);
+  await page.waitForFunction(() => window.ueState?.eventsSetup === true);
+}
+
+// Text tool → click canvas → inline editor + format bar open. Types text.
+async function createTextAndOpenBar(page, text, cx = 90, cy = 90) {
+  await page.evaluate(() => window.ueSetTool('text'));
+  await page.waitForFunction(() => window.ueState?.currentTool === 'text');
+  await page.evaluate(({ x, y }) => {
+    const canvas = document.querySelectorAll('.ue-page-slot canvas')[0];
+    const rect = canvas.getBoundingClientRect();
+    const opts = { bubbles: true, cancelable: true, clientX: rect.left + x, clientY: rect.top + y, button: 0 };
+    canvas.dispatchEvent(new MouseEvent('mousedown', opts));
+    canvas.dispatchEvent(new MouseEvent('mouseup', opts));
+  }, { x: cx, y: cy });
+  await page.waitForSelector('#inline-text-editor');
+  await page.waitForSelector('#text-format-bar:not([hidden])');
+  await page.locator('#inline-text-editor').focus();
+  await page.keyboard.type(text);
+}
+
+const anno0 = (page) => page.evaluate(() => window.ueState.annotations[0]?.[0]);
+
+test.describe('text format bar', () => {
+  test('appears while editing and applies font / bold / italic / size / color live', async ({ page }) => {
+    await loadSample(page);
+    await createTextAndOpenBar(page, 'Halo');
+
+    // Font family
+    await page.selectOption('#tfb-font', 'Courier');
+    expect(await page.evaluate(() => window.ueState.annotations[0][0].fontFamily)).toBe('Courier');
+
+    // Bold + italic toggles (buttons keep editor focus via mousedown preventDefault)
+    await page.click('#tfb-bold');
+    await page.click('#tfb-italic');
+    let a = await anno0(page);
+    expect(a.bold).toBe(true);
+    expect(a.italic).toBe(true);
+    await expect(page.locator('#tfb-bold')).toHaveClass(/active/);
+
+    // Size via number input
+    await page.fill('#tfb-size', '30');
+    await page.dispatchEvent('#tfb-size', 'change');
+    expect(await page.evaluate(() => window.ueState.annotations[0][0].fontSize)).toBe(30);
+
+    // Color via input event
+    await page.evaluate(() => {
+      const c = document.getElementById('tfb-color');
+      c.value = '#2563eb';
+      c.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect((await anno0(page)).color.toLowerCase()).toBe('#2563eb');
+
+    // Commit and confirm formatting survived + persisted for the next annotation
+    await page.locator('#inline-text-editor').focus();
+    await page.keyboard.press('Enter');
+    await page.waitForSelector('#inline-text-editor', { state: 'detached' });
+    a = await anno0(page);
+    expect(a).toMatchObject({ text: 'Halo', fontFamily: 'Courier', bold: true, italic: true, fontSize: 30 });
+    const last = await page.evaluate(() => window.ueState.lastTextOptions);
+    expect(last).toMatchObject({ fontFamily: 'Courier', bold: true, italic: true, fontSize: 30 });
+
+    // Bar hidden after commit
+    await expect(page.locator('#text-format-bar')).toBeHidden();
+  });
+
+  test('restyles an already-selected text annotation (select tool)', async ({ page }) => {
+    await loadSample(page);
+    await createTextAndOpenBar(page, 'Dunia');
+    await page.locator('#inline-text-editor').focus();
+    await page.keyboard.press('Enter');
+    await page.waitForSelector('#inline-text-editor', { state: 'detached' });
+
+    // WHY deselect first: a freshly-created annotation stays selected
+    // (canvas-events.js sets selectedAnnotation on inline create), so a click
+    // near its edge would hit a resize handle instead of re-selecting. Click
+    // empty space to clear selection, then click the annotation's interior.
+    await page.evaluate(() => window.ueSetTool('select'));
+    await page.evaluate(() => {
+      const canvas = document.querySelectorAll('.ue-page-slot canvas')[0];
+      const rect = canvas.getBoundingClientRect();
+      const opts = { bubbles: true, cancelable: true, clientX: rect.right - 12, clientY: rect.bottom - 12, button: 0 };
+      canvas.dispatchEvent(new MouseEvent('mousedown', opts));
+      canvas.dispatchEvent(new MouseEvent('mouseup', opts));
+    });
+    await expect(page.locator('#text-format-bar')).toBeHidden(); // deselected
+
+    // Now click the annotation interior (x past the left edge, y mid-height).
+    await page.evaluate(() => {
+      const a = window.ueState.annotations[0][0];
+      const canvas = document.querySelectorAll('.ue-page-slot canvas')[0];
+      const rect = canvas.getBoundingClientRect();
+      const scale = rect.width / (canvas.width / window.ueState.devicePixelRatio);
+      const sx = rect.left + (a.x + 8) * scale;
+      const sy = rect.top + (a.y - a.fontSize / 2) * scale;
+      const opts = { bubbles: true, cancelable: true, clientX: sx, clientY: sy, button: 0 };
+      canvas.dispatchEvent(new MouseEvent('mousedown', opts));
+      canvas.dispatchEvent(new MouseEvent('mouseup', opts));
+    });
+
+    expect(await page.evaluate(() => window.ueState.selectedAnnotation)).not.toBeNull();
+    await expect(page.locator('#text-format-bar')).toBeVisible();
+    await page.click('#tfb-bold');
+    expect((await anno0(page)).bold).toBe(true);
+
+    // Deselect (switch tool) hides the bar.
+    await page.evaluate(() => window.ueSetTool('whiteout'));
+    await expect(page.locator('#text-format-bar')).toBeHidden();
+  });
+});


### PR DESCRIPTION
## What
Adds a Word/Figma/Canva-style contextual **text format bar** (font, bold, italic, size, color) and fixes the **click-away-creates-a-second-text-box** bug.

### Why
PR #54 rerouted the Text tool to inline-on-first-click, which bypassed the (now orphaned) `text-input-modal` — leaving **no reachable UI** to set font/bold/italic. This restores it, inline.

### Highlights
- Floating bar appears while editing **and** when a text annotation is selected (restyle after the fact). Applies **live**, persists to `lastTextOptions`, one undo per change-burst.
- Root-cause fix: while an inline editor is open, a canvas pointerdown **commits-and-consumes** the click (via `commitActiveInlineTextEditor()`), so the Text tool can't place a duplicate box; you land back in Pilih.
- Data model / render / export already consumed `fontFamily/bold/italic` — this only adds the missing UI.
- Changelog: announces text formatting + Paraf.

### Tests
`tests/text-format-bar.spec.js` — live formatting + persistence, restyle-selected, and click-away-no-duplicate (verified it fails without the guard). Lint + 40 functional + 8 visual green (bar hidden by default → no baseline shift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)