### PR TITLE
feat(editor): drop a file onto the sidebar to append pages

### DIFF
--- a/js/editor/sidebar.js
+++ b/js/editor/sidebar.js
@@ -197,10 +197,25 @@ function ueSetupSidebarDragDrop() {
     removeSidebarDropIndicator();
   });
 
+  // Clear the file-drop hint when the OS drag actually leaves the container
+  // (dragleave also fires moving between children — guard on relatedTarget).
+  container.addEventListener('dragleave', (e) => {
+    if (!container.contains(e.relatedTarget)) {
+      container.classList.remove('drag-over-files');
+    }
+  });
+
   container.addEventListener('dragover', (e) => {
     e.preventDefault();
+    if (!draggedItem) {
+      // OS file drag (no internal reorder in progress) — signal "drop to add".
+      if (e.dataTransfer.types.includes('Files')) {
+        e.dataTransfer.dropEffect = 'copy';
+        container.classList.add('drag-over-files');
+      }
+      return;
+    }
     e.dataTransfer.dropEffect = 'move';
-    if (!draggedItem) return;
 
     const item = e.target.closest('.ue-thumbnail');
     if (!item || item === draggedItem) {
@@ -232,8 +247,32 @@ function ueSetupSidebarDragDrop() {
     }
   });
 
-  container.addEventListener('drop', (e) => {
+  container.addEventListener('drop', async (e) => {
     e.preventDefault();
+
+    // FILE DROP (from OS) — APPEND pages to the current document. Distinguished
+    // from internal reorder by the presence of files (reorder carries only
+    // text/plain, no files). WHY stopPropagation: #ue-thumbnails is inside
+    // #unified-editor-workspace, whose drop handler REPLACES the file — without
+    // this, dropping to append would instead wipe the doc. WHY append (not
+    // replace): dropping on the page LIST clearly means "add these to my doc".
+    const files = e.dataTransfer.files;
+    if (files && files.length > 0) {
+      e.stopPropagation();
+      container.classList.remove('drag-over-files');
+      removeSidebarDropIndicator();
+      showFullscreenLoading('Menambahkan halaman...');
+      try {
+        await window.ueAddFiles(Array.from(files));
+      } catch (err) {
+        console.error('Error appending dropped files:', err);
+        showToast('Gagal menambahkan file', 'error');
+      } finally {
+        hideFullscreenLoading();
+      }
+      return;
+    }
+
     if (!draggedItem) return;
 
     const indicator = ueState.sidebarDropIndicator;

--- a/style.css
+++ b/style.css
@@ -2492,6 +2492,14 @@ a:hover {
   animation: dropIndicatorPulse 0.8s ease-in-out infinite;
 }
 
+/* Dropping an OS file onto the thumbnail list appends pages — signal the target. */
+#ue-thumbnails.drag-over-files {
+  outline: 2px dashed var(--accent-primary);
+  outline-offset: -6px;
+  background: var(--accent-light);
+  border-radius: var(--radius-md);
+}
+
 .ue-thumbnail canvas {
   max-width: 100%;
   max-height: 120px;

--- a/tests/sidebar-drop-append.spec.js
+++ b/tests/sidebar-drop-append.spec.js
@@ -1,0 +1,60 @@
+/*
+ * PDFLokal — drop an OS file onto the sidebar thumbnail list to APPEND pages.
+ *
+ * Wave 1: previously a file dropped on the sidebar was eaten by the reorder
+ * handler, and a file dropped on the canvas REPLACES the doc (workspace dropzone).
+ * Now dropping on #ue-thumbnails appends — the obvious "add these to my doc" intent.
+ *
+ * Critical: #ue-thumbnails is inside #unified-editor-workspace, whose drop handler
+ * replaces the file. The sidebar handler must stopPropagation so append doesn't
+ * turn into replace. This test proves 2 pages + a 1-page drop = 3 (not 1).
+ */
+import { test, expect } from '@playwright/test';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SAMPLE_PDF = path.join(__dirname, 'fixtures', 'sample-2pages.pdf');
+
+async function loadEditor(page) {
+  await page.goto('/');
+  await page.setInputFiles('#file-input', SAMPLE_PDF);
+  await page.waitForFunction(() => document.body.classList.contains('editor-active'));
+  await page.waitForFunction(() => window.ueState?.pages?.length === 2);
+}
+
+// Dispatch a synthetic OS file drop of the given URL onto #ue-thumbnails.
+async function dropFileOnSidebar(page, url, { dragOverOnly = false } = {}) {
+  return page.evaluate(async ({ u, dragOverOnly }) => {
+    const res = await fetch(u);
+    const buf = await res.arrayBuffer();
+    const file = new File([buf], 'dropped.pdf', { type: 'application/pdf' });
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    const container = document.getElementById('ue-thumbnails');
+    container.dispatchEvent(new DragEvent('dragover', { dataTransfer: dt, bubbles: true, cancelable: true }));
+    if (dragOverOnly) return container.classList.contains('drag-over-files');
+    container.dispatchEvent(new DragEvent('drop', { dataTransfer: dt, bubbles: true, cancelable: true }));
+    return null;
+  }, { u: url, dragOverOnly });
+}
+
+test.describe('Sidebar drop-to-append', () => {
+  test('dropping a PDF on the sidebar appends its pages (does not replace)', async ({ page }) => {
+    await loadEditor(page);
+    expect(await page.evaluate(() => window.ueState.pages.length)).toBe(2);
+
+    await dropFileOnSidebar(page, '/tests/fixtures/sample-2pages.pdf');
+
+    // 2 existing + 2 dropped = 4. If stopPropagation failed, the workspace dropzone
+    // would have replaced the doc and length would be 2 (or the drop would no-op).
+    await page.waitForFunction(() => window.ueState?.pages?.length === 4, null, { timeout: 10_000 });
+    expect(await page.evaluate(() => window.ueState.sourceFiles.length)).toBe(2);
+  });
+
+  test('dragging a file over the sidebar shows the drop-target hint', async ({ page }) => {
+    await loadEditor(page);
+    const hasHint = await dropFileOnSidebar(page, '/tests/fixtures/sample-2pages.pdf', { dragOverOnly: true });
+    expect(hasHint).toBe(true);
+  });
+});


### PR DESCRIPTION
## Wave 1 — drop-to-append

Dropping a PDF/image on the `#ue-thumbnails` list now **APPENDS** its pages to the current document — the obvious "add these to my doc" intent. Previously the sidebar drop was eaten by the reorder handler, and dropping on the canvas *replaces* via the workspace dropzone.

- OS file drop is distinguished from internal reorder by `dataTransfer.files` (reorder carries only `text/plain`).
- **`stopPropagation` is essential**: `#ue-thumbnails` sits inside `#unified-editor-workspace`, whose drop handler *replaces* the file — without it, append would silently become replace.
- `dragover` shows a dashed accent drop-target hint (`.drag-over-files`), cleared on `dragleave` (guarded on `relatedTarget` so child moves don't flicker it).

## Tests — `tests/sidebar-drop-append.spec.js`
- append: 2 existing + a 2-page drop = **4** (proves no replace).
- drop-target hint appears on dragover.
- Hint also verified live via MCP screenshot.

Smoke (34) green · `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)