### PR TITLE
feat(render): lab — render-on-settle

### DIFF
--- a/js/lab.js
+++ b/js/lab.js
@@ -26,7 +26,7 @@ const statusEl = document.getElementById('lab-status');
 const setStatus = (s) => { statusEl.textContent = s; };
 
 let zoom = 1;
-function applyZoom() { stage.style.transform = `scale(${zoom})`; scheduleWindow(); }
+function applyZoom() { stage.style.transform = `scale(${zoom})`; updateWindow(0); }
 document.getElementById('z-in').onclick = () => { zoom = Math.min(zoom + 0.2, 3); applyZoom(); };
 document.getElementById('z-out').onclick = () => { zoom = Math.max(zoom - 0.2, 0.3); applyZoom(); };
 
@@ -51,12 +51,12 @@ async function loadDoc(name, bytes) {
   const fit = Math.min(1, (scrollEl.clientWidth - 32) / pages[0].width);
   zoom = fit; stage.style.transform = `scale(${zoom})`;
 
-  // Lay out EVERY slot immediately (correct size + placeholder). Instant open.
-  for (const page of pages) {
-    const view = renderPageView(page, { activeId: demo.id });
+  // Lay out EVERY slot immediately (correct size + numbered placeholder). Instant open.
+  pages.forEach((page, i) => {
+    const view = renderPageView(page, { activeId: demo.id, label: `Hal ${i + 1}` });
     stage.appendChild(view);
     slots.push({ page, view });
-  }
+  });
   wireDemoDrag(doc, demo);
 
   rasterizer = createPageRasterizer(doc);
@@ -65,37 +65,56 @@ async function loadDoc(name, bytes) {
 }
 
 // The GTA-streaming core: rasterize pages within ~2 screens of the viewport,
-// release pages beyond ~4 screens. Bounded memory, any doc size.
-function updateWindow() {
+// release pages beyond ~4 screens (bounded memory, any doc size).
+//
+// RENDER-ON-SETTLE: while the finger is flinging fast, we DON'T rasterize — you
+// aren't reading, you're travelling, and we'd never keep up anyway. We still
+// RELEASE far pages (keep memory bounded) and show numbered placeholders. The
+// moment the scroll settles, we catch up and sharpen. Never fights the user;
+// saves the weak phone's battery on pages you fling past.
+const FLING = 45; // px/frame above which we treat it as "travelling", not reading
+
+function updateWindow(velocity = 0) {
   if (!rasterizer || slots.length === 0) return;
   const sc = scrollEl.getBoundingClientRect();
   const loadPad = sc.height * 2;
   const keepPad = sc.height * 4;
+  const flinging = velocity > FLING;
 
   for (const slot of slots) {
     const r = slot.view.getBoundingClientRect();
     const near = r.bottom > sc.top - loadPad && r.top < sc.bottom + loadPad;
     const far = r.bottom < sc.top - keepPad || r.top > sc.bottom + keepPad;
 
-    if (near && !slot.page.raster && !slot.loading) {
-      slot.loading = true;
+    if (far && slot.page.raster) {
+      clearPageRaster(slot.view);   // release always — bounds memory even mid-fling
+      slot.page.raster = null;
+    } else if (near && !flinging && !slot.page.raster && !slot.loading) {
+      slot.loading = true;          // rasterize only when NOT flinging
       rasterizer.rasterize(slot.page, { scale: 2 })
         .then((raster) => { setPageRaster(slot.view, raster); slot.loading = false; })
         .catch(() => { slot.loading = false; });
-    } else if (far && slot.page.raster) {
-      clearPageRaster(slot.view);   // free memory — scroll-back re-rasterizes
-      slot.page.raster = null;
     }
   }
 }
 
-function scheduleWindow() {
-  if (ticking) return;
-  ticking = true;
-  requestAnimationFrame(() => { ticking = false; updateWindow(); });
+let lastTop = 0, settleTimer = null;
+function onScroll() {
+  if (!ticking) {
+    ticking = true;
+    requestAnimationFrame(() => {
+      ticking = false;
+      const top = scrollEl.scrollTop;
+      const v = Math.abs(top - lastTop);
+      lastTop = top;
+      updateWindow(v);            // gated: skips rasterizing during a fast fling
+    });
+  }
+  clearTimeout(settleTimer);
+  settleTimer = setTimeout(() => updateWindow(0), 130); // catch up once it settles
 }
-scrollEl.addEventListener('scroll', scheduleWindow, { passive: true });
-window.addEventListener('resize', scheduleWindow);
+scrollEl.addEventListener('scroll', onScroll, { passive: true });
+window.addEventListener('resize', () => updateWindow(0));
 
 // Pointer-based drag (mouse + touch). Updates the core model, moves the element.
 // Screen delta ÷ zoom so it tracks the finger 1:1 at any zoom.

--- a/js/render/page-view.js
+++ b/js/render/page-view.js
@@ -19,13 +19,19 @@
 
 // Render a full page view (background + annotation overlay).
 // opts.activeId = id of the currently-active annotation → rendered on top.
-export function renderPageView(page, { activeId = null } = {}) {
+// opts.label   = placeholder caption (e.g. "Hal 42").
+export function renderPageView(page, opts = {}) {
+  const { activeId = null } = opts;
   const view = document.createElement('div');
   view.className = 'pv-page';
   view.dataset.pageId = page.id;
   view.style.cssText =
     `position:relative;flex:0 0 auto;width:${page.width}px;height:${page.height}px;` +
     'background:#fff;box-shadow:0 2px 14px rgba(0,0,0,.14);border-radius:2px';
+
+  // Intentional placeholder text (e.g. "Hal 42") so a flung-past page reads as
+  // "loading", not "broken". Stored on the view so clearPageRaster can reuse it.
+  if (opts.label) view.dataset.phLabel = opts.label;
 
   if (page.raster) attachRaster(view, page.raster);
   else attachPlaceholder(view);
@@ -53,7 +59,7 @@ function attachPlaceholder(view) {
   ph.style.cssText =
     'position:absolute;inset:0;display:flex;align-items:center;justify-content:center;' +
     'color:#c4c4c4;font-size:13px;background:#fff';
-  ph.textContent = 'memuat…';
+  ph.textContent = view.dataset.phLabel || 'memuat…';
   view.insertBefore(ph, view.firstChild);
 }
 


### PR DESCRIPTION
Founder's "manage scroll speed" idea, done the non-hostile way: **don't cap the user's scroll** (that feels broken) — slow the *rendering* to match intent. While flinging fast we skip rasterizing (you're travelling, not reading) but still release far pages (bounded memory) and show numbered `Hal N` placeholders; the moment scroll settles we catch up and sharpen. Saves weak-phone battery too. Separate page, zero app impact. Tests + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)