### PR TITLE
fix(editor): Wave 0 PR B — Sentry true-fixes (JS-4/7/8)

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -85,14 +85,6 @@ Running list of UI/UX findings + small fixes to pick up later. Append new items 
   - Diagnosis: z-index ordering. The `signature-btn-wrapper` sits in `#ue-canvas-wrapper` which has its own stacking context on mobile. The current `--z-canvas-ui: 20` isn't winning against something else in the mobile layout.
   - Fix: bump `--z-canvas-ui` OR explicitly set `z-index: var(--z-canvas-ui)` on `.signature-btn-wrapper` + verify the stacking context. User noted this isn't critical to the app's function but it IS visibly broken.
 
-- **[med]** Root cause for Sentry JAVASCRIPT-7 — `ueState.annotations[selectedPage]` was undefined when "Hapus Edit Halaman Ini" fired — [undo-redo.js:182](js/editor/undo-redo.js#L182) (defensive guard shipped in PR #67)
-  - Crash repro hypothesis: user selected a page, then deleted/reordered pages (Gabungkan modal or page-manager). `selectedPage` index was carried over but the per-page annotations bucket wasn't reseated to match. Same fingerprint as the existing stale-selectedAnnotation backlog item — both symptoms of "index map didn't follow page mutation."
-  - True fix: ensure every page-array mutation (splice, reorder, delete) re-keys `ueState.annotations` and `ueState.selectedAnnotation` atomically. Probably wrap in a single helper `mutatePages(fn)` that handles the rebind. Same helper would close the stale selection item below.
-
-- **[med]** Root cause for Sentry JAVASCRIPT-8 — a page in `ueState.pages` had no `.canvas` placeholder after drag-reorder, crashed `ueRenderThumbnails` — [sidebar.js:93](js/editor/sidebar.js#L93) (defensive guard shipped in PR #67)
-  - Crash repro hypothesis: some code path creates a page object via direct push or restore that bypasses `createPageInfo()` (the SSOT factory that seats the `canvas: {width, height}` placeholder). Suspects: undo restore (undo-redo.js `ueRestorePages`), Gabungkan modal split/extract (`uePmConfirmExtract`), or any path that builds a page after a PDF re-load.
-  - Investigation: `grep -rn "ueState.pages.push\|ueState.pages\\[" js/editor/` and check each push site — every one MUST go through `createPageInfo(...)`. Add a dev-mode invariant: in renderPageCanvas/ueRenderThumbnails, when `!page.canvas` log a Sentry breadcrumb so we can identify the offending path next time.
-
 - **[high]** "Ganti File" doesn't open the file picker on Android Chrome (mobile) — [index.html:470](index.html#L470) and [sidebar.js:22-47](js/editor/sidebar.js#L22-L47) and [index.html:503-504](index.html#L503-L504)
   - User reports: on mobile, after a file is loaded, tapping "Ganti File" does nothing. The fix that just shipped (#64) made the REPLACEMENT work — this is a separate issue, the file picker itself never opens.
   - Likely cause: combination of `style="display:none"` on `#ue-replace-input` (line 503-504) PLUS the inline `onclick="ueReplaceFiles(); closeEditorFileMenu()"` on line 470 — `closeEditorFileMenu()` runs synchronously right after `input.click()`, mutating the DOM (removing the `.open` class on the dropdown) inside the same user-gesture tick. Mobile Chrome's hardened picker policy treats `.click()` on `display:none` inputs as suspicious, especially when the surrounding DOM mutates immediately. The home dropzone's `#ue-file-input` works because its trigger button doesn't have a follow-up DOM mutation.
@@ -122,10 +114,6 @@ Running list of UI/UX findings + small fixes to pick up later. Append new items 
   - User draws a signature in the signature/paraf modal; Ctrl+Z fires the global editor undo (`ueUndo()`) and rolls back an annotation on the PDF underneath instead of erasing the last pen stroke. Worse: nothing in the signature canvas changes, so user thinks the shortcut is broken and keeps pressing it — eating multiple undos.
   - Fix: in `keyboard.js`'s modifier-combo branch, check whether `signature-modal` or `paraf-modal` has `.active`; if so, route to `state.signaturePad.fromData(state.signaturePad.toData().slice(0, -1))` (SignaturePad has no native `undo()` but supports the data-rewind pattern). Same for `state.parafPad`. Bonus: extend to `inline-text-editor` open state — Ctrl+Z there should let contentEditable's native undo run.
 
-- **[med]** `ueRemoveAnnotation` and `rebuildAnnotationMapping` leave `selectedAnnotation` stale — [annotations.js:134](js/editor/annotations.js#L134), [page-manager.js:323](js/editor/page-manager.js#L323)
-  - Root cause behind Sentry JAVASCRIPT-4. `ueRemoveAnnotation` only clears selection on EXACT `(pageIndex, index)` match — so deleting annotation 0 with selection at index 1 leaves selection pointing to a now-shifted slot. `rebuildAnnotationMapping` (page reorder/delete) never touches selection at all.
-  - Defensive guards in canvas-events.js + canvas-utils.js stop the crash (shipped). True fix: (a) `ueRemoveAnnotation` should decrement `selectedAnnotation.index` when removing an earlier sibling, and null when removing past-end; (b) `rebuildAnnotationMapping` should reindex selection through `oldPages.indexOf(pageRef)` like it does for annotations.
-
 - **[med]** Sidebar page-number badge too large and too centered, covers thumbnail content — [style.css:2536-2547](style.css#L2536-L2547) (`.ue-thumbnail-number`)
   - Big dark rounded badges (1, 2, 3…) sit mid-thumbnail on a multi-page document. Current CSS: `bottom: var(--space-sm)` + `padding: 4px 10px` + `font-size: 0.75rem`. On short landscape thumbnails the badge dominates the visible area.
   - Fix candidates: shrink badge (font 0.65rem / padding 2px 6px), move to a corner (top-right), or fade out unless thumbnail is hovered/selected.
@@ -133,6 +121,12 @@ Running list of UI/UX findings + small fixes to pick up later. Append new items 
 ---
 
 ## Done
+
+- **[med×3]** Sentry true-fixes JS-4 / JS-7 / JS-8 (Jul 1) — [annotations.js ueRemoveAnnotation](js/editor/annotations.js#L134), [remove-annotation-selection.spec.js](tests/remove-annotation-selection.spec.js)
+  - **JS-4 (true-fixed):** `ueRemoveAnnotation` now reseats `selectedAnnotation` — removing an earlier sibling on the same page shifts the selection index down by one (was left pointing one slot off → the crash in `ueGetResizeHandle`); removing the selected one nulls it; removing a later one leaves it untouched. 3 tests.
+  - **JS-7 (verified closed, no code change):** the `?.length` guard plus every page mutation now routing through `mutatePages` (which re-keys the annotations map) removes the out-of-sync-bucket root.
+  - **JS-8 (verified closed, no code change):** audited all `ueState.pages.push` sites — every one goes through `createPageInfo` (file-loading ×2, undo-redo). No off-SSOT page creation remains.
+  - Also confirmed `rebuildAnnotationMapping` is now dead code (nothing calls it; `mutatePages` replaced it) — logged for Wave 0 cleanup (PR C).
 
 - **[high]** Kelola Halaman (page-manager) modal redesign (Jul 1) — [page-manager.js](js/editor/page-manager.js), [kelola-halaman.spec.js](tests/kelola-halaman.spec.js)
   - Grounded in the **ux-heuristics** + **ui-craft** skills. Audit scored the old modal 4/10 (naming mismatch; hover-only rotate/delete = catastrophic on touch; zero reorder affordance; hidden "Split" mode; add/arrange/extract crammed together).

--- a/docs/roadmap-2.md
+++ b/docs/roadmap-2.md
@@ -23,7 +23,7 @@ _Low-risk, self-contained; drains ~10 items. Batchable across 1–2 sittings._
 - [x] REVERT whiteout auto-switch-to-Pilih (#60) — whiteout stays sticky; tests flipped · **[high]** _(PR A)_
 - [x] Arrow-key nudge for a selected annotation (1px / Shift=10px), one undo per burst · **[high]** _(PR A)_
 - [x] Ctrl+Z inside the signature/paraf modal rewinds the pen stroke, not a doc annotation · **[high]** _(PR A)_
-- [ ] Sentry true-fixes JS-4 / JS-7 / JS-8 — one atomic re-key pass (selection follows page/annotation mutations; audit off-SSOT page creation) · **[med×3]**
+- [x] Sentry true-fixes JS-4 / JS-7 / JS-8 — JS-4 reseats selection in `ueRemoveAnnotation`; JS-7/8 verified already closed by `mutatePages` + `createPageInfo` SSOT · **[med×3]** _(PR B)_ · _also surfaced: `rebuildAnnotationMapping` is now dead code → remove in PR C_
 - [ ] Paraf Konfirmasi/delete buttons z-index behind canvas on mobile · **[low]**
 - [ ] Sidebar page-number badge too large / covers thumbnail · **[med]**
 - [ ] Red-outline around active page — decide keep/soften/remove (desktop-only already) · **[low]**

--- a/js/editor/annotations.js
+++ b/js/editor/annotations.js
@@ -134,13 +134,24 @@ export function ueAddAnnotation(pageIndex, anno) {
 export function ueRemoveAnnotation(pageIndex, annoIndex) {
   if (!ueState.annotations[pageIndex]) return;
   ueState.annotations[pageIndex].splice(annoIndex, 1);
-  if (ueState.selectedAnnotation &&
-      ueState.selectedAnnotation.pageIndex === pageIndex &&
-      ueState.selectedAnnotation.index === annoIndex) {
-    ueState.selectedAnnotation = null;
-    // The removed annotation may have been the format bar's target — hide it.
-    // window.* avoids an annotations ↔ text-format-bar import cycle.
-    window.hideTextFormatBar?.();
+
+  // WHY reindex, not just exact-match clear (true fix for Sentry JAVASCRIPT-4):
+  // the splice shifts every sibling after annoIndex down by one. If the SELECTED
+  // annotation sat after the removed one, its stored .index now points at the
+  // wrong slot (or past the end → the crash in ueGetResizeHandle). Reseat it:
+  const sel = ueState.selectedAnnotation;
+  if (sel && sel.pageIndex === pageIndex) {
+    if (sel.index === annoIndex) {
+      // The selected annotation itself was removed.
+      ueState.selectedAnnotation = null;
+      // It may have been the format bar's target — hide it. window.* avoids an
+      // annotations ↔ text-format-bar import cycle.
+      window.hideTextFormatBar?.();
+    } else if (sel.index > annoIndex) {
+      // An earlier sibling was removed — selection shifted down by one.
+      ueState.selectedAnnotation = { pageIndex, index: sel.index - 1 };
+    }
+    // sel.index < annoIndex → unaffected.
   }
 }
 

--- a/tests/remove-annotation-selection.spec.js
+++ b/tests/remove-annotation-selection.spec.js
@@ -1,0 +1,55 @@
+/*
+ * PDFLokal — ueRemoveAnnotation keeps selectedAnnotation correct (Sentry JS-4).
+ * Removing an EARLIER sibling on the same page used to leave selection pointing
+ * one slot off (→ crash in ueGetResizeHandle on the next tap).
+ */
+import { test, expect } from '@playwright/test';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SAMPLE_PDF = path.join(__dirname, 'fixtures', 'sample-2pages.pdf');
+
+async function loadWithThreeAnnos(page) {
+  await page.goto('/');
+  await page.setInputFiles('#file-input', SAMPLE_PDF);
+  await page.waitForFunction(() => window.ueState?.pages?.length === 2);
+  await page.evaluate(() => {
+    for (const x of [100, 200, 300]) {
+      window.ueAddAnnotation(0, { type: 'whiteout', x, y: 1, width: 10, height: 10 });
+    }
+  });
+}
+
+const sel = (page) => page.evaluate(() => window.ueState.selectedAnnotation);
+const selX = (page) => page.evaluate(() => {
+  const s = window.ueState.selectedAnnotation;
+  return s ? window.ueState.annotations[s.pageIndex][s.index].x : null;
+});
+
+test.describe('ueRemoveAnnotation selection integrity', () => {
+  test('removing an earlier sibling shifts selection down by one (same anno)', async ({ page }) => {
+    await loadWithThreeAnnos(page);
+    await page.evaluate(() => { window.ueState.selectedAnnotation = { pageIndex: 0, index: 2 }; });
+
+    await page.evaluate(() => window.ueRemoveAnnotation(0, 0)); // remove index 0
+
+    expect(await sel(page)).toEqual({ pageIndex: 0, index: 1 });
+    expect(await selX(page)).toBe(300); // still the SAME annotation
+  });
+
+  test('removing the selected annotation clears selection', async ({ page }) => {
+    await loadWithThreeAnnos(page);
+    await page.evaluate(() => { window.ueState.selectedAnnotation = { pageIndex: 0, index: 1 }; });
+    await page.evaluate(() => window.ueRemoveAnnotation(0, 1));
+    expect(await sel(page)).toBeNull();
+  });
+
+  test('removing a later sibling leaves selection untouched', async ({ page }) => {
+    await loadWithThreeAnnos(page);
+    await page.evaluate(() => { window.ueState.selectedAnnotation = { pageIndex: 0, index: 0 }; });
+    await page.evaluate(() => window.ueRemoveAnnotation(0, 2));
+    expect(await sel(page)).toEqual({ pageIndex: 0, index: 0 });
+    expect(await selX(page)).toBe(100);
+  });
+});


### PR DESCRIPTION
Wave 0 (Sentry batch).

- **JS-4 true fix** — `ueRemoveAnnotation` reseats `selectedAnnotation` after the splice (earlier-sibling removal shifts the index down by one; selected-removal nulls it; later-sibling untouched). Closes the stale-index → `ueGetResizeHandle` crash at the source, not just the defensive guard.
- **JS-7 / JS-8 verified already closed** (no code change) — `mutatePages` re-keys the annotations map on every page mutation, and all `ueState.pages.push` go through `createPageInfo`.
- Surfaced dead code: `rebuildAnnotationMapping` (replaced by `mutatePages`) → PR C cleanup.

Tests: `tests/remove-annotation-selection.spec.js` (3). Lint + 47 functional green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)