### PR TITLE
feat(render): Phase 1a — image-backed render engine + phone-openable lab

### DIFF
--- a/js/lab.js
+++ b/js/lab.js
@@ -1,0 +1,100 @@
+/*
+ * PDFLokal — js/lab.js  (Phase-1 render-engine PREVIEW, not part of the app)
+ * ============================================================================
+ * A throwaway harness to let the founder FEEL the new image-backed rendering on
+ * a real phone BEFORE we swap the live editor. It wires: PDF bytes → core Doc
+ * (import + rasterize) → render/page-view. Then it drops one draggable demo
+ * annotation on page 1 so you can drag it around and confirm it stays ON TOP of
+ * the pages (the "slides behind" fix), and scroll/zoom without flicker.
+ *
+ * Nothing here touches the live app. Not linked from anywhere; robots-noindex.
+ */
+import { createDoc, createAnnotation } from './core/model.js';
+import { addAnnotation } from './core/operations.js';
+import { importPdf, rasterizePage } from './core/import.js';
+import { renderPageView } from './render/page-view.js';
+
+window.pdfjsLib.GlobalWorkerOptions.workerSrc = '/js/vendor/pdf.worker.min.js';
+
+const stage = document.getElementById('pv-stage');
+const statusEl = document.getElementById('lab-status');
+const setStatus = (s) => { statusEl.textContent = s; };
+
+let zoom = 1;
+function applyZoom() { stage.style.transform = `scale(${zoom})`; }
+document.getElementById('z-in').onclick = () => { zoom = Math.min(zoom + 0.2, 3); applyZoom(); };
+document.getElementById('z-out').onclick = () => { zoom = Math.max(zoom - 0.2, 0.3); applyZoom(); };
+
+// Load a document from bytes, rasterize every page, render the column.
+async function loadDoc(name, bytes) {
+  setStatus('memuat…');
+  stage.innerHTML = '';
+  const doc = createDoc();
+  const pages = await importPdf(doc, { name, bytes });
+
+  // A draggable demo annotation on page 1 — proves "active object always on top".
+  const demo = addAnnotation(doc, pages[0].id,
+    createAnnotation('text', { text: 'Seret aku ✍️  (aku selalu di atas)', x: 60, y: 140, fontSize: 22, color: '#111', bold: true }));
+
+  // Fit the first page to the viewport width for a sensible default zoom.
+  const fit = Math.min(1, (stage.parentElement.clientWidth - 32) / pages[0].width);
+  zoom = fit; applyZoom();
+
+  for (const page of pages) {
+    await rasterizePage(doc, page, { scale: 2 });
+    const view = renderPageView(page, { activeId: demo.id });
+    stage.appendChild(view);
+    setStatus(`${stage.children.length}/${pages.length} halaman`);
+  }
+  setStatus(`${pages.length} halaman · seret teks hijau, scroll, zoom ± — cek flicker`);
+
+  wireDemoDrag(doc, demo);
+}
+
+// Pointer-based drag (works mouse + touch). Updates the annotation in the core
+// model, then moves its element. Screen delta is divided by zoom so it tracks
+// the finger 1:1 at any zoom.
+function wireDemoDrag(doc, anno) {
+  const el = stage.querySelector(`[data-anno-id="${anno.id}"]`);
+  if (!el) return;
+  el.style.cursor = 'grab';
+  el.style.touchAction = 'none';
+  let startX = 0, startY = 0, baseX = 0, baseY = 0, dragging = false;
+
+  el.addEventListener('pointerdown', (e) => {
+    dragging = true; el.setPointerCapture(e.pointerId);
+    startX = e.clientX; startY = e.clientY; baseX = anno.x; baseY = anno.y;
+    el.style.zIndex = '1000'; el.style.cursor = 'grabbing';
+    e.preventDefault();
+  });
+  el.addEventListener('pointermove', (e) => {
+    if (!dragging) return;
+    anno.x = baseX + (e.clientX - startX) / zoom;
+    anno.y = baseY + (e.clientY - startY) / zoom;
+    el.style.left = anno.x + 'px';
+    el.style.top = anno.y + 'px';
+  });
+  const end = () => { dragging = false; el.style.cursor = 'grab'; };
+  el.addEventListener('pointerup', end);
+  el.addEventListener('pointercancel', end);
+}
+
+// Wire the file picker + auto-load the bundled sample so it's alive on open.
+document.getElementById('lab-file').addEventListener('change', async (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  loadDoc(file.name, bytes).catch((err) => { console.error(err); setStatus('gagal memuat'); });
+  e.target.value = '';
+});
+
+(async () => {
+  try {
+    const res = await fetch('/tests/fixtures/sample-2pages.pdf');
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    await loadDoc('sample-2pages.pdf', bytes);
+  } catch (err) {
+    console.error(err);
+    setStatus('Buka PDF untuk mulai');
+  }
+})();

--- a/js/render/page-view.js
+++ b/js/render/page-view.js
@@ -1,0 +1,78 @@
+/*
+ * PDFLokal — render/page-view.js  (RENDER LAYER — Phase 1)
+ * ============================================================================
+ * Renders one core Page as an IMAGE-BACKED view:
+ *   - background = the rasterized page as an <img>  → survives the mobile GPU
+ *     backing-store purge that blanks live <canvas>es. Zoom = CSS transform on
+ *     the parent (atomic, GPU-accelerated, no re-render, no flicker).
+ *   - annotations = ONE overlay layer above the <img>. Stacking is decided ONLY
+ *     by z-index WITHIN this overlay, so an annotation can never hide behind
+ *     another page's canvas (the old bug). The active object is always top-most.
+ *
+ * Coordinates are page-space px (== PDF points, top-left origin). The whole page
+ * view is sized to the page's point dimensions; zoom is a transform:scale() the
+ * caller applies to a wrapper — so annotation↔page registration is exact at any
+ * zoom without recomputing anything.
+ *
+ * Reads the core model only. No ueState, no vendor libs. DOM out.
+ */
+
+// Render a full page view (background + annotation overlay).
+// opts.activeId = id of the currently-active annotation → rendered on top.
+export function renderPageView(page, { activeId = null } = {}) {
+  const view = document.createElement('div');
+  view.className = 'pv-page';
+  view.dataset.pageId = page.id;
+  view.style.cssText =
+    `position:relative;flex:0 0 auto;width:${page.width}px;height:${page.height}px;` +
+    'background:#fff;box-shadow:0 2px 14px rgba(0,0,0,.14);border-radius:2px';
+
+  if (page.raster) {
+    const img = document.createElement('img');
+    img.className = 'pv-bg';
+    img.src = page.raster.dataUrl;
+    img.draggable = false;
+    img.alt = '';
+    img.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;user-select:none;pointer-events:none';
+    view.appendChild(img);
+  }
+
+  const overlay = document.createElement('div');
+  overlay.className = 'pv-overlay';
+  overlay.style.cssText = 'position:absolute;inset:0';
+  for (const anno of page.annotations) {
+    const el = renderAnnotationEl(anno);
+    el.style.zIndex = anno.id === activeId ? '1000' : '1'; // active always on top
+    overlay.appendChild(el);
+  }
+  view.appendChild(overlay);
+  return view;
+}
+
+// One annotation as a positioned DOM element (page-space px).
+export function renderAnnotationEl(anno) {
+  const el = document.createElement('div');
+  el.className = 'pv-anno pv-anno-' + anno.type;
+  el.dataset.annoId = anno.id;
+  el.style.cssText = `position:absolute;left:${anno.x || 0}px;top:${anno.y || 0}px`;
+
+  if (anno.type === 'text') {
+    el.textContent = anno.text || '';
+    el.style.font =
+      `${anno.italic ? 'italic ' : ''}${anno.bold ? '700 ' : '400 '}` +
+      `${anno.fontSize || 24}px ${anno.fontFamily || 'Helvetica, Arial, sans-serif'}`;
+    el.style.color = anno.color || '#000';
+    el.style.whiteSpace = 'pre';
+    el.style.lineHeight = '1.2';
+  } else if (anno.type === 'whiteout') {
+    el.style.width = (anno.width || 0) + 'px';
+    el.style.height = (anno.height || 0) + 'px';
+    el.style.background = '#fff';
+  } else if (anno.type === 'signature' && anno.image) {
+    const im = document.createElement('img');
+    im.src = anno.image;
+    im.style.cssText = `display:block;width:${anno.width || 150}px;height:auto`;
+    el.appendChild(im);
+  }
+  return el;
+}

--- a/lab.html
+++ b/lab.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+  <meta name="robots" content="noindex" />
+  <title>PDFLokal — Lab (render engine preview)</title>
+  <style>
+    * { box-sizing: border-box; }
+    html, body { margin: 0; height: 100%; }
+    body { display: flex; flex-direction: column; font-family: system-ui, sans-serif; background: #e9ecef; color: #1c1917; }
+    #lab-bar {
+      display: flex; align-items: center; gap: 10px; padding: 10px 12px;
+      background: #fff; border-bottom: 1px solid #dcdcdc; flex: 0 0 auto;
+    }
+    #lab-bar b { font-size: 14px; }
+    #lab-bar .spacer { flex: 1; }
+    #lab-bar button, #lab-bar label {
+      font: inherit; font-size: 13px; padding: 6px 12px; border: 1px solid #cfcfcf;
+      border-radius: 8px; background: #f7f7f7; cursor: pointer; min-height: 40px;
+    }
+    #lab-bar .z { min-width: 40px; }
+    #lab-status { font-size: 12px; color: #666; }
+    /* The scroll container — body scroll of image-backed pages. */
+    #pv-scroll { flex: 1; overflow: auto; -webkit-overflow-scrolling: touch; padding: 16px 0 40vh; }
+    #pv-stage {
+      display: flex; flex-direction: column; align-items: center; gap: 16px;
+      transform-origin: top center; will-change: transform;
+    }
+    input[type=file] { display: none; }
+  </style>
+</head>
+<body>
+  <div id="lab-bar">
+    <b>Lab</b>
+    <span id="lab-status">memuat…</span>
+    <span class="spacer"></span>
+    <button class="z" id="z-out" aria-label="Perkecil">−</button>
+    <button class="z" id="z-in" aria-label="Perbesar">+</button>
+    <label>Buka PDF<input type="file" id="lab-file" accept="application/pdf,.pdf" /></label>
+  </div>
+  <div id="pv-scroll"><div id="pv-stage"></div></div>
+
+  <script src="js/vendor/pdf.min.js"></script>
+  <script type="module" src="js/lab.js"></script>
+</body>
+</html>

--- a/tests/lab-render.spec.js
+++ b/tests/lab-render.spec.js
@@ -1,0 +1,33 @@
+/*
+ * PDFLokal — Phase-1 render-engine preview (/lab.html) smoke test.
+ *
+ * Guards the new image-backed render path: a PDF flows through the core
+ * (import + rasterize) and renders as <img>-backed pages with a single
+ * annotation overlay whose active object is top-most. This is the engine the
+ * live editor adopts in Phase 1 — if it goes red, the render layer regressed.
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('render engine preview (lab)', () => {
+  test('renders image-backed pages with the active annotation on top', async ({ page }) => {
+    await page.goto('/lab.html');
+
+    // Core import + rasterize + render: the bundled 2-page sample auto-loads.
+    await page.waitForFunction(
+      () => document.querySelectorAll('.pv-page').length === 2,
+      null, { timeout: 10_000 });
+
+    // Backgrounds are real rasterized PNGs (not live canvases).
+    expect(await page.locator('.pv-bg').count()).toBe(2);
+    const bgIsPng = await page.evaluate(() =>
+      (document.querySelector('.pv-bg')?.src || '').startsWith('data:image/png'));
+    expect(bgIsPng).toBe(true);
+
+    // Exactly one demo annotation, and it is top-most (z-index 1000) —
+    // the structural fix for "annotation slides behind another page".
+    const anno = page.locator('.pv-anno');
+    await expect(anno).toHaveCount(1);
+    const z = await anno.evaluate((el) => Number(getComputedStyle(el).zIndex));
+    expect(z).toBeGreaterThanOrEqual(1000);
+  });
+});


### PR DESCRIPTION
## Foundation rebuild — Phase 1a (the first thing you can *feel* on your phone)

The new render layer, plus a safe preview to judge it on a real Android **before** the live editor is touched.

- **`js/render/page-view.js`** — renders a core `Page` as an `<img>` background (survives the mobile GPU-backing-store purge that blanks live canvases; zoom = CSS transform, atomic, no flicker) + **ONE annotation overlay** where the active object is always top-most. Stacking is decided only within the overlay → an annotation **can never hide behind another page** (the structural fix for the "slides behind" bug).
- **`lab.html` + `js/lab.js`** — a throwaway harness (`noindex`, unlinked from the app): PDF bytes → core `Doc` (import + rasterize) → `page-view`. Auto-loads the sample; **Buka PDF** to test your own big file; a draggable demo annotation proves always-on-top; scroll + zoom to feel for flicker.
- **`tests/lab-render.spec.js`** — 2 `<img>`-backed pages + the active annotation at z-index 1000.

### How to judge it
Open **pdflokal.id/lab** on your Android. Load a big PDF. Scroll fast, zoom, drag the green text. It should be smooth, no flicker, and the text always sits on top.

### Safety
**Separate page — zero impact on the live app.** The editor you use is untouched.

### Verification
- `npx playwright test tests/lab-render.spec.js` → green · `npm run lint` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)