### PR TITLE
feat(signature): paste an image from the clipboard into the signature flow

### DIFF
--- a/js/init-file-handling.js
+++ b/js/init-file-handling.js
@@ -325,6 +325,15 @@ async function handlePaste(e) {
     if (isImage(item)) {
       const file = item.getAsFile();
       if (file) {
+        // WHY signature modal first: pasting a copied screenshot straight into the
+        // "Upload Foto" flow saves the download→save→upload round-trip. loadSignatureImage
+        // advances to the bg-removal modal itself, so no tab switch is needed. Paraf is
+        // draw-only (no upload tab), so it's intentionally excluded.
+        if (document.getElementById('signature-modal')?.classList.contains('active')) {
+          const { loadSignatureImage } = await import('./pdf-tools/index.js');
+          await loadSignatureImage(file);
+          return; // handled — don't also route the paste to an image tool
+        }
         if (state.currentTool === 'img-to-pdf') {
           import('./image-tools.js').then(m => m.addImagesToPDF([file]));
         } else if (state.currentTool === 'compress-img' || state.currentTool === 'resize' || state.currentTool === 'convert-img' || state.currentTool === 'remove-bg') {

--- a/tests/signature-paste.spec.js
+++ b/tests/signature-paste.spec.js
@@ -1,0 +1,65 @@
+/*
+ * PDFLokal — paste an image into the signature "Upload Foto" flow.
+ *
+ * Wave 1: users had to download → save → re-upload a signature image (three
+ * round-trips) for something already on their clipboard. Now, while the signature
+ * modal is open, Ctrl/Cmd+V routes the pasted image straight to loadSignatureImage,
+ * which advances to the background-removal modal. Paraf (draw-only) is excluded.
+ */
+import { test, expect } from '@playwright/test';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SAMPLE_PDF = path.join(__dirname, 'fixtures', 'sample-2pages.pdf');
+
+async function loadEditor(page) {
+  await page.goto('/');
+  await page.setInputFiles('#file-input', SAMPLE_PDF);
+  await page.waitForFunction(() => document.body.classList.contains('editor-active'));
+  await page.waitForFunction(() => window.ueState?.pages?.length === 2);
+}
+
+// Dispatch a synthetic paste carrying a small PNG, as if the user hit Ctrl/Cmd+V.
+async function pasteImage(page) {
+  await page.evaluate(async () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 40; canvas.height = 20;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = '#000'; ctx.fillRect(0, 0, 40, 20);
+    const blob = await new Promise((r) => canvas.toBlob(r, 'image/png'));
+    const file = new File([blob], 'pasted.png', { type: 'image/png' });
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    document.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true }));
+  });
+}
+
+test.describe('Signature clipboard paste', () => {
+  test('paste while signature modal open → advances to bg-removal modal', async ({ page }) => {
+    await loadEditor(page);
+
+    await page.evaluate(() => window.openSignatureModal());
+    await page.waitForFunction(() =>
+      document.getElementById('signature-modal')?.classList.contains('active'));
+
+    await pasteImage(page);
+
+    // loadSignatureImage closes the signature modal and opens signature-bg-modal.
+    await page.waitForFunction(() =>
+      document.getElementById('signature-bg-modal')?.classList.contains('active'),
+      null, { timeout: 5000 });
+    await expect(page.locator('#signature-modal')).not.toHaveClass(/active/);
+    // The uploaded image is now staged for background removal.
+    expect(await page.evaluate(() => !!window.state?.signatureUploadImage)).toBe(true);
+  });
+
+  test('paste with NO signature modal open does not open the bg-removal modal', async ({ page }) => {
+    await loadEditor(page);
+    // No modal open — a stray paste in the editor must not hijack into the sig flow.
+    await pasteImage(page);
+    await page.waitForTimeout(300);
+    expect(await page.evaluate(() =>
+      document.getElementById('signature-bg-modal')?.classList.contains('active'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Wave 1 — clipboard convenience

Adding a signature image used to mean download → save to disk → re-upload. Now, **while the signature modal is open**, `Ctrl/Cmd+V` routes a pasted image straight to `loadSignatureImage`, which advances to the background-removal modal.

- Paraf is draw-only (no upload tab) → intentionally excluded.
- A stray paste with **no** signature modal open still falls through to the existing image-tool routing, unchanged.
- The pasted `File` is captured **before** the `await` (dynamic import), so the clipboard item can't go stale.

## Tests — `tests/signature-paste.spec.js`
- positive: paste while sig modal open → bg-removal modal opens, `signatureUploadImage` staged.
- negative: paste with no sig modal → bg-removal modal stays closed.

Smoke (34) green · `npm run lint` clean. Changelog batched with the drag-to-append PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)