### PR TITLE
feat(render): Phase 2 (lab) — streaming/windowed page loading

### DIFF
--- a/js/core/import.js
+++ b/js/core/import.js
@@ -41,27 +41,44 @@ export async function importPdf(doc, { name, bytes }) {
 // this on demand. Result is stashed on `page.raster` so the DOM can show an
 // <img> that survives the mobile GPU-backing-store purge (unlike a live canvas).
 //
-// NOTE: reloads the PDF.js document per call for now — a per-source doc cache
-// is a render-layer concern (Phase 2), deliberately not baked into the adapter.
-export async function rasterizePage(doc, page, { scale = 2 } = {}) {
-  const source = getSource(doc, page.sourceId);
-  if (!source) return null;
+// One-shot convenience (reloads the PDF.js doc each call). For streaming/windowed
+// rendering use createPageRasterizer() below, which caches the doc per source.
+export async function rasterizePage(doc, page, opts = {}) {
+  const r = createPageRasterizer(doc);
+  try { return await r.rasterize(page, opts); }
+  finally { await r.destroy(); }
+}
 
-  const pdf = await window.pdfjsLib.getDocument({ data: source.bytes.slice() }).promise;
-  const pdfPage = await pdf.getPage(page.sourcePageNum + 1);
-  const vp = pdfPage.getViewport({ scale, rotation: page.rotation });
+// A rasterizer that caches the PDF.js document per source, so windowed/streaming
+// rendering (Phase 2) can rasterize many pages without reloading the whole PDF
+// each time. This is the render-layer's tool for "3-nearest" loading on any
+// document size within a bounded memory budget.
+export function createPageRasterizer(doc) {
+  const docCache = new Map(); // sourceId -> PDF.js document promise
 
-  const canvas = document.createElement('canvas');
-  canvas.width = Math.ceil(vp.width);
-  canvas.height = Math.ceil(vp.height);
-  await pdfPage.render({ canvasContext: canvas.getContext('2d'), viewport: vp }).promise;
-  await pdf.destroy();
+  function getPdf(sourceId) {
+    if (!docCache.has(sourceId)) {
+      const source = getSource(doc, sourceId);
+      docCache.set(sourceId, window.pdfjsLib.getDocument({ data: source.bytes.slice() }).promise);
+    }
+    return docCache.get(sourceId);
+  }
 
-  page.raster = {
-    dataUrl: canvas.toDataURL('image/png'),
-    width: canvas.width,
-    height: canvas.height,
-    scale,
+  return {
+    async rasterize(page, { scale = 2 } = {}) {
+      const pdf = await getPdf(page.sourceId);
+      const pdfPage = await pdf.getPage(page.sourcePageNum + 1);
+      const vp = pdfPage.getViewport({ scale, rotation: page.rotation });
+      const canvas = document.createElement('canvas');
+      canvas.width = Math.ceil(vp.width);
+      canvas.height = Math.ceil(vp.height);
+      await pdfPage.render({ canvasContext: canvas.getContext('2d'), viewport: vp }).promise;
+      page.raster = { dataUrl: canvas.toDataURL('image/png'), width: canvas.width, height: canvas.height, scale };
+      return page.raster;
+    },
+    async destroy() {
+      for (const p of docCache.values()) { try { (await p).destroy(); } catch { /* already gone */ } }
+      docCache.clear();
+    },
   };
-  return page.raster;
 }

--- a/js/lab.js
+++ b/js/lab.js
@@ -1,59 +1,104 @@
 /*
- * PDFLokal — js/lab.js  (Phase-1 render-engine PREVIEW, not part of the app)
+ * PDFLokal — js/lab.js  (Phase-1/2 render preview — NOT part of the app)
  * ============================================================================
- * A throwaway harness to let the founder FEEL the new image-backed rendering on
- * a real phone BEFORE we swap the live editor. It wires: PDF bytes → core Doc
- * (import + rasterize) → render/page-view. Then it drops one draggable demo
- * annotation on page 1 so you can drag it around and confirm it stays ON TOP of
- * the pages (the "slides behind" fix), and scroll/zoom without flicker.
+ * Streaming render harness so the founder can feel the real strategy on a phone
+ * BEFORE the live editor is touched. The model:
+ *   - Open INSTANTLY: read all page sizes (cheap), lay out every page slot at
+ *     the correct dimensions immediately. Scrollbar is right from t=0; nothing
+ *     reflows. Only pixels stream in.
+ *   - STREAM like GTA maps: rasterize only pages near the viewport; release the
+ *     far ones to free memory. Memory stays bounded on ANY document size — the
+ *     only thing that survives "1 juta phones" (mostly low-end Android).
+ *   - Placeholders, never blank → fast-scroll reads as loading, not flicker.
  *
- * Nothing here touches the live app. Not linked from anywhere; robots-noindex.
+ * Nothing here touches the live app (separate page, noindex, unlinked).
  */
 import { createDoc, createAnnotation } from './core/model.js';
 import { addAnnotation } from './core/operations.js';
-import { importPdf, rasterizePage } from './core/import.js';
-import { renderPageView } from './render/page-view.js';
+import { importPdf, createPageRasterizer } from './core/import.js';
+import { renderPageView, setPageRaster, clearPageRaster } from './render/page-view.js';
 
 window.pdfjsLib.GlobalWorkerOptions.workerSrc = '/js/vendor/pdf.worker.min.js';
 
+const scrollEl = document.getElementById('pv-scroll');
 const stage = document.getElementById('pv-stage');
 const statusEl = document.getElementById('lab-status');
 const setStatus = (s) => { statusEl.textContent = s; };
 
 let zoom = 1;
-function applyZoom() { stage.style.transform = `scale(${zoom})`; }
+function applyZoom() { stage.style.transform = `scale(${zoom})`; scheduleWindow(); }
 document.getElementById('z-in').onclick = () => { zoom = Math.min(zoom + 0.2, 3); applyZoom(); };
 document.getElementById('z-out').onclick = () => { zoom = Math.max(zoom - 0.2, 0.3); applyZoom(); };
 
-// Load a document from bytes, rasterize every page, render the column.
+let slots = [];          // [{ page, view }]
+let rasterizer = null;   // per-source PDF.js doc cache
+let ticking = false;
+
 async function loadDoc(name, bytes) {
-  setStatus('memuat…');
-  stage.innerHTML = '';
+  if (rasterizer) await rasterizer.destroy();
+  slots = []; stage.innerHTML = '';
+  setStatus('membuka…');
+
   const doc = createDoc();
-  const pages = await importPdf(doc, { name, bytes });
+  const pages = await importPdf(doc, { name, bytes }); // instant: metadata only
 
-  // A draggable demo annotation on page 1 — proves "active object always on top".
-  const demo = addAnnotation(doc, pages[0].id,
-    createAnnotation('text', { text: 'Seret aku ✍️  (aku selalu di atas)', x: 60, y: 140, fontSize: 22, color: '#111', bold: true }));
+  // A draggable demo annotation on page 1 — proves "active object always on top",
+  // and that it stays put even while the page image streams in/out underneath.
+  const demo = addAnnotation(doc, pages[0].id, createAnnotation('text', {
+    text: 'Seret aku ✍️ (selalu di atas)', x: 48, y: 120, fontSize: 22, color: '#111', bold: true,
+  }));
 
-  // Fit the first page to the viewport width for a sensible default zoom.
-  const fit = Math.min(1, (stage.parentElement.clientWidth - 32) / pages[0].width);
-  zoom = fit; applyZoom();
+  const fit = Math.min(1, (scrollEl.clientWidth - 32) / pages[0].width);
+  zoom = fit; stage.style.transform = `scale(${zoom})`;
 
+  // Lay out EVERY slot immediately (correct size + placeholder). Instant open.
   for (const page of pages) {
-    await rasterizePage(doc, page, { scale: 2 });
     const view = renderPageView(page, { activeId: demo.id });
     stage.appendChild(view);
-    setStatus(`${stage.children.length}/${pages.length} halaman`);
+    slots.push({ page, view });
   }
-  setStatus(`${pages.length} halaman · seret teks hijau, scroll, zoom ± — cek flicker`);
-
   wireDemoDrag(doc, demo);
+
+  rasterizer = createPageRasterizer(doc);
+  setStatus(`${pages.length} halaman — dibuka langsung, isi mengalir saat scroll`);
+  updateWindow(); // rasterize whatever's on screen now
 }
 
-// Pointer-based drag (works mouse + touch). Updates the annotation in the core
-// model, then moves its element. Screen delta is divided by zoom so it tracks
-// the finger 1:1 at any zoom.
+// The GTA-streaming core: rasterize pages within ~2 screens of the viewport,
+// release pages beyond ~4 screens. Bounded memory, any doc size.
+function updateWindow() {
+  if (!rasterizer || slots.length === 0) return;
+  const sc = scrollEl.getBoundingClientRect();
+  const loadPad = sc.height * 2;
+  const keepPad = sc.height * 4;
+
+  for (const slot of slots) {
+    const r = slot.view.getBoundingClientRect();
+    const near = r.bottom > sc.top - loadPad && r.top < sc.bottom + loadPad;
+    const far = r.bottom < sc.top - keepPad || r.top > sc.bottom + keepPad;
+
+    if (near && !slot.page.raster && !slot.loading) {
+      slot.loading = true;
+      rasterizer.rasterize(slot.page, { scale: 2 })
+        .then((raster) => { setPageRaster(slot.view, raster); slot.loading = false; })
+        .catch(() => { slot.loading = false; });
+    } else if (far && slot.page.raster) {
+      clearPageRaster(slot.view);   // free memory — scroll-back re-rasterizes
+      slot.page.raster = null;
+    }
+  }
+}
+
+function scheduleWindow() {
+  if (ticking) return;
+  ticking = true;
+  requestAnimationFrame(() => { ticking = false; updateWindow(); });
+}
+scrollEl.addEventListener('scroll', scheduleWindow, { passive: true });
+window.addEventListener('resize', scheduleWindow);
+
+// Pointer-based drag (mouse + touch). Updates the core model, moves the element.
+// Screen delta ÷ zoom so it tracks the finger 1:1 at any zoom.
 function wireDemoDrag(doc, anno) {
   const el = stage.querySelector(`[data-anno-id="${anno.id}"]`);
   if (!el) return;
@@ -79,13 +124,12 @@ function wireDemoDrag(doc, anno) {
   el.addEventListener('pointercancel', end);
 }
 
-// Wire the file picker + auto-load the bundled sample so it's alive on open.
 document.getElementById('lab-file').addEventListener('change', async (e) => {
   const file = e.target.files[0];
   if (!file) return;
   const bytes = new Uint8Array(await file.arrayBuffer());
-  loadDoc(file.name, bytes).catch((err) => { console.error(err); setStatus('gagal memuat'); });
   e.target.value = '';
+  loadDoc(file.name, bytes).catch((err) => { console.error(err); setStatus('gagal memuat'); });
 });
 
 (async () => {

--- a/js/render/page-view.js
+++ b/js/render/page-view.js
@@ -27,15 +27,8 @@ export function renderPageView(page, { activeId = null } = {}) {
     `position:relative;flex:0 0 auto;width:${page.width}px;height:${page.height}px;` +
     'background:#fff;box-shadow:0 2px 14px rgba(0,0,0,.14);border-radius:2px';
 
-  if (page.raster) {
-    const img = document.createElement('img');
-    img.className = 'pv-bg';
-    img.src = page.raster.dataUrl;
-    img.draggable = false;
-    img.alt = '';
-    img.style.cssText = 'position:absolute;inset:0;width:100%;height:100%;user-select:none;pointer-events:none';
-    view.appendChild(img);
-  }
+  if (page.raster) attachRaster(view, page.raster);
+  else attachPlaceholder(view);
 
   const overlay = document.createElement('div');
   overlay.className = 'pv-overlay';
@@ -47,6 +40,49 @@ export function renderPageView(page, { activeId = null } = {}) {
   }
   view.appendChild(overlay);
   return view;
+}
+
+// ---- streaming helpers (Phase 2: swap in / release the page image) ---------
+
+// A calm "loading" placeholder — shown for pages not yet rasterized. NOT blank,
+// so fast-scroll reads as loading, not flicker.
+function attachPlaceholder(view) {
+  if (view.querySelector('.pv-ph') || view.querySelector('.pv-bg')) return;
+  const ph = document.createElement('div');
+  ph.className = 'pv-ph';
+  ph.style.cssText =
+    'position:absolute;inset:0;display:flex;align-items:center;justify-content:center;' +
+    'color:#c4c4c4;font-size:13px;background:#fff';
+  ph.textContent = 'memuat…';
+  view.insertBefore(ph, view.firstChild);
+}
+
+function attachRaster(view, raster) {
+  const img = document.createElement('img');
+  img.className = 'pv-bg';
+  img.src = raster.dataUrl;
+  img.draggable = false;
+  img.alt = '';
+  img.style.cssText =
+    'position:absolute;inset:0;width:100%;height:100%;user-select:none;pointer-events:none;' +
+    'opacity:0;transition:opacity .12s ease';
+  view.insertBefore(img, view.firstChild);
+  requestAnimationFrame(() => { img.style.opacity = '1'; });
+  return img;
+}
+
+// Called when a page enters the window and has been rasterized.
+export function setPageRaster(view, raster) {
+  if (view.querySelector('.pv-bg')) return;
+  view.querySelector('.pv-ph')?.remove();
+  attachRaster(view, raster);
+}
+
+// Called when a page leaves the window — drop the image to free memory, restore
+// the placeholder. Scrolling back re-rasterizes it (a brief, bounded load).
+export function clearPageRaster(view) {
+  view.querySelector('.pv-bg')?.remove();
+  attachPlaceholder(view);
 }
 
 // One annotation as a positioned DOM element (page-space px).

--- a/tests/lab-render.spec.js
+++ b/tests/lab-render.spec.js
@@ -12,13 +12,15 @@ test.describe('render engine preview (lab)', () => {
   test('renders image-backed pages with the active annotation on top', async ({ page }) => {
     await page.goto('/lab.html');
 
-    // Core import + rasterize + render: the bundled 2-page sample auto-loads.
+    // Slots are laid out INSTANTLY (streaming: metadata first, pixels later).
     await page.waitForFunction(
       () => document.querySelectorAll('.pv-page').length === 2,
       null, { timeout: 10_000 });
 
-    // Backgrounds are real rasterized PNGs (not live canvases).
-    expect(await page.locator('.pv-bg').count()).toBe(2);
+    // Both sample pages are near the viewport → they stream in as real PNGs.
+    await page.waitForFunction(
+      () => document.querySelectorAll('.pv-bg').length === 2,
+      null, { timeout: 10_000 });
     const bgIsPng = await page.evaluate(() =>
       (document.querySelector('.pv-bg')?.src || '').startsWith('data:image/png'));
     expect(bgIsPng).toBe(true);


### PR DESCRIPTION
## Foundation rebuild — Phase 2 (in the lab)

Founder tested Phase 1a on real Android: **much smoother**, but the first-load fast-scroll flickered. Cause: the lab rasterized **all** pages eagerly (pop-in), which also doesn't scale — a big PDF on a low-end phone would OOM. Fix = **stream like GTA maps**.

- **`core/import.js`** — `createPageRasterizer(doc)`: caches the PDF.js document per source so windowed rendering rasterizes many pages without reloading the PDF each time.
- **`render/page-view.js`** — a calm placeholder (`memuat…`, never blank) + `setPageRaster` (fade in) / `clearPageRaster` (release to free memory).
- **`lab.js`** — lay out **every** page slot instantly at the correct size (stable layout, scrollbar right from t=0, no reflow), then rasterize only pages within ~2 screens and **release** beyond ~4. **Memory stays bounded regardless of page count** — the only thing that survives "1 juta phones."

### How to judge it
Open **pdflokal.id/lab.html** on Android, **Buka PDF** → load a **big** file (20–100+ pages). It should **open instantly**, scroll smoothly, show calm "memuat…" placeholders when you outrun the loader (not a flash), and never crash. Scroll back → a released page re-loads briefly.

### Safety
Separate page, zero impact on the live app.

### Verification
- `npm run test:core` 7/7 · adapter + lab browser tests green · lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)