### PR TITLE
feat(core): Phase 0 — headless document model + operations

### DIFF
--- a/docs/foundation-plan.md
+++ b/docs/foundation-plan.md
@@ -1,0 +1,101 @@
+# PDFLokal — Foundation Plan (v1)
+
+> **What this is:** the concrete, phased plan to reorganize the code so it can serve the vision. Reads with [product-definition.md](product-definition.md) (the *why/what*), `memory/architectural-direction-2026-06-09.md` (the original direction), and the July-2026 architecture map (below, §1). This is the *how*.
+>
+> **The rule (from June 9):** incremental, shippable, **one structural change per phase**; each phase's scope is revisited *before* it begins; behavior-changing phases get a **verify-on-real-device-before-merge** gate. No big-bang rewrite.
+
+---
+
+## 1. The diagnosis (from reading the actual code, July 2026)
+
+The spaghetti has one taproot: **there is no single document model, and rendering mixes DOM with canvas.**
+
+- **Six parallel "truths," all keyed by array index**, kept in sync by `mutatePages()` (partial) plus manual work the caller must remember:
+  `ueState.pages[]` · `annotations{}` · `pageScales{}` · `pageCaches{}` · `pageCanvases[]` · `sourceFiles[]`. Any one drifting = wrong render or crash. (`mutatePages` doesn't even own `pageCanvases` — the caller re-splices it by hand.)
+- **`selectedAnnotation = {pageIndex, index}`** — two indices that must both stay valid through every mutation. This is the "stale selection / slides behind" family, by construction.
+- **Mixed rendering:** annotations are drawn *onto the page canvas*, but their UI (the signature confirm/delete buttons) are **separate DOM elements** positioned from canvas coords. A newer page's canvas creates its own stacking context and paints over the button → **the "confirm button / annotation hides behind another page" bug** the founder hit. It's structural, not a CSS typo.
+- **`pdf-export.js` reads `ueState.devicePixelRatio` and lazily-computed `pageScales`** → it is *not* headless; it can't run without the live render having happened.
+
+Everything we keep patching lives in these four facts.
+
+## 2. Target architecture — three layers
+
+```
+┌── CORE (js/core/, headless, no DOM) ──────────────────────────┐
+│  One Doc model. A Page OWNS its annotations. Everything is     │
+│  referenced by object/id — never by array index.              │
+│  operations.js = the single mutation path.                    │
+│  import (PDF.js → raster + meta) · export (model → pdf-lib)    │
+│  = adapters at the edges. Core logic runs in Node.            │
+└───────────────┬───────────────────────────────────────────────┘
+                │ read + subscribe
+┌───────────────▼──── RENDER (js/render/) ──────────────────────┐
+│  Page background = rasterized <img> (survives mobile GPU       │
+│  purge; zoom = CSS scale, atomic). Annotations = ONE overlay   │
+│  layer above the <img>. The active object is ALWAYS top-most.  │
+│  Viewport-relative: 3 nearest mounted (mobile) / N (desktop);  │
+│  far pages = light placeholders. Evict = cheap; reload = fast. │
+└───────────────┬───────────────────────────────────────────────┘
+                │ input → operations
+┌───────────────▼──── INTERACT (js/interact/) ──────────────────┐
+│  ONE input path (pointer events; mouse + touch unified) →      │
+│  hit-test the model → dispatch a core operation. Tools = verbs.│
+│  Same path on mobile and desktop.                             │
+└───────────────────────────────────────────────────────────────┘
+```
+
+## 3. The invariants (acceptance criteria — from product-definition §9)
+
+1. One document model = one source of truth.
+2. Page = picture; annotations = one overlay above it; active object = top-most.
+3. Objects referenced, never indexed.
+4. One interaction model → one input path (mobile + desktop).
+5. Every mutation goes through one operation path.
+6. The core is headless — model + operations + import + export run with no DOM.
+
+**Litmus test for "done":** the core can load bytes, apply operations, and emit a correct PDF **in Node, with no browser.**
+
+## 4. Current → target map
+
+| Today (smeared) | Tomorrow (one home) |
+|---|---|
+| `ueState.pages[]` + `sourceFiles[]` | `Doc { sources[], pages[] }` in `core/model.js` |
+| `annotations{pageIndex:[...]}` | `page.annotations[]` — on the page object |
+| `selectedAnnotation {pageIndex,index}` | `doc.selection { pageId, annotationId }` — by id |
+| `pageScales{}` `pageCaches{}` `pageCanvases[]` | render-layer concerns, keyed by `page.id`, not global index |
+| `mutatePages()` re-keying dance | *deleted* — object refs don't need re-keying |
+| annotations on page canvas + DOM buttons | one annotation overlay; UI in the same layer, top-most |
+| `pdf-export.js` reads `ueState` | `core/export.js` takes a `Doc`, returns bytes |
+
+## 5. Phasing
+
+**Phase 0 — The headless core. ← we start here.**
+Build `js/core/model.js` + `js/core/operations.js`: the `Doc` model (pages own annotations, everything by id/ref) and the single mutation path, proven with `node --test` (instant, no DOM). **Zero risk — not wired into the live app yet.** Then the import/export adapters (`core/import.js`, `core/export.js`), browser-tested against the golden suite (vendored PDF.js/pdf-lib are browser builds). Deliverable: *the "backend" exists and passes tests, and can round-trip a PDF headlessly.*
+
+**Phase 1 — Image-background rendering + single annotation overlay.**
+Rasterize each page on import; render pages as `<img>`; move annotations to one overlay layer with the active object always top-most. **Kills the mobile flicker/purge class AND the slides-behind bug.** Ship + **verify on a real Android device** before merge.
+
+**Phase 2 — Viewport 3-nearest mounting.** Drive-style loading; far pages = placeholders; fast-scroll shows a brief, *expected* loading state.
+
+**Phase 3 — Migrate the live editor onto the Core; retire the parallel state** (`pageCanvases`/`pageCaches`/`pageScales`/`annotations{}` collapse into `page.id`-keyed render state + `page.annotations`).
+
+**Phase 4 — Reactive subscribers, IF state-sync pain still hurts after 0–3.** Tentative (June 9): don't build machinery preemptively; verify the pain first.
+
+Each phase is revisited before it begins. Old and new coexist until each phase ships.
+
+## 6. Verification / feedback loop (per phase)
+
+- **Core:** `node --test tests/core/` — instant, headless. The mutation invariants (reorder/delete keeps annotations + selection correct with **zero re-keying**) are the proof the spaghetti class is gone.
+- **Rendering:** Playwright visual suite + **a real-Android pass** (the mobile bugs need a device — DevTools won't repro stacking-context purges).
+- **Export fidelity:** the golden PDF suite (`tests/golden/`) guards glyph/rotation/coords.
+- **Discipline:** before/after regression on the touched flow + adjacent flows.
+
+## 7. Guardrails / non-goals
+
+- No big-bang rewrite. No server jobs. No new heavy deps.
+- Don't build the reactive layer (Phase 4) preemptively.
+- Behavior-changing phases (1–3) do **not** merge on green CI alone — the founder verifies the mobile merge→edit→download path on a real phone first. (Every mobile bug is a leak in a paid funnel.)
+
+## 8. Status
+
+- **Phase 0 started July 2026.** Model + operations + headless tests: see `js/core/` and `tests/core/`.

--- a/js/core/model.js
+++ b/js/core/model.js
@@ -1,0 +1,100 @@
+/*
+ * PDFLokal — core/model.js  (HEADLESS domain model — no DOM, no vendor libs)
+ * ============================================================================
+ * The ONE source of truth for a document. This layer must run in Node with no
+ * browser (that's the litmus test — see docs/foundation-plan.md).
+ *
+ * The two rules that kill the old spaghetti:
+ *   1. A Page OWNS its annotations (page.annotations[]). There is NO parallel
+ *      `annotations{pageIndex:[...]}` map to keep in sync.
+ *   2. Everything is referenced by STABLE ID / object, never by array index.
+ *      Reorder or delete a page and nothing needs re-keying — the annotations
+ *      travel on the page object; selection points at ids.
+ *
+ * Factories only here (pure shapes). Mutations live in core/operations.js so
+ * there is exactly one mutation path (invariant #5).
+ */
+
+// Monotonic ids — deterministic within a session, collision-free, and (unlike
+// array indices) stable across reorder/delete. Not persisted; identity only.
+let _seq = 0;
+export function nextId(prefix) {
+  _seq += 1;
+  return `${prefix}_${_seq}`;
+}
+// Test-only: reset the counter so id assertions are deterministic per test.
+export function _resetIds() { _seq = 0; }
+
+// A source file — the ONLY place raw bytes live. Pages reference it by id.
+export function createSource({ name, bytes, numPages = 0 }) {
+  return { id: nextId('src'), name, bytes, numPages };
+}
+
+// An annotation — stable id, referenced directly (never by {pageIndex,index}).
+// `type` is one of: 'whiteout' | 'text' | 'signature' | 'watermark' | 'pageNumber'.
+// `props` carries the type-specific fields (x, y, width, text, …).
+export function createAnnotation(type, props = {}) {
+  return { id: nextId('anno'), type, ...props };
+}
+
+// A page. Immutable identity (id). Owns its annotations. `raster` is filled by
+// the render/import layer in Phase 1 (an image of the page) — null in pure core.
+export function createPage({
+  source,            // a Source object (we store source.id)
+  sourcePageNum,     // 0-based page index within that source
+  width, height,     // intrinsic (unrotated) size, PDF points
+  rotation = 0,      // 0 | 90 | 180 | 270
+  isFromImage = false,
+}) {
+  return {
+    id: nextId('page'),
+    sourceId: source.id,
+    sourcePageNum,
+    width,
+    height,
+    rotation,
+    isFromImage,
+    raster: null,          // Phase 1: rasterized page image (render-time artifact)
+    annotations: [],       // annotations live HERE — no parallel map
+  };
+}
+
+// The whole document — one source of truth. Selection is by id, never index.
+export function createDoc() {
+  return {
+    sources: [],   // Source[]
+    pages: [],     // Page[] in display order
+    selection: { pageId: null, annotationId: null },
+  };
+}
+
+// ---- read helpers (pure lookups; no mutation) ------------------------------
+
+export function getPage(doc, pageId) {
+  return doc.pages.find((p) => p.id === pageId) || null;
+}
+
+export function getSource(doc, sourceId) {
+  return doc.sources.find((s) => s.id === sourceId) || null;
+}
+
+// Locate an annotation anywhere in the doc by id. Returns { page, annotation,
+// index } or null. `index` is only for splicing inside operations — callers
+// hold the annotation OBJECT, never the number.
+export function findAnnotation(doc, annotationId) {
+  for (const page of doc.pages) {
+    const index = page.annotations.findIndex((a) => a.id === annotationId);
+    if (index !== -1) return { page, annotation: page.annotations[index], index };
+  }
+  return null;
+}
+
+// The currently selected page / annotation objects (or null). Derived from ids
+// so they can never go stale the way a cached {pageIndex,index} did.
+export function selectedPage(doc) {
+  return doc.selection.pageId ? getPage(doc, doc.selection.pageId) : null;
+}
+export function selectedAnnotation(doc) {
+  const found = doc.selection.annotationId ? findAnnotation(doc, doc.selection.annotationId) : null;
+  return found ? found.annotation : null;
+}

--- a/js/core/operations.js
+++ b/js/core/operations.js
@@ -1,0 +1,115 @@
+/*
+ * PDFLokal — core/operations.js  (HEADLESS — the single mutation path)
+ * ============================================================================
+ * Every change to a Doc goes through one of these (invariant #5). They are pure
+ * w.r.t. the DOM: they take a Doc, mutate it in place, and return the affected
+ * entity. No rendering, no vendor libs, no globals.
+ *
+ * The headline the old code couldn't make: reorder / delete a page and there is
+ * NO re-keying. Annotations ride on the page object; selection points at ids.
+ * `mutatePages()` and its six-parallel-map dance simply don't exist here.
+ */
+
+import { getPage, findAnnotation, getSource } from './model.js';
+
+const clamp = (n, lo, hi) => Math.min(Math.max(n, lo), hi);
+
+// ---- sources ---------------------------------------------------------------
+
+export function addSource(doc, source) {
+  doc.sources.push(source);
+  return source;
+}
+
+// ---- pages -----------------------------------------------------------------
+
+export function addPages(doc, pages) {
+  doc.pages.push(...pages);
+  return pages;
+}
+
+export function removePage(doc, pageId) {
+  const i = doc.pages.findIndex((p) => p.id === pageId);
+  if (i === -1) return null;
+  const [removed] = doc.pages.splice(i, 1);
+  // Selection is by id → clearing it is trivial and can't dangle.
+  if (doc.selection.pageId === pageId) {
+    doc.selection = { pageId: null, annotationId: null };
+  } else if (doc.selection.annotationId && !findAnnotation(doc, doc.selection.annotationId)) {
+    // The selected annotation lived on the removed page.
+    doc.selection.annotationId = null;
+  }
+  return removed;
+}
+
+// Move a page to a new display index. NO re-keying of anything — this is the
+// whole point. Annotations and selection are untouched and still correct.
+export function reorderPage(doc, pageId, toIndex) {
+  const from = doc.pages.findIndex((p) => p.id === pageId);
+  if (from === -1) return null;
+  const [pg] = doc.pages.splice(from, 1);
+  doc.pages.splice(clamp(toIndex, 0, doc.pages.length), 0, pg);
+  return pg;
+}
+
+export function rotatePage(doc, pageId, deltaDeg = 90) {
+  const pg = getPage(doc, pageId);
+  if (!pg) return null;
+  pg.rotation = (((pg.rotation + deltaDeg) % 360) + 360) % 360;
+  return pg;
+}
+
+// ---- annotations (all by id / object; never by index) ----------------------
+
+export function addAnnotation(doc, pageId, annotation) {
+  const pg = getPage(doc, pageId);
+  if (!pg) return null;
+  pg.annotations.push(annotation);
+  return annotation;
+}
+
+export function updateAnnotation(doc, annotationId, patch) {
+  const found = findAnnotation(doc, annotationId);
+  if (!found) return null;
+  Object.assign(found.annotation, patch);
+  return found.annotation;
+}
+
+export function removeAnnotation(doc, annotationId) {
+  const found = findAnnotation(doc, annotationId);
+  if (!found) return null;
+  found.page.annotations.splice(found.index, 1);
+  if (doc.selection.annotationId === annotationId) doc.selection.annotationId = null;
+  return found.annotation;
+}
+
+// ---- selection (by id — cannot go stale) -----------------------------------
+
+export function selectPage(doc, pageId) {
+  doc.selection = { pageId, annotationId: null };
+  return getPage(doc, pageId);
+}
+
+export function selectAnnotation(doc, annotationId) {
+  const found = annotationId ? findAnnotation(doc, annotationId) : null;
+  doc.selection.annotationId = found ? annotationId : null;
+  if (found) doc.selection.pageId = found.page.id;
+  return found ? found.annotation : null;
+}
+
+export function clearSelection(doc) {
+  doc.selection = { pageId: null, annotationId: null };
+}
+
+// ---- export intent (headless boundary contract) ----------------------------
+
+// The export adapter (core/export.js, Phase 0b) will consume exactly this:
+// each entry pairs a page with its source bytes. No DOM, no ueState — proving
+// the core can drive a PDF build in Node. Returned here as data only.
+export function buildExportPlan(doc) {
+  return doc.pages.map((page) => ({
+    page,
+    source: getSource(doc, page.sourceId),
+    annotations: page.annotations,
+  }));
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "lint": "eslint js/",
     "lint:fix": "eslint js/ --fix",
+    "test:core": "node --test 'tests/core/**/*.test.mjs'",
     "test": "playwright test",
     "test:headed": "playwright test --headed",
     "test:ui": "playwright test --ui",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -10,6 +10,9 @@ const BASE_URL = `http://localhost:${PORT}`;
 
 export default defineConfig({
   testDir: './tests',
+  // tests/core/ is the HEADLESS domain core suite — it runs under `node --test`
+  // (npm run test:core), not Playwright. Keep the browser runner out of it.
+  testIgnore: 'core/**',
   timeout: 30_000,
   expect: { timeout: 5_000 },
   fullyParallel: false,

--- a/tests/core/model.test.mjs
+++ b/tests/core/model.test.mjs
@@ -1,0 +1,108 @@
+/*
+ * PDFLokal — headless core tests (node --test, NO browser, NO DOM).
+ *
+ * These prove the invariant that the old six-parallel-map architecture could
+ * never hold: reorder / delete a page and annotations + selection stay correct
+ * with ZERO re-keying, because annotations ride on the page object and
+ * selection points at stable ids. If this file is green, the "state drift /
+ * slides-behind / stale selection" bug class is structurally impossible in the
+ * core.
+ *
+ * Run: npm run test:core   (or: node --test tests/core/)
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createDoc, createSource, createPage, createAnnotation,
+  getPage, findAnnotation, selectedAnnotation, selectedPage, _resetIds,
+} from '../../js/core/model.js';
+import {
+  addSource, addPages, removePage, reorderPage, rotatePage,
+  addAnnotation, updateAnnotation, removeAnnotation,
+  selectPage, selectAnnotation, buildExportPlan,
+} from '../../js/core/operations.js';
+
+// Build a 3-page doc; page 2 carries a text annotation.
+function fixture() {
+  _resetIds();
+  const doc = createDoc();
+  const src = addSource(doc, createSource({ name: 'a.pdf', bytes: new Uint8Array([1]), numPages: 3 }));
+  const pages = [0, 1, 2].map((n) =>
+    createPage({ source: src, sourcePageNum: n, width: 595, height: 842 }));
+  addPages(doc, pages);
+  const note = addAnnotation(doc, pages[2].id,
+    createAnnotation('text', { text: 'hi', x: 10, y: 20 }));
+  return { doc, src, pages, note };
+}
+
+test('a page owns its annotations — no parallel map', () => {
+  const { doc, pages, note } = fixture();
+  assert.equal(pages[2].annotations.length, 1);
+  assert.equal(pages[2].annotations[0], note);
+  assert.equal(pages[0].annotations.length, 0);
+});
+
+test('REORDER: annotations follow their page with zero re-keying', () => {
+  const { doc, pages, note } = fixture();
+  // Move page 2 (the annotated one) to the front.
+  reorderPage(doc, pages[2].id, 0);
+  assert.equal(doc.pages[0].id, pages[2].id, 'annotated page moved to front');
+  // The SAME annotation object is still on the SAME page object. Nothing re-keyed.
+  assert.equal(doc.pages[0].annotations[0], note);
+  assert.equal(findAnnotation(doc, note.id).page.id, pages[2].id);
+});
+
+test('DELETE: removing an unrelated page leaves annotations intact', () => {
+  const { doc, pages, note } = fixture();
+  removePage(doc, pages[0].id);
+  assert.equal(doc.pages.length, 2);
+  // note still resolves, still on its page — no index arithmetic needed.
+  assert.equal(findAnnotation(doc, note.id).annotation, note);
+});
+
+test('selection is by id and cannot dangle', () => {
+  const { doc, pages, note } = fixture();
+  selectAnnotation(doc, note.id);
+  assert.equal(selectedAnnotation(doc), note);
+  assert.equal(selectedPage(doc).id, pages[2].id);
+
+  // Reorder — selection still resolves to the same objects.
+  reorderPage(doc, pages[2].id, 0);
+  assert.equal(selectedAnnotation(doc), note);
+
+  // Delete the selected annotation's page — selection clears, no crash.
+  removePage(doc, pages[2].id);
+  assert.equal(selectedAnnotation(doc), null);
+  assert.equal(selectedPage(doc), null);
+});
+
+test('annotation update/remove operate by id', () => {
+  const { doc, note } = fixture();
+  updateAnnotation(doc, note.id, { text: 'bye', x: 99 });
+  assert.equal(findAnnotation(doc, note.id).annotation.text, 'bye');
+  assert.equal(note.x, 99);
+
+  removeAnnotation(doc, note.id);
+  assert.equal(findAnnotation(doc, note.id), null);
+});
+
+test('rotatePage normalizes into [0,360)', () => {
+  const { doc, pages } = fixture();
+  rotatePage(doc, pages[0].id, 90);
+  rotatePage(doc, pages[0].id, 90);
+  assert.equal(getPage(doc, pages[0].id).rotation, 180);
+  rotatePage(doc, pages[0].id, 270); // 180 + 270 = 450 → 90
+  assert.equal(getPage(doc, pages[0].id).rotation, 90);
+});
+
+test('buildExportPlan pairs each page with its source bytes (headless)', () => {
+  const { doc, src, pages } = fixture();
+  const plan = buildExportPlan(doc);
+  assert.equal(plan.length, 3);
+  assert.equal(plan[0].source, src);
+  assert.equal(plan[2].annotations.length, 1);
+  // Reorder changes plan order without touching annotations — export stays correct.
+  reorderPage(doc, pages[2].id, 0);
+  assert.equal(buildExportPlan(doc)[0].annotations.length, 1);
+});


### PR DESCRIPTION
## Foundation rebuild — Phase 0

First slice of the foundation plan (`docs/foundation-plan.md`), which reorganizes the code to serve the locked product vision. This introduces the **headless domain core** — the "backend" — in isolation.

### What
- **`js/core/model.js`** — the ONE document model: `Doc { sources[], pages[], selection{pageId, annotationId} }`. A **Page owns its annotations**; everything is referenced by stable **id/object, never array index**.
- **`js/core/operations.js`** — the single mutation path (pages: add/remove/reorder/rotate; annotations: add/update/remove/select). No `mutatePages()` six-map re-keying dance.
- **`tests/core/model.test.mjs`** — 7 headless tests (`npm run test:core`, pure Node, no browser).

### Why it matters
The green test **`REORDER: annotations follow their page with zero re-keying`** proves the "state drift / stale selection / slides-behind" bug class is *structurally impossible* in the core — annotations ride on the page object, selection points at ids.

### Safety
**Isolated** — not wired into the live editor (that's Phase 3). Purely additive, **zero regression risk**. Playwright config now ignores `tests/core/` (it's a `node --test` suite, not a browser suite).

### Verification
- `npm run test:core` → 7/7 green (headless).
- `npm run lint` → clean.
- Existing Playwright suites untouched (testIgnore scoped to `core/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)