### PR TITLE
fix(editor): Wave 0 PR A — whiteout sticky, arrow-nudge, Ctrl+Z in sig modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,34 @@
 
 > **Urus dokumen langsung di browser.** Cepat, gratis, file tidak pernah diupload.
 
-PDFLokal adalah tool PDF gratis untuk pengguna Indonesia. Semua proses berjalan di browser - file tidak pernah meninggalkan perangkat Anda.
+PDFLokal adalah tool PDF gratis untuk pengguna Indonesia. Semua proses berjalan di browser - file tidak pernah meninggalkan perangkatmu.
 
 **[Buka PDFLokal](https://www.pdflokal.id/)**
 
 ## Update Terbaru
 
+**Juli 2026:**
+- **Contextual text format bar** — pick font, bold/italic, size, and color while typing; select a text annotation and the format menu appears above it. Remembers your last-used style
+- **Mobile editor polish** — fixed toolbar overlap and Ganti File render bugs
+
+**Mei 2026:**
+- **Paraf (initials)** — dedicated draw-and-place tool with "Semua Hal." to stamp every page at once
+- **UX pass** — Escape closes overlays, inline text on first click, signature draw-by-default
+
+**Maret 2026:**
+- **Zero CDN dependencies** — every library self-hosted, works fully offline
+- **Reactive state layer** — pub/sub event emitter + `PageRenderer` render pipeline
+- **Quality tooling** — ESLint flat config + CI, SonarCloud analysis
+- **Mobile rendering fixes** — removed canvas eviction (persistent render, no white-flash flicker)
+
 **Februari 2026:**
 - **Editor UI redesign** — floating toolbar, compact sidebar, bottom bar, mobile-optimized layout
-- **Paraf (initials)** — draw and place initials with "Semua Hal." button to apply to all pages
 - **Lazy page rendering** — instant thumbnails on load, full rendering via IntersectionObserver
 - **Pinch-to-zoom** on mobile
 - **Inline text editing** — double-click text annotations to edit in-place
 - **SSOT architecture** — centralized helpers for annotations, modals, file types, PDF loading
 - **Accessibility** — ARIA roles, focus traps, keyboard navigation for all modals and tools
-- **Performance** — PDF.js Web Worker, image registry for undo optimization, page cache eviction
+- **Performance** — PDF.js Web Worker, image registry for undo optimization
 
 **Januari 2026:**
 - Security headers (CSP, X-Frame-Options)
@@ -77,11 +90,12 @@ npx serve .
 
 ### Tech Stack
 - **Vanilla JS** — Native ES modules, no build step, no framework
+- **Zero CDN** — every library below is self-hosted; the app runs fully offline
 - **[pdf-lib](https://pdf-lib.js.org/)** — PDF manipulation (self-hosted)
 - **[PDF.js](https://mozilla.github.io/pdf.js/)** — PDF rendering with Web Worker (self-hosted)
 - **[Signature Pad](https://github.com/szimek/signature_pad)** — Digital signatures (self-hosted)
 - **[fontkit](https://github.com/foliojs/fontkit)** — Embeds Montserrat + Carlito into exported PDFs (self-hosted)
-- **[pdf-encrypt-lite](https://github.com/nicholasohjj/pdf-encrypt-lite)** — PDF password encryption (CDN)
+- **[pdf-encrypt-lite](https://github.com/nicholasohjj/pdf-encrypt-lite)** — PDF password encryption (self-hosted)
 - **Canvas API** — Image processing
 - **Self-hosted fonts** — UI font Plus Jakarta Sans + annotation fonts Montserrat / Carlito (268KB)
 
@@ -98,7 +112,7 @@ pdflokal/
 │   │   ├── state.js        # State, constants, annotation factories
 │   │   ├── utils.js        # Helpers (toast, download, file type checks)
 │   │   └── navigation.js   # Routing, modal helpers, history
-│   ├── editor/             # Unified Editor (14 modules)
+│   ├── editor/             # Unified Editor (15 modules)
 │   │   ├── index.js        # Barrel exports + window bridges
 │   │   ├── canvas-events.js
 │   │   ├── file-loading.js

--- a/docs/roadmap-2.md
+++ b/docs/roadmap-2.md
@@ -20,9 +20,9 @@ risk rises gradually.
 ## Wave 0 — Quick wins & Sentry cleanup  ⬅ NOW
 _Low-risk, self-contained; drains ~10 items. Batchable across 1–2 sittings._
 
-- [ ] REVERT whiteout auto-switch-to-Pilih (#60) — delete one `ueSetTool('select')` + flip 2 tests · **[high]**
-- [ ] Arrow-key nudge for a selected text annotation (1px / Shift=10px), debounced undo · **[high]**
-- [ ] Ctrl+Z inside the signature/paraf modal rewinds the pen stroke, not a doc annotation · **[high]**
+- [x] REVERT whiteout auto-switch-to-Pilih (#60) — whiteout stays sticky; tests flipped · **[high]** _(PR A)_
+- [x] Arrow-key nudge for a selected annotation (1px / Shift=10px), one undo per burst · **[high]** _(PR A)_
+- [x] Ctrl+Z inside the signature/paraf modal rewinds the pen stroke, not a doc annotation · **[high]** _(PR A)_
 - [ ] Sentry true-fixes JS-4 / JS-7 / JS-8 — one atomic re-key pass (selection follows page/annotation mutations; audit off-SSOT page creation) · **[med×3]**
 - [ ] Paraf Konfirmasi/delete buttons z-index behind canvas on mobile · **[low]**
 - [ ] Sidebar page-number badge too large / covers thumbnail · **[med]**

--- a/js/editor/canvas-events.js
+++ b/js/editor/canvas-events.js
@@ -449,14 +449,12 @@ export function ueSetupCanvasEvents() {
         }));
         track('editor_action', { action: 'whiteout' });
         ueRedrawAnnotations();
-        // WHY auto-switch: After a tool's action completes, the user almost
-        // always wants to verify/move/zoom — not draw another whiteout
-        // immediately. Keeping whiteout sticky meant one stray tap on the
-        // canvas would spawn a new annotation. Text/signature/paraf already
-        // do this; whiteout was the holdout.
-        // WHY window.*: signatures.js does the same dance and we already
-        // accept the circular-import workaround there.
-        if (typeof window.ueSetTool === 'function') window.ueSetTool('select');
+        // WHY whiteout stays sticky (reverted PR #60's auto-switch): redacting a
+        // page is a MULTI-stamp workflow — covering several secrets means drawing
+        // box after box. Auto-switching to Pilih after every drag forced a re-click
+        // of Whiteout between each box, which is more friction than the original
+        // stray-tap complaint. Text (one-per-click → move it) and signature/paraf
+        // still auto-switch; whiteout is the deliberate outlier.
       }
     } else if (ueState.currentTool === 'text') {
       // WHY: Inline editing on first creation (UX audit finding H1). The modal-per-text

--- a/js/keyboard.js
+++ b/js/keyboard.js
@@ -67,6 +67,48 @@ function handleDeleteKey(e) {
   }
 }
 
+// WHY: Ctrl+Z while drawing in the signature/paraf modal must rewind the last
+// PEN STROKE — not fire the global editor undo (which rolls back a document
+// annotation the user can't even see behind the modal). SignaturePad has no
+// undo(), but supports the data-rewind pattern. Returns true if it handled the
+// key (so the caller consumes it).
+function rewindSignaturePadIfOpen(key) {
+  if (key !== 'z') return false; // only undo; the pad has no redo
+  const sigOpen = document.getElementById('signature-modal')?.classList.contains('active');
+  const parafOpen = document.getElementById('paraf-modal')?.classList.contains('active');
+  const pad = sigOpen ? state.signaturePad : (parafOpen ? state.parafPad : null);
+  if (!pad || typeof pad.toData !== 'function') return false;
+  const data = pad.toData();
+  if (data.length > 0) pad.fromData(data.slice(0, -1));
+  return true; // consume even when empty, so it never falls through to ueUndo
+}
+
+// Arrow-key nudge for a selected, non-locked annotation (Shift = 10px). Returns
+// true if it moved something. One undo snapshot per burst of taps (debounced),
+// so holding/spamming arrows is a single undo entry, not one-per-pixel.
+let nudgeUndoTimer = null;
+function nudgeSelectedAnnotation(dx, dy) {
+  const sel = ueState.selectedAnnotation;
+  if (!sel) return false;
+  const anno = ueState.annotations[sel.pageIndex]?.[sel.index];
+  if (!anno || anno.locked) return false;
+
+  if (!nudgeUndoTimer) window.ueSaveEditUndoState();
+  clearTimeout(nudgeUndoTimer);
+  nudgeUndoTimer = setTimeout(() => { nudgeUndoTimer = null; }, 500);
+
+  anno.x += dx;
+  anno.y += dy;
+  window.ueRedrawAnnotations();
+  window.ueUpdateConfirmButtonPosition?.(anno);
+  window.repositionTextFormatBar?.();
+  return true;
+}
+
+const NUDGE_VECTORS = {
+  ArrowLeft: [-1, 0], ArrowRight: [1, 0], ArrowUp: [0, -1], ArrowDown: [0, 1],
+};
+
 // WHY: Navigation handlers extracted from keydown listener to reduce complexity (S3776).
 // Map pattern: key → { handler, preventDefault }. Same pattern as modifier/tool handlers.
 const navigationHandlers = {
@@ -110,6 +152,12 @@ export function setupKeyboardShortcuts() {
 
     // Modifier combos (Ctrl/Cmd + key)
     if ((e.ctrlKey || e.metaKey) && inEditor && modifierHandlers[key]) {
+      if (key === 'z' || key === 'y') {
+        // Drawing modal open → rewind the pen stroke, not the document.
+        if (rewindSignaturePadIfOpen(key)) { e.preventDefault(); return; }
+        // Typing in a field / inline text editor → let native undo/redo run.
+        if (isTyping) return;
+      }
       e.preventDefault();
       modifierHandlers[key].handler();
       return;
@@ -127,6 +175,14 @@ export function setupKeyboardShortcuts() {
         handleDeleteKey(e);
         return;
       }
+    }
+
+    // Arrow keys nudge a selected annotation (Shift = 10px) instead of paging.
+    // Only when something's selected; otherwise arrows fall through to page nav.
+    if (NUDGE_VECTORS[e.key] && ueState.selectedAnnotation) {
+      const mult = e.shiftKey ? 10 : 1;
+      const [ux, uy] = NUDGE_VECTORS[e.key];
+      if (nudgeSelectedAnnotation(ux * mult, uy * mult)) { e.preventDefault(); return; }
     }
 
     const nav = navigationHandlers[e.key];

--- a/tests/keyboard-nudge.spec.js
+++ b/tests/keyboard-nudge.spec.js
@@ -1,0 +1,111 @@
+/*
+ * PDFLokal — Wave 0 keyboard behaviors:
+ *  - Arrow keys nudge a selected annotation (Shift = 10px); page-nav preserved
+ *    when nothing is selected.
+ *  - Ctrl+Z inside the signature/paraf modal rewinds the pen stroke instead of
+ *    firing the global editor undo.
+ */
+import { test, expect } from '@playwright/test';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SAMPLE_PDF = path.join(__dirname, 'fixtures', 'sample-2pages.pdf');
+
+async function loadSample(page) {
+  await page.goto('/');
+  await page.setInputFiles('#file-input', SAMPLE_PDF);
+  await page.waitForFunction(() => window.ueState?.pages?.length === 2);
+  await page.waitForFunction(() => window.ueState?.eventsSetup === true);
+}
+
+// Seed a selected whiteout annotation on page 0 at a known position.
+async function seedSelectedAnno(page, x = 100, y = 100) {
+  await page.evaluate(({ ax, ay }) => {
+    const i = window.ueAddAnnotation(0, { type: 'whiteout', x: ax, y: ay, width: 50, height: 30 });
+    window.ueState.selectedAnnotation = { pageIndex: 0, index: i };
+  }, { ax: x, ay: y });
+}
+
+const pos = (page) => page.evaluate(() => {
+  const a = window.ueState.annotations[0][0];
+  return { x: a.x, y: a.y };
+});
+
+test.describe('arrow-key nudge', () => {
+  test('arrows move a selected annotation; Shift = 10px', async ({ page }) => {
+    await loadSample(page);
+    await seedSelectedAnno(page, 100, 100);
+
+    await page.keyboard.press('ArrowRight');
+    expect(await pos(page)).toEqual({ x: 101, y: 100 });
+
+    await page.keyboard.press('ArrowDown');
+    expect(await pos(page)).toEqual({ x: 101, y: 101 });
+
+    await page.keyboard.press('Shift+ArrowLeft');
+    expect(await pos(page)).toEqual({ x: 91, y: 101 });
+
+    await page.keyboard.press('Shift+ArrowUp');
+    expect(await pos(page)).toEqual({ x: 91, y: 91 });
+  });
+
+  test('a burst of nudges collapses into ONE undo entry', async ({ page }) => {
+    await loadSample(page);
+    await seedSelectedAnno(page, 100, 100);
+    const undoBefore = await page.evaluate(() => window.ueState.undoStack?.length ?? 0);
+
+    for (let i = 0; i < 5; i++) await page.keyboard.press('ArrowRight');
+    expect((await pos(page)).x).toBe(105);
+
+    const undoAfter = await page.evaluate(() => window.ueState.undoStack?.length ?? 0);
+    expect(undoAfter - undoBefore).toBe(1); // one snapshot for the whole burst
+  });
+
+  test('arrows still page-navigate when nothing is selected', async ({ page }) => {
+    await loadSample(page);
+    await page.evaluate(() => { window.ueState.selectedAnnotation = null; window.ueSelectPage(0); });
+    await page.keyboard.press('ArrowRight');
+    await page.waitForFunction(() => window.ueState.selectedPage === 1);
+    expect(await page.evaluate(() => window.ueState.selectedPage)).toBe(1);
+  });
+});
+
+test.describe('Ctrl+Z inside the signature modal', () => {
+  test('rewinds the pen stroke and does NOT fire the global undo', async ({ page }) => {
+    await loadSample(page);
+    // Something on the document that the global undo COULD roll back.
+    await seedSelectedAnno(page, 200, 200);
+    await page.evaluate(() => { window.ueState.selectedAnnotation = null; });
+
+    // Spy on the global undo.
+    await page.evaluate(() => {
+      window.__undoCalls = 0;
+      const orig = window.ueUndo;
+      window.ueUndo = () => { window.__undoCalls++; return orig && orig(); };
+    });
+
+    await page.evaluate(() => window.ueOpenSignatureModal());
+    await page.waitForSelector('#signature-modal.active');
+
+    // Draw two strokes on the signature pad.
+    await page.evaluate(() => {
+      const c = document.getElementById('signature-canvas');
+      const r = c.getBoundingClientRect();
+      const stroke = (x1, y1, x2, y2) => {
+        c.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, clientX: r.left + x1, clientY: r.top + y1, pointerId: 1 }));
+        c.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, clientX: r.left + x2, clientY: r.top + y2, pointerId: 1 }));
+        c.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, clientX: r.left + x2, clientY: r.top + y2, pointerId: 1 }));
+      };
+      stroke(10, 10, 40, 40);
+      stroke(50, 50, 80, 80);
+    });
+    expect(await page.evaluate(() => window.state.signaturePad.toData().length)).toBe(2);
+
+    await page.keyboard.press('Control+z');
+
+    expect(await page.evaluate(() => window.state.signaturePad.toData().length)).toBe(1); // one stroke rewound
+    expect(await page.evaluate(() => window.__undoCalls)).toBe(0); // global undo NOT fired
+    expect(await page.evaluate(() => window.ueState.annotations[0].length)).toBe(1); // doc annotation untouched
+  });
+});

--- a/tests/smoke.spec.js
+++ b/tests/smoke.spec.js
@@ -601,7 +601,9 @@ test.describe('auto-switch to select after tool completion', () => {
     }, { p: pageIndex, ax1: x1, ay1: y1, ax2: x2, ay2: y2 });
   }
 
-  test('whiteout: tool switches to select after a valid drag', async ({ page }) => {
+  test('whiteout: STAYS sticky after a valid drag (multi-stamp redaction)', async ({ page }) => {
+    // WHY sticky: reverted PR #60. Redacting a page means drawing box after box;
+    // auto-switching to Pilih between each is more friction than it's worth.
     await page.goto('/');
     await loadSamplePdf(page);
 
@@ -611,21 +613,20 @@ test.describe('auto-switch to select after tool completion', () => {
     const annoCount = await page.evaluate(() => window.ueState.annotations[0]?.length || 0);
     const tool = await page.evaluate(() => window.ueState.currentTool);
     expect(annoCount).toBe(1);
-    expect(tool).toBe('select');
+    expect(tool).toBe('whiteout');
   });
 
-  test('whiteout: tiny no-op drag does NOT switch tool', async ({ page }) => {
-    // Invariant: switching only when the action actually completed. Width<=5
-    // means the user clicked but didn't really draw — keep them in whiteout.
+  test('whiteout: a second drag stamps another box without re-selecting the tool', async ({ page }) => {
     await page.goto('/');
     await loadSamplePdf(page);
 
     await page.evaluate(() => window.ueSetTool('whiteout'));
-    await drawWhiteoutRect(page, 0, 50, 50, 52, 52);
+    await drawWhiteoutRect(page, 0, 50, 50, 150, 100);
+    await drawWhiteoutRect(page, 0, 60, 160, 160, 210); // no re-click of Whiteout
 
     const annoCount = await page.evaluate(() => window.ueState.annotations[0]?.length || 0);
     const tool = await page.evaluate(() => window.ueState.currentTool);
-    expect(annoCount).toBe(0);
+    expect(annoCount).toBe(2);
     expect(tool).toBe('whiteout');
   });
 


### PR DESCRIPTION
Wave 0 (behavior batch). Three self-contained fixes:

1. **Whiteout stays sticky** — reverts PR #60's auto-switch. Redaction is multi-stamp; auto-switching to Pilih between boxes was more friction than the stray-tap it fixed. Text + signature/paraf still auto-switch. Tests flipped.
2. **Arrow-key nudge** — arrows move a selected non-locked annotation (1px / Shift=10px); one undo per burst; falls through to page-nav when nothing's selected.
3. **Ctrl+Z in signature/paraf modal** rewinds the pen stroke (not the invisible global undo); text fields defer to native undo.

Tests: `tests/keyboard-nudge.spec.js` (4) + updated whiteout tests. Lint + 50 functional + 8 visual green.

(Also carries a small README tone edit — "Anda" → "kamu" — made in the IDE.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)