### PR TITLE
fix(editor): restore broken "Split PDF" homepage card

### DIFF
--- a/js/init-ui.js
+++ b/js/init-ui.js
@@ -3,7 +3,7 @@
  * Tool cards, range sliders, signature/paraf pads, modal backdrop close
  */
 
-import { state, mobileState, uePmState } from './lib/state.js';
+import { state, mobileState } from './lib/state.js';
 import {
   showToast, showFullscreenLoading, hideFullscreenLoading,
   setupCanvasDPR
@@ -97,8 +97,13 @@ function handleEditorCardWithFilePicker(mode) {
             editor.uePmOpenModal();
 
             setTimeout(() => {
-              if (mode === 'split' && !uePmState.extractMode) {
-                editor.uePmToggleExtractMode();
+              // WHY select-all for split: the redesigned Kelola Halaman modal has
+              // no separate "Split mode" — extraction is done by selecting pages
+              // then hitting "Split jadi PDF". Selecting all surfaces that action
+              // bar so the user sees the affordance and deselects what they don't
+              // want. (Previously this called the removed uePmToggleExtractMode.)
+              if (mode === 'split') {
+                editor.uePmSelectAll();
               }
               hideFullscreenLoading();
             }, 100);

--- a/js/lib/state.js
+++ b/js/lib/state.js
@@ -335,9 +335,11 @@ export function createPageNumberAnnotation({ text, fontSize, color = '#000000', 
 // ============================================================
 
 export const uePmState = {
-  isOpen: false,            // Whether the Gabungkan modal is currently visible
-  extractMode: false,       // true = "Split" mode (multi-select pages for extraction)
-  selectedForExtract: [],   // Array of page indices selected for split/extraction
+  isOpen: false,            // Whether the Kelola Halaman modal is currently visible
+  // WHY no extractMode: the redesigned modal has no separate "Split mode".
+  // Selection is always available; selectedForExtract holds page OBJECT refs
+  // (not indices) so it survives reorder/delete without index remapping.
+  selectedForExtract: [],   // Array of page object references selected for bulk actions
   draggedIndex: -1,         // Index of the page currently being dragged (-1 = none)
   dropIndicator: null       // DOM element showing where dragged page will land
 };

--- a/tests/split-card.spec.js
+++ b/tests/split-card.spec.js
@@ -1,0 +1,47 @@
+/*
+ * PDFLokal — "Split PDF" homepage card flow.
+ *
+ * REGRESSION: the Kelola Halaman redesign (#73) removed uePmToggleExtractMode(),
+ * but init-ui.js's split-card handler still called editor.uePmToggleExtractMode()
+ * — a TypeError that broke the "Split PDF" card entirely. The redesigned modal has
+ * no "Split mode"; the card now opens the modal and selects all pages so the
+ * "Split jadi PDF" action bar is immediately visible (user deselects what they
+ * don't want). This test drives the genuine card → filechooser → modal flow.
+ */
+import { test, expect } from '@playwright/test';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SAMPLE_PDF = path.join(__dirname, 'fixtures', 'sample-2pages.pdf');
+
+test.describe('Split PDF card', () => {
+  test('opens Kelola Halaman with all pages selected + Split action visible', async ({ page }) => {
+    const errors = [];
+    page.on('pageerror', (e) => errors.push(e.message));
+
+    await page.goto('/');
+
+    // Clicking the card lazily creates #split-pdf-input and calls input.click(),
+    // which Playwright surfaces as a 'filechooser' event.
+    const fileChooserPromise = page.waitForEvent('filechooser');
+    await page.click('.tool-card[data-tool="split-pdf"]');
+    const fileChooser = await fileChooserPromise;
+    await fileChooser.setFiles(SAMPLE_PDF);
+
+    // Editor opens, PDF loads, modal appears.
+    await page.waitForFunction(() => window.ueState?.pages?.length === 2, null, { timeout: 10_000 });
+    await page.waitForFunction(() =>
+      document.getElementById('ue-gabungkan-modal')?.classList.contains('active'));
+
+    // select-all fired (100ms setTimeout) → bulk-action bar shows the Split button.
+    await expect(page.locator('#ue-pm-selection-count')).toHaveText('2 dipilih');
+    await expect(page.locator('#ue-pm-selection-actions')).toBeVisible();
+    await expect(
+      page.locator('#ue-pm-selection-actions button:has-text("Split jadi PDF")')
+    ).toBeVisible();
+
+    // No uncaught TypeError from the removed uePmToggleExtractMode().
+    expect(errors, `unexpected page errors: ${errors.join(' | ')}`).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

The Kelola Halaman redesign (#73) removed `uePmToggleExtractMode()`, but `init-ui.js`'s split-card handler still called `editor.uePmToggleExtractMode()`. Clicking the **Split PDF** homepage card → pick a file → **TypeError** (`editor.uePmToggleExtractMode is not a function`). The card has been dead since #73 merged.

## Fix

The redesigned modal has no separate "Split mode" — extraction is selection-based. The Split card now opens the modal and calls `uePmSelectAll()`, surfacing the **"Split jadi PDF"** bulk-action bar so the user sees the affordance and deselects what they don't want.

- `init-ui.js` — select-all for split mode; drop now-unused `uePmState` import
- `state.js` — remove dead `extractMode` field (its last reference was the broken call)
- `tests/split-card.spec.js` — regression test driving the genuine **card → filechooser → modal** flow; asserts no `pageerror` and that select-all + the Split button appear

## Verification

- Lint clean
- New split-card test green (confirmed it fails on the old TypeError path)
- Full `kelola-halaman` + `smoke` suites (40 tests) green
- No visual baselines touched (no screenshots in this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)