### PR TITLE
feat: Editor v2 — clean rebuild on the headless core (hidden beta at /editor-v2.html)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,6 +21,8 @@ jobs:
           filters: |
             runnable:
               - 'index.html'
+              - 'editor-v2.html'
+              - 'lab.html'
               - 'dukung.html'
               - 'privasi.html'
               - 'style.css'

--- a/docs/android-verification.md
+++ b/docs/android-verification.md
@@ -1,0 +1,58 @@
+# Android Verification Loop (tier 2)
+
+> **What this solves:** the old workflow's biggest friction — only the founder could
+> verify mobile work, on his physical phone. Now the agent can self-verify on
+> **real Android Chrome** (real compositor, real GPU raster path, Android keyboard)
+> in an emulator, and the founder's phone becomes the *final* gate, not the inner loop.
+
+## The two tiers
+
+| Tier | What | Catches | Cost |
+|------|------|---------|------|
+| 1 | Playwright `mobile-chrome` project (Pixel 7 descriptor: touch, 412×915, DPR 2.6) | layout, touch-event logic, viewport bugs | free, runs in CI on every PR (`npm run test:mobile`) |
+| 2 | Android emulator (AVD) + real Chrome, driven via adb + CDP | compositor/GPU class, Android keyboard, real scrolling physics | local only, needs the emulator running |
+| final | Founder's physical phone (low-end reality, real network, real hands) | everything else | founder's time — spend it only on merge gates |
+
+An emulator on an M-series Mac is **not** a Rp1-juta phone: it has the host's GPU and
+RAM. Treat tier 2 as "real Chrome, ideal hardware". Memory-pressure behavior still
+needs the low-end physical device.
+
+## One-time setup (already done Jul 2026)
+
+Installed via Homebrew + sdkmanager (~10GB total):
+- OpenJDK (`brew install openjdk`) — sdkmanager needs it
+- `brew install --cask android-commandlinetools`
+- SDK packages into `~/Library/Android/sdk`: `platform-tools`, `emulator`,
+  `system-images;android-35;google_apis_playstore;arm64-v8a` (Play image = Chrome preinstalled)
+- `cmdline-tools;latest` installed INTO the sdk root (the Homebrew copy can't see
+  the SDK — it resolves the root from its own path)
+- AVD: `pdflokal-test` (Pixel 7, Android 15, arm64 — boots in ~15s on Apple Silicon)
+
+## Daily use
+
+```bash
+# 1. boot the emulator (headless; ~15s)
+~/Library/Android/sdk/emulator/emulator -avd pdflokal-test -no-window -no-audio -no-boot-anim &
+
+# 2. serve the app
+npx serve -p 5050 --no-clipboard .
+
+# 3. drive real Chrome + screenshot (loads the 2-page fixture into editor-v2)
+node scripts/android-verify.mjs /editor-v2.html my-check
+```
+
+`scripts/android-verify.mjs` does the plumbing every run (idempotent):
+- `adb reverse tcp:5050 tcp:5050` — the device's localhost:5050 → the Mac's server
+- `adb forward tcp:9222 localabstract:chrome_devtools_remote` — Chrome's DevTools socket
+- `chromium.connectOverCDP('http://localhost:9222')` — full Playwright control of the
+  REAL Chrome (goto, setInputFiles, locators, screenshots — everything works)
+
+## Gotchas
+
+- **Chrome first-run:** a fresh AVD shows Chrome's welcome + notification prompts once.
+  Tap through manually (`adb shell input tap …` after `adb exec-out screencap`) or just
+  do it once — the AVD persists state across boots.
+- The Play-Store image is **not rootable** (`adb root` fails) — fine, nothing here needs root.
+- Docker-Android is a dead end on macOS (no KVM). Don't retry it.
+- Emulator screencap: `adb exec-out screencap -p > shot.png` (whole device); the script's
+  Playwright screenshot is page-only and usually what you want.

--- a/docs/roadmap-2.md
+++ b/docs/roadmap-2.md
@@ -13,17 +13,28 @@ _Updated: 2026-07 — **pivoted** from a pure backlog-flush to a vision-led foun
 
 ---
 
-## ★ THE SPINE — Foundation rebuild (priority) → [foundation-plan.md](foundation-plan.md)
+## ★ THE SPINE — Editor v2: clean rebuild & swap → [foundation-plan.md](foundation-plan.md)
 
-Target: 3 clean layers — **Core** (headless `js/core/`) / **Render** (image-backed pages + one annotation overlay) / **Interact** (one input path). Built *beside* the live app, swapped in incrementally. No big-bang.
+> **Strategy revised Jul 2 2026** (decisions.md): the old "wire the engine into the live
+> editor behind a flag" plan is retired. Audit verdict: only ~800 of the live editor's
+> 4,200 LOC are salvageable math; incremental wiring needs throwaway index↔id shims.
+> Instead: **build Editor v2 clean on `js/core` + `js/render`, BESIDE the live app
+> (`editor-v2.html`, noindex/unlinked), reach parity on merge→edit→download, then swap
+> `index.html` to it and delete the old editor.** Founder approved.
 
-- [x] **Phase 0** — headless core: one `Doc` model, page owns its annotations, everything by id not index. 7 headless tests. · **#81**
-- [x] **Phase 0b** — import adapter: `importPdf` (bytes→Doc) + `rasterizePage` + `createPageRasterizer` (per-source doc cache). · **#82**
-- [x] **Phase 1a** — image-backed render engine (`js/render/page-view.js`) + phone-openable preview `lab.html`. · **#83**
-- [x] **Phase 2 (in the lab)** — streaming/windowed loading (bounded memory), render-on-settle, scroll telegraph (shimmer + position pill). **Validated on real Android. Rendering approach LOCKED** (`memory/render-architecture-2026-07.md`). · **#84 #85 #86**
-- [ ] **Phase 0c** — export adapter: `Doc → pdf-lib → bytes`, golden-verified. _(open — completes the headless round-trip)_
-- [ ] **Phase 1b / 3** — wire the engine into the **LIVE editor** behind a flag; retire the old canvas pipeline. ⬅ **NEXT (the big, risky step).** Real-Android verify before merge. **Kills mobile flicker + slides-behind + paraf z-index — structurally.**
-- [ ] **Phase 4** — reactive subscribers, IF state-sync pain remains (tentative — verify pain first).
+- [x] **Phase 0** — headless core (`Doc` model, id-based). · **#81**
+- [x] **Phase 0b** — import adapter (bytes→Doc, lazy rasterize). · **#82**
+- [x] **Phase 1a + 2** — image-backed render + streaming + settle + telegraph, validated on real Android; **approach LOCKED**. · **#83–86**
+- [x] **Engine completion (Jul 2)** — `core/history.js` (ONE unified undo/redo), move/resize ops, `core/export.js` (Doc→pdf-lib, pixel-verified — found 2 live bugs in the old exporter), `render/viewport.js` (streaming extracted from lab), `render/interaction.js` (one pointer path, DOM hit-testing, gesture-level undo).
+- [x] **v2 skeleton (Jul 2)** — `editor-v2.html` + `js/v2/app.js`: load/merge → text (tap-to-type) → whiteout (drag) → signature (draw+place) → undo/redo → download. Container scroll. First mobile touch tests green; verified on real Android Chrome (emulator).
+- [ ] **v2 parity** — text format bar (font/B/I/size/color) · paraf + semua-hal · page management (reorder/delete/rotate + sidebar/picker) · image-as-page import · Ganti File · keyboard shortcuts · file-size guards · a11y pass. ⬅ **NEXT**
+- [ ] **The swap** — full test suite + founder's real-phone gate on merge→edit→download → `index.html` points at v2 → cleanup agent deletes the old editor (~3,400 LOC) + its CSS.
+- [ ] **Phase 4** — reactive subscribers, IF state-sync pain remains (tentative).
+
+### Mobile verification (the gap, closed Jul 2 — [android-verification.md](android-verification.md))
+- **Tier 1:** Playwright `mobile-chrome` project (Pixel 7 touch emulation) — `npm run test:mobile`, runs in CI.
+- **Tier 2:** Android emulator (Pixel 7 AVD, boots ~15s) + real Chrome driven via adb+CDP — `node scripts/android-verify.mjs`.
+- **Final gate only:** founder's physical phone.
 
 ### ⤷ Absorbed by the foundation — do NOT fix separately
 - **Wave 2 (performance / mobile-canvas / pinch-zoom flicker / fast-scroll jump-to-page-1)** → **Phase 1 + 2.** Same root cause (no-eviction memory pressure), same fix (image pages + windowed rendering).

--- a/editor-v2.html
+++ b/editor-v2.html
@@ -390,7 +390,7 @@
     </div>
   </dialog>
 
-  <input type="file" id="file-input" accept="application/pdf" multiple hidden>
+  <input type="file" id="file-input" accept="application/pdf,image/*" multiple hidden>
 
   <script src="js/vendor/pdf.min.js"></script>
   <script src="js/vendor/pdf-lib.min.js"></script>

--- a/editor-v2.html
+++ b/editor-v2.html
@@ -240,6 +240,41 @@
     .pm-bulk button:disabled { opacity: .35; }
     .pm-bulk .btn-ghost { border: none; background: none; }
 
+    /* ---- signature modal extras ---- */
+    .sig-tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--line); }
+    .sig-tab {
+      padding: 8px 14px; font-size: 13.5px; color: var(--muted);
+      border-bottom: 2px solid transparent; border-radius: 0; min-height: 40px;
+    }
+    .sig-tab.on { color: var(--accent); border-bottom-color: var(--accent); font-weight: 600; }
+    .sig-inline { align-self: flex-start; font-size: 13px; }
+    .sig-pane-draw { display: flex; flex-direction: column; gap: 6px; }
+    .sig-pane-upload { display: flex; flex-direction: column; gap: 10px; }
+    .sig-upload-drop {
+      display: flex; align-items: center; justify-content: center; min-height: 64px;
+      border: 1.5px dashed var(--line); border-radius: 10px; cursor: pointer;
+      color: var(--muted); font-size: 14px;
+    }
+    .sig-check { display: flex; align-items: center; gap: 8px; font-size: 13px; color: var(--ink); min-height: 32px; }
+    .sig-check input { width: 17px; height: 17px; accent-color: var(--accent); }
+    .sig-preview { display: flex; justify-content: center; }
+    .sig-preview canvas {
+      max-width: 100%; max-height: 140px; border-radius: 8px;
+      background: repeating-conic-gradient(#eee 0% 25%, #fff 0% 50%) 0 0/14px 14px;
+    }
+
+    /* signature context strip ("Semua Hal.") */
+    #sig-bar {
+      display: none; align-items: center; gap: 8px; height: 46px; flex: 0 0 auto;
+      padding: 0 10px; background: var(--surface); border-bottom: 1px solid var(--line);
+      font-size: 12.5px; color: var(--muted);
+    }
+    #sig-bar.show { display: flex; }
+    #sig-bar button {
+      min-height: 34px; padding: 0 13px; border-radius: 8px;
+      border: 1px solid var(--line); background: var(--bg); font-size: 13px;
+    }
+
     #toast {
       position: fixed; left: 50%; transform: translateX(-50%); bottom: 130px; z-index: 40;
       background: rgba(26,29,33,.9); color: #fff; font-size: 13px;
@@ -289,6 +324,10 @@
   </div>
 
   <div id="format-bar" role="toolbar" aria-label="Format teks"></div>
+  <div id="sig-bar" role="toolbar" aria-label="Aksi tanda tangan">
+    <span id="sig-bar-label"></span>
+    <button id="btn-all-pages">Terapkan ke Semua Hal.</button>
+  </div>
 
   <main id="v2-scroll">
     <div id="v2-stage"></div>
@@ -327,10 +366,24 @@
 
   <dialog id="sig-modal" aria-label="Buat tanda tangan">
     <div class="sheet">
-      <h2>Gambar tanda tanganmu</h2>
-      <canvas id="sig-canvas"></canvas>
+      <div class="sig-tabs" role="tablist">
+        <button class="sig-tab on" data-tab="draw" role="tab" aria-selected="true">Gambar</button>
+        <button class="sig-tab" data-tab="upload" role="tab" aria-selected="false">Upload</button>
+      </div>
+      <div class="sig-pane-draw">
+        <canvas id="sig-canvas"></canvas>
+        <button class="btn-ghost sig-inline" id="sig-clear">Ulangi</button>
+      </div>
+      <div class="sig-pane-upload" style="display:none">
+        <label class="sig-upload-drop">
+          <input type="file" id="sig-file" accept="image/*" hidden>
+          <span>Pilih foto tanda tangan 📷</span>
+        </label>
+        <label class="sig-check"><input type="checkbox" id="sig-removebg" checked> Hapus latar putih</label>
+        <div id="sig-preview" class="sig-preview"></div>
+      </div>
+      <label class="sig-check"><input type="checkbox" id="sig-paraf"> Jadikan paraf (inisial, lebih kecil)</label>
       <div class="sheet-actions">
-        <button class="btn-ghost" id="sig-clear">Ulangi</button>
         <button class="btn-ghost" id="sig-cancel">Batal</button>
         <button class="btn-primary" id="sig-use">Pakai</button>
       </div>

--- a/editor-v2.html
+++ b/editor-v2.html
@@ -108,10 +108,15 @@
       -webkit-overflow-scrolling: touch;
       position: relative;
     }
+    /* Zoom = transform:scale on the stage; the sizer carries the SCALED layout
+       size so the scroll container is always correct. transform (not CSS zoom):
+       zoom's coordinate reporting was quirky before Chrome 128 — a real
+       old-Android problem for this market. transform is standardized everywhere. */
+    #v2-sizer { position: relative; margin: 0 auto; padding: 16px 0 90px; }
     #v2-stage {
+      position: absolute; top: 16px; left: 0;
       display: flex; flex-direction: column; align-items: center; gap: 16px;
-      padding: 16px 8px 90px;
-      transform-origin: top center;
+      transform-origin: top left;
     }
 
     /* placeholder shimmer (telegraph: "loading", not "broken") */
@@ -294,9 +299,6 @@
     <button class="icon-btn" id="btn-redo" disabled aria-label="Ulangi" title="Ulangi (Ctrl+Y)">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>
     </button>
-    <button class="icon-btn" id="btn-pages" disabled aria-label="Kelola halaman" title="Kelola halaman">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
-    </button>
     <button id="btn-download" disabled>Unduh</button>
   </header>
 
@@ -321,6 +323,10 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
       Hapus
     </button>
+    <button class="tool" id="btn-pages" disabled aria-label="Kelola halaman — urutkan, putar, hapus, ekstrak">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+      Halaman
+    </button>
   </div>
 
   <div id="format-bar" role="toolbar" aria-label="Format teks"></div>
@@ -330,7 +336,7 @@
   </div>
 
   <main id="v2-scroll">
-    <div id="v2-stage"></div>
+    <div id="v2-sizer"><div id="v2-stage"></div></div>
     <div id="empty">
       <h1>Edit PDF langsung di HP-mu</h1>
       <p>Gabung, tanda tangan, tulis, dan tutup teks — semua diproses di perangkatmu, nggak ada yang di-upload.</p>

--- a/editor-v2.html
+++ b/editor-v2.html
@@ -17,6 +17,16 @@
       --accent: #4f8ef7; --line: rgba(0,0,0,.08);
       --header-h: 44px; --toolbar-h: 52px;
     }
+    /* Self-hosted fonts (preview parity with the PDF export) */
+    @font-face { font-family: 'Montserrat'; src: url('fonts/montserrat-regular.woff2') format('woff2'); font-weight: 400; font-style: normal; font-display: swap; }
+    @font-face { font-family: 'Montserrat'; src: url('fonts/montserrat-bold.woff2') format('woff2'); font-weight: 700; font-style: normal; font-display: swap; }
+    @font-face { font-family: 'Montserrat'; src: url('fonts/montserrat-italic.woff2') format('woff2'); font-weight: 400; font-style: italic; font-display: swap; }
+    @font-face { font-family: 'Montserrat'; src: url('fonts/montserrat-bolditalic.woff2') format('woff2'); font-weight: 700; font-style: italic; font-display: swap; }
+    @font-face { font-family: 'Carlito'; src: url('fonts/carlito-regular.woff2') format('woff2'); font-weight: 400; font-style: normal; font-display: swap; }
+    @font-face { font-family: 'Carlito'; src: url('fonts/carlito-bold.woff2') format('woff2'); font-weight: 700; font-style: normal; font-display: swap; }
+    @font-face { font-family: 'Carlito'; src: url('fonts/carlito-italic.woff2') format('woff2'); font-weight: 400; font-style: italic; font-display: swap; }
+    @font-face { font-family: 'Carlito'; src: url('fonts/carlito-bolditalic.woff2') format('woff2'); font-weight: 700; font-style: italic; font-display: swap; }
+
     * { margin: 0; padding: 0; box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
     html, body { height: 100%; overflow: hidden; }
     body {
@@ -64,6 +74,32 @@
     }
     .tool svg { width: 19px; height: 19px; }
     .tool.active { background: rgba(79,142,247,.12); color: var(--accent); }
+
+    /* ---- format bar: contextual, only when text is in play ---- */
+    #format-bar {
+      display: none; align-items: center; gap: 6px;
+      height: 46px; flex: 0 0 auto; padding: 0 10px;
+      background: var(--surface); border-bottom: 1px solid var(--line);
+      overflow-x: auto; scrollbar-width: none;
+    }
+    #format-bar.show { display: flex; }
+    #format-bar select {
+      font: inherit; font-size: 13px; min-height: 34px; border-radius: 8px;
+      border: 1px solid var(--line); background: var(--bg); padding: 0 6px; color: var(--ink);
+    }
+    .fb-font { max-width: 118px; }
+    .fb-toggle {
+      min-width: 34px; min-height: 34px; border: 1px solid var(--line); border-radius: 8px;
+      font-size: 14px; color: var(--muted); background: var(--bg);
+    }
+    .fb-bold { font-weight: 800; }
+    .fb-italic { font-style: italic; font-family: Georgia, serif; }
+    .fb-toggle.on { background: rgba(79,142,247,.14); color: var(--accent); border-color: var(--accent); }
+    .fb-color {
+      width: 26px; height: 26px; min-height: 26px; border-radius: 50%;
+      border: 1.5px solid var(--line); flex: 0 0 auto;
+    }
+    .fb-color.on { box-shadow: 0 0 0 2.5px var(--accent); }
 
     /* ---- document area: CONTAINER scroll (kills edge-overscroll flicker) ---- */
     #v2-scroll {
@@ -197,6 +233,8 @@
       Hapus
     </button>
   </div>
+
+  <div id="format-bar" role="toolbar" aria-label="Format teks"></div>
 
   <main id="v2-scroll">
     <div id="v2-stage"></div>

--- a/editor-v2.html
+++ b/editor-v2.html
@@ -189,6 +189,57 @@
     .btn-ghost { color: var(--muted); padding: 0 14px; }
     .btn-primary { background: var(--accent); color: #fff; font-weight: 600; padding: 0 16px; border-radius: 8px; min-height: 40px; }
 
+    /* ---- page manager sheet ---- */
+    .pm-sheet-body { max-width: 560px; max-height: 86vh; display: flex; flex-direction: column; }
+    .pm-head { display: flex; align-items: center; gap: 10px; }
+    .pm-head h2 { flex: 0 0 auto; }
+    .pm-hint { flex: 1; font-size: 10.5px; color: var(--muted); line-height: 1.3; }
+    .pm-grid {
+      flex: 1; overflow-y: auto; overscroll-behavior: contain;
+      display: grid; grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+      gap: 10px; padding: 4px 2px 8px;
+    }
+    .pm-tile {
+      position: relative; border-radius: 10px; border: 2px solid var(--line);
+      overflow: hidden; cursor: pointer; touch-action: pan-y; background: #fff;
+      min-height: 44px;
+    }
+    .pm-tile.sel { border-color: var(--accent); }
+    .pm-tile.dragging { opacity: .55; transform: scale(.95); z-index: 10; }
+    .pm-tile.drop-hint { border-color: var(--accent); border-style: dashed; }
+    .pm-thumb { width: 100%; background-size: cover; background-position: top center; background-color: #fafafa; }
+    .pm-num {
+      position: absolute; left: 4px; bottom: 4px;
+      background: rgba(26,29,33,.72); color: #fff; font-size: 10px; font-weight: 600;
+      padding: 1px 6px; border-radius: 6px; pointer-events: none;
+    }
+    .pm-check {
+      position: absolute; top: 4px; right: 4px; width: 22px; height: 22px;
+      display: none; align-items: center; justify-content: center;
+      background: var(--accent); color: #fff; font-size: 12px; border-radius: 50%;
+      pointer-events: none;
+    }
+    .pm-tile.sel .pm-check { display: flex; }
+    .pm-add {
+      display: flex; flex-direction: column; align-items: center; justify-content: center;
+      gap: 2px; color: var(--muted); font-size: 11px; border-style: dashed;
+      background: var(--bg); min-height: 110px; font-family: inherit;
+    }
+    .pm-add span { font-size: 22px; line-height: 1; }
+    .pm-bulk {
+      display: none; align-items: center; gap: 6px; padding-top: 10px;
+      border-top: 1px solid var(--line); flex-wrap: wrap;
+    }
+    .pm-bulk.show { display: flex; }
+    .pm-count { font-size: 12.5px; color: var(--muted); flex: 1; }
+    .pm-bulk button {
+      min-height: 38px; padding: 0 13px; border-radius: 8px;
+      border: 1px solid var(--line); background: var(--bg); font-size: 13px;
+    }
+    .pm-bulk button.danger { color: #d33131; border-color: rgba(211,49,49,.35); }
+    .pm-bulk button:disabled { opacity: .35; }
+    .pm-bulk .btn-ghost { border: none; background: none; }
+
     #toast {
       position: fixed; left: 50%; transform: translateX(-50%); bottom: 130px; z-index: 40;
       background: rgba(26,29,33,.9); color: #fff; font-size: 13px;
@@ -207,6 +258,9 @@
     </button>
     <button class="icon-btn" id="btn-redo" disabled aria-label="Ulangi" title="Ulangi (Ctrl+Y)">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>
+    </button>
+    <button class="icon-btn" id="btn-pages" disabled aria-label="Kelola halaman" title="Kelola halaman">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
     </button>
     <button id="btn-download" disabled>Unduh</button>
   </header>
@@ -252,6 +306,24 @@
     <button id="z-out" aria-label="Perkecil">−</button>
   </div>
   <div id="toast" role="status" aria-live="polite"></div>
+
+  <dialog id="pm-sheet" aria-label="Kelola halaman">
+    <div class="sheet pm-sheet-body">
+      <div class="pm-head">
+        <h2>Kelola Halaman</h2>
+        <span class="pm-hint">Ketuk untuk memilih · tahan lalu geser untuk mengurutkan</span>
+        <button class="btn-ghost" id="pm-close" aria-label="Tutup">✕</button>
+      </div>
+      <div id="pm-grid" class="pm-grid"></div>
+      <div id="pm-bulk" class="pm-bulk">
+        <span class="pm-count"></span>
+        <button data-act="rotate">Putar</button>
+        <button data-act="extract">Ekstrak</button>
+        <button data-act="delete" class="danger">Hapus</button>
+        <button data-act="clear" class="btn-ghost">Batal</button>
+      </div>
+    </div>
+  </dialog>
 
   <dialog id="sig-modal" aria-label="Buat tanda tangan">
     <div class="sheet">

--- a/editor-v2.html
+++ b/editor-v2.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <meta name="robots" content="noindex, nofollow">
+  <title>PDFLokal — Editor v2 (beta)</title>
+  <!--
+    Editor v2 — the clean rebuild on js/core + js/render (decision: Jul 2 2026,
+    decisions.md "clean rebuild & swap"). Lives BESIDE the live app: unlinked,
+    noindex, zero impact on index.html until the swap. Self-contained CSS on
+    purpose — style.css belongs to the old editor and dies with it.
+  -->
+  <style>
+    :root {
+      --bg: #f2f4f7; --surface: #ffffff; --ink: #1a1d21; --muted: #6b7280;
+      --accent: #4f8ef7; --line: rgba(0,0,0,.08);
+      --header-h: 44px; --toolbar-h: 52px;
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+    html, body { height: 100%; overflow: hidden; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: var(--bg); color: var(--ink);
+      display: flex; flex-direction: column;
+    }
+
+    /* ---- header ---- */
+    header {
+      height: var(--header-h); flex: 0 0 auto;
+      display: flex; align-items: center; gap: 8px; padding: 0 10px;
+      background: var(--surface); border-bottom: 1px solid var(--line);
+    }
+    .brand { font-weight: 700; font-size: 15px; }
+    .brand .beta { font-size: 10px; color: var(--accent); vertical-align: super; font-weight: 600; }
+    .spacer { flex: 1; }
+    button {
+      font: inherit; border: none; background: none; cursor: pointer; color: var(--ink);
+      border-radius: 8px; min-height: 36px;
+    }
+    .icon-btn {
+      width: 40px; display: inline-flex; align-items: center; justify-content: center;
+      color: var(--muted);
+    }
+    .icon-btn:disabled { opacity: .3; cursor: default; }
+    .icon-btn svg { width: 20px; height: 20px; }
+    #btn-download {
+      background: var(--accent); color: #fff; font-weight: 600; font-size: 13.5px;
+      padding: 0 14px; border-radius: 8px;
+    }
+    #btn-download:disabled { opacity: .4; }
+
+    /* ---- toolbar: tools are verbs; ≥44px targets; nothing hover-only ---- */
+    #toolbar {
+      height: var(--toolbar-h); flex: 0 0 auto;
+      display: flex; align-items: center; justify-content: center; gap: 4px;
+      background: var(--surface); border-bottom: 1px solid var(--line);
+      padding: 0 8px; overflow-x: auto;
+    }
+    .tool {
+      display: inline-flex; flex-direction: column; align-items: center; justify-content: center;
+      gap: 1px; min-width: 56px; height: 44px; border-radius: 10px;
+      font-size: 10.5px; color: var(--muted);
+    }
+    .tool svg { width: 19px; height: 19px; }
+    .tool.active { background: rgba(79,142,247,.12); color: var(--accent); }
+
+    /* ---- document area: CONTAINER scroll (kills edge-overscroll flicker) ---- */
+    #v2-scroll {
+      flex: 1; overflow-y: auto; overflow-x: hidden;
+      overscroll-behavior: contain;
+      -webkit-overflow-scrolling: touch;
+      position: relative;
+    }
+    #v2-stage {
+      display: flex; flex-direction: column; align-items: center; gap: 16px;
+      padding: 16px 8px 90px;
+      transform-origin: top center;
+    }
+
+    /* placeholder shimmer (telegraph: "loading", not "broken") */
+    .pv-ph { overflow: hidden; }
+    .pv-ph::after {
+      content: ''; position: absolute; inset: 0;
+      background: linear-gradient(100deg, transparent 30%, rgba(0,0,0,.045) 50%, transparent 70%);
+      animation: pv-shimmer 1.1s infinite;
+    }
+    @keyframes pv-shimmer {
+      from { transform: translateX(-100%); } to { transform: translateX(100%); }
+    }
+
+    /* position pill */
+    #v2-pill {
+      position: fixed; left: 50%; transform: translateX(-50%);
+      bottom: 76px; z-index: 30;
+      background: rgba(26,29,33,.82); color: #fff; font-size: 12.5px; font-weight: 600;
+      padding: 6px 14px; border-radius: 999px; pointer-events: none;
+      opacity: 0; transition: opacity .25s ease;
+    }
+    #v2-pill.show { opacity: 1; }
+    @media (prefers-reduced-motion: reduce) {
+      .pv-ph::after { animation: none; }
+      #v2-pill { transition: none; }
+    }
+
+    /* zoom (floating, bottom-right, thumb-reachable) */
+    #zoom-ctl {
+      position: fixed; right: 10px; bottom: 14px; z-index: 30;
+      display: flex; flex-direction: column; border-radius: 12px; overflow: hidden;
+      background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
+    }
+    #zoom-ctl button { width: 44px; height: 44px; font-size: 20px; color: var(--muted); border-radius: 0; }
+    #zoom-ctl button:first-child { border-bottom: 1px solid var(--line); }
+
+    /* empty state */
+    #empty {
+      position: absolute; inset: 0; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 14px; padding: 24px; text-align: center;
+    }
+    #empty h1 { font-size: 19px; font-weight: 700; }
+    #empty p { color: var(--muted); font-size: 13.5px; max-width: 300px; }
+    #btn-open {
+      background: var(--accent); color: #fff; font-weight: 600; font-size: 15px;
+      padding: 13px 26px; border-radius: 12px;
+    }
+    #empty .privacy { font-size: 11.5px; color: var(--muted); opacity: .8; }
+
+    /* inline text editor overlay */
+    .v2-text-edit {
+      position: absolute; z-index: 2000; min-width: 40px;
+      outline: 1.5px dashed var(--accent); outline-offset: 3px;
+      white-space: pre; line-height: 1.2; background: rgba(255,255,255,.6);
+    }
+    .v2-text-edit:focus { outline-style: solid; }
+
+    /* signature dialog */
+    dialog {
+      width: 100%; height: 100%; max-width: none; max-height: none;
+      background: rgba(0,0,0,.45); border: none;
+      display: none; align-items: center; justify-content: center; padding: 16px;
+    }
+    dialog[open] { display: flex; }
+    .sheet {
+      background: var(--surface); border-radius: 16px; padding: 16px;
+      width: 100%; max-width: 460px; display: flex; flex-direction: column; gap: 12px;
+    }
+    .sheet h2 { font-size: 15.5px; }
+    #sig-canvas {
+      width: 100%; height: 180px; border: 1.5px dashed var(--line);
+      border-radius: 10px; touch-action: none; background: #fff;
+    }
+    .sheet-actions { display: flex; gap: 8px; justify-content: flex-end; }
+    .btn-ghost { color: var(--muted); padding: 0 14px; }
+    .btn-primary { background: var(--accent); color: #fff; font-weight: 600; padding: 0 16px; border-radius: 8px; min-height: 40px; }
+
+    #toast {
+      position: fixed; left: 50%; transform: translateX(-50%); bottom: 130px; z-index: 40;
+      background: rgba(26,29,33,.9); color: #fff; font-size: 13px;
+      padding: 9px 16px; border-radius: 10px; opacity: 0; transition: opacity .2s;
+      pointer-events: none; max-width: 88vw; text-align: center;
+    }
+    #toast.show { opacity: 1; }
+  </style>
+</head>
+<body>
+  <header>
+    <span class="brand">PDFLokal <span class="beta">v2 beta</span></span>
+    <span class="spacer"></span>
+    <button class="icon-btn" id="btn-undo" disabled aria-label="Urungkan" title="Urungkan (Ctrl+Z)">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6 2.3L3 13"/></svg>
+    </button>
+    <button class="icon-btn" id="btn-redo" disabled aria-label="Ulangi" title="Ulangi (Ctrl+Y)">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>
+    </button>
+    <button id="btn-download" disabled>Unduh</button>
+  </header>
+
+  <div id="toolbar" role="toolbar" aria-label="Alat">
+    <button class="tool active" data-tool="select" aria-pressed="true">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 3 7.07 16.97 2.51-7.39 7.39-2.51L3 3z"/></svg>
+      Pilih
+    </button>
+    <button class="tool" data-tool="text" aria-pressed="false">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 7 4 4 20 4 20 7"/><line x1="9" y1="20" x2="15" y2="20"/><line x1="12" y1="4" x2="12" y2="20"/></svg>
+      Teks
+    </button>
+    <button class="tool" data-tool="whiteout" aria-pressed="false">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="8" width="18" height="8" rx="1"/></svg>
+      Tip-Ex
+    </button>
+    <button class="tool" data-tool="signature" aria-pressed="false">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 17c3-6 5-8 6-6s-1 7 1 7 3-9 5-9 0 9 2 9 2-3 4-3"/></svg>
+      TTD
+    </button>
+    <button class="tool" id="btn-delete-anno" disabled aria-label="Hapus objek terpilih">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+      Hapus
+    </button>
+  </div>
+
+  <main id="v2-scroll">
+    <div id="v2-stage"></div>
+    <div id="empty">
+      <h1>Edit PDF langsung di HP-mu</h1>
+      <p>Gabung, tanda tangan, tulis, dan tutup teks — semua diproses di perangkatmu, nggak ada yang di-upload.</p>
+      <button id="btn-open">Buka PDF</button>
+      <span class="privacy">🔒 100% privat — file kamu nggak pernah ninggalin perangkat</span>
+    </div>
+  </main>
+
+  <div id="v2-pill" aria-hidden="true"></div>
+  <div id="zoom-ctl">
+    <button id="z-in" aria-label="Perbesar">+</button>
+    <button id="z-out" aria-label="Perkecil">−</button>
+  </div>
+  <div id="toast" role="status" aria-live="polite"></div>
+
+  <dialog id="sig-modal" aria-label="Buat tanda tangan">
+    <div class="sheet">
+      <h2>Gambar tanda tanganmu</h2>
+      <canvas id="sig-canvas"></canvas>
+      <div class="sheet-actions">
+        <button class="btn-ghost" id="sig-clear">Ulangi</button>
+        <button class="btn-ghost" id="sig-cancel">Batal</button>
+        <button class="btn-primary" id="sig-use">Pakai</button>
+      </div>
+    </div>
+  </dialog>
+
+  <input type="file" id="file-input" accept="application/pdf" multiple hidden>
+
+  <script src="js/vendor/pdf.min.js"></script>
+  <script src="js/vendor/pdf-lib.min.js"></script>
+  <script src="js/vendor/fontkit.umd.min.js"></script>
+  <script src="js/vendor/signature_pad.umd.min.js"></script>
+  <script type="module" src="js/v2/app.js"></script>
+</body>
+</html>

--- a/js/core/export.js
+++ b/js/core/export.js
@@ -1,0 +1,356 @@
+/*
+ * PDFLokal — core/export.js  (I/O ADAPTER at the browser edge — PDF OUT)
+ * ============================================================================
+ * Turns a core Doc back into PDF bytes with pdf-lib. Mirror of import.js: this
+ * is the ONE place pdf-lib touches the model on the way out. The pure core
+ * (model.js/operations.js) never imports a vendor lib — pdf-lib and fontkit
+ * are INJECTED via `deps` (defaulting to the browser globals), so this module
+ * has zero vendor imports and no ueState/DOM dependencies.
+ *
+ * COORDINATES — the one contract everything below hangs on:
+ *   Core annotations live in PAGE-SPACE POINTS with a TOP-LEFT origin, in the
+ *   rotated page frame the user sees (see render/page-view.js). PDF space is
+ *   BOTTOM-LEFT origin in the UNROTATED frame — pdf-lib's setRotation() is
+ *   metadata only: drawing happens in unrotated page space and the viewer
+ *   rotates on display. So every annotation goes through
+ *   transformAnnotationCoords() to (a) flip Y and (b) undo the page rotation.
+ *   For rotation 0 that reduces to y_pdf = pageHeight - y_top - elementHeight.
+ *
+ *   There is NO canvas/pixel scale here. The old editor's pageScales ×
+ *   devicePixelRatio dance does not exist in the core — annotations are
+ *   already in points. Do not reintroduce scale math.
+ */
+
+import { buildExportPlan } from './operations.js';
+
+// ---- fonts ------------------------------------------------------------------
+
+// Key format: [family] → { [bold][italic] } → pdf-lib font name.
+// Helvetica/Times/Courier are pdf-lib standard fonts (no bytes embedded);
+// Montserrat/Carlito are self-hosted files embedded via fontkit.
+const FONT_NAME_MAP = {
+  'Helvetica':   { '00': 'Helvetica', '10': 'HelveticaBold', '01': 'HelveticaOblique', '11': 'HelveticaBoldOblique' },
+  'Times-Roman': { '00': 'TimesRoman', '10': 'TimesRomanBold', '01': 'TimesRomanItalic', '11': 'TimesRomanBoldItalic' },
+  'Courier':     { '00': 'Courier', '10': 'CourierBold', '01': 'CourierOblique', '11': 'CourierBoldOblique' },
+  'Montserrat':  { '00': 'Montserrat', '10': 'Montserrat-Bold', '01': 'Montserrat-Italic', '11': 'Montserrat-BoldItalic' },
+  'Carlito':     { '00': 'Carlito', '10': 'Carlito-Bold', '01': 'Carlito-Italic', '11': 'Carlito-BoldItalic' },
+};
+
+const CUSTOM_FONT_URLS = {
+  'Montserrat': 'fonts/montserrat-regular.woff2',
+  'Montserrat-Bold': 'fonts/montserrat-bold.woff2',
+  'Montserrat-Italic': 'fonts/montserrat-italic.woff2',
+  'Montserrat-BoldItalic': 'fonts/montserrat-bolditalic.woff2',
+  'Carlito': 'fonts/carlito-regular.woff2',
+  'Carlito-Bold': 'fonts/carlito-bold.woff2',
+  'Carlito-Italic': 'fonts/carlito-italic.woff2',
+  'Carlito-BoldItalic': 'fonts/carlito-bolditalic.woff2',
+};
+
+const CUSTOM_FONT_FAMILIES = new Set(['Montserrat', 'Carlito']);
+
+// WHY: AbortController timeout prevents export from hanging indefinitely if a
+// self-hosted font file fails to load (e.g. offline, 404). Same guard as the
+// old editor export (security hardening, Mar 2026).
+const FONT_FETCH_TIMEOUT_MS = 10000;
+
+function resolveFontName(fontFamily, bold, italic) {
+  const variant = `${bold ? '1' : '0'}${italic ? '1' : '0'}`;
+  const family = FONT_NAME_MAP[fontFamily];
+  if (family) return { name: family[variant], isCustom: CUSTOM_FONT_FAMILIES.has(fontFamily) };
+  console.warn('[core/export] Unknown font family:', fontFamily, '- falling back to Helvetica');
+  return { name: FONT_NAME_MAP['Helvetica'][variant], isCustom: false };
+}
+
+async function cacheFallbackFont(env, fontName, bold) {
+  // WHY 'HelveticaBold' (no hyphen): PDFLib.StandardFonts KEYS are camel-case
+  // ('HelveticaBold'); the hyphenated form is the enum VALUE. The old export
+  // used the value as a key here, silently getting `undefined` for bold
+  // fallbacks — fixed in this port.
+  const fallbackName = bold ? 'HelveticaBold' : 'Helvetica';
+  if (!env.fontCache[fallbackName]) {
+    env.fontCache[fallbackName] = await env.newDoc.embedFont(env.PDFLib.StandardFonts[fallbackName]);
+  }
+  // WHY: also cache under the REQUESTED name so later annotations using the
+  // failed font hit the cache instead of re-waiting the full fetch timeout ×N.
+  env.fontCache[fontName] = env.fontCache[fallbackName];
+  return env.fontCache[fontName];
+}
+
+async function embedCustomFont(env, fontName, bold) {
+  // WHY guards: custom fonts need fontkit (for embedFont on raw bytes) and a
+  // fetch-capable environment. A headless caller injecting only PDFLib still
+  // gets a valid PDF — the text falls back to Helvetica instead of throwing.
+  if (!env.fontkit || typeof fetch !== 'function') {
+    console.warn('[core/export] fontkit/fetch unavailable — Helvetica fallback for', fontName);
+    return cacheFallbackFont(env, fontName, bold);
+  }
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FONT_FETCH_TIMEOUT_MS);
+    const res = await fetch(CUSTOM_FONT_URLS[fontName], { signal: controller.signal });
+    clearTimeout(timeoutId);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const fontBytes = await res.arrayBuffer();
+    env.fontCache[fontName] = await env.newDoc.embedFont(fontBytes);
+    return env.fontCache[fontName];
+  } catch (err) {
+    console.error('[core/export] Failed to load font:', fontName, err);
+    return cacheFallbackFont(env, fontName, bold);
+  }
+}
+
+async function embedStandardFont(env, fontName, bold) {
+  const std = env.PDFLib.StandardFonts[fontName];
+  if (!std) {
+    console.error('[core/export] Invalid standard font name:', fontName);
+    return cacheFallbackFont(env, fontName, bold);
+  }
+  env.fontCache[fontName] = await env.newDoc.embedFont(std);
+  return env.fontCache[fontName];
+}
+
+async function getFont(env, fontFamily, bold, italic) {
+  const { name, isCustom } = resolveFontName(fontFamily || 'Helvetica', bold, italic);
+  if (env.fontCache[name]) return env.fontCache[name];
+  return isCustom ? embedCustomFont(env, name, bold) : embedStandardFont(env, name, bold);
+}
+
+// ---- coordinate transforms --------------------------------------------------
+
+// WHY: Map a point from the rotated page frame (top-left origin, Y-down, in
+// points) to the unrotated PDF frame (bottom-left origin, Y-up). Ported from
+// the old editor export (golden-tested there) minus the canvas scale factors.
+// Pair with `rotate: degrees(rotation)` on drawText/drawImage so glyphs/images
+// are oriented correctly after the page is /Rotate'd. wU/hU are the UNROTATED
+// page dims from page.getSize() (the MediaBox).
+function transformAnnotationCoords(rotation, xV, yV, wU, hU) {
+  switch (rotation) {
+    case 90:  return { x: yV,      y: xV };
+    case 180: return { x: wU - xV, y: yV };
+    case 270: return { x: wU - yV, y: hU - xV };
+    default:  return { x: xV,      y: hU - yV };
+  }
+}
+
+// Whiteout: pdf-lib drawRectangle is axis-aligned in the unrotated page frame.
+// For 90°/270° page rotations the view-horizontal direction maps to
+// PDF-vertical, so width and height swap. The anchor is the corner of the
+// view-space rect that becomes the bottom-left of the unrotated PDF rect
+// after the rotation transform (verify each case by hand against
+// transformAnnotationCoords).
+function whiteoutCornerAndDims(rotation, anno, wU, hU) {
+  const { x: xC, y: yC, width: wC, height: hC } = anno;
+  switch (rotation) {
+    case 90: {  // view TL → PDF bottom-left
+      const { x, y } = transformAnnotationCoords(90, xC, yC, wU, hU);
+      return { x, y, width: hC, height: wC };
+    }
+    case 180: {  // view TR → PDF bottom-left
+      const { x, y } = transformAnnotationCoords(180, xC + wC, yC, wU, hU);
+      return { x, y, width: wC, height: hC };
+    }
+    case 270: {  // view BR → PDF bottom-left
+      const { x, y } = transformAnnotationCoords(270, xC + wC, yC + hC, wU, hU);
+      return { x, y, width: hC, height: wC };
+    }
+    default: {  // rotation 0: view BL → PDF bottom-left
+      const { x, y } = transformAnnotationCoords(0, xC, yC + hC, wU, hU);
+      return { x, y, width: wC, height: hC };
+    }
+  }
+}
+
+// ---- per-type drawers --------------------------------------------------------
+
+function parseHexColor(PDFLib, hex) {
+  const h = (hex || '#000000').replace('#', '');
+  return PDFLib.rgb(
+    Number.parseInt(h.slice(0, 2), 16) / 255,
+    Number.parseInt(h.slice(2, 4), 16) / 255,
+    Number.parseInt(h.slice(4, 6), 16) / 255,
+  );
+}
+
+// WHY these ratios: core text `y` is the TOP of the text block (page-view.js
+// lays text out as a DOM element with CSS line-height 1.2), but pdf-lib's
+// drawText anchors at the BASELINE. First baseline sits ≈ half-leading (0.1em)
+// + typical Latin ascent (0.8em) below the block top. The old export skipped
+// this because its `y` WAS the canvas fillText baseline — the new core stores
+// box tops, so the offset moves here.
+const TEXT_BASELINE_RATIO = 0.9;
+const TEXT_LINE_HEIGHT = 1.2; // must match page-view.js CSS line-height
+
+function drawWhiteout(pdfPage, anno, frame, env) {
+  const r = whiteoutCornerAndDims(frame.rotation, anno, frame.wU, frame.hU);
+  pdfPage.drawRectangle({ x: r.x, y: r.y, width: r.width, height: r.height, color: env.PDFLib.rgb(1, 1, 1) });
+}
+
+async function drawText(pdfPage, anno, frame, env) {
+  const font = await env.getFont(anno.fontFamily, anno.bold, anno.italic);
+  const color = parseHexColor(env.PDFLib, anno.color);
+  const rotate = env.PDFLib.degrees(frame.rotation);
+  const size = anno.fontSize || 16;
+  const lines = String(anno.text ?? '').split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    const yV = anno.y + size * TEXT_BASELINE_RATIO + i * size * TEXT_LINE_HEIGHT;
+    const { x, y } = transformAnnotationCoords(frame.rotation, anno.x, yV, frame.wU, frame.hU);
+    pdfPage.drawText(lines[i], { x, y, size, font, color, rotate });
+  }
+}
+
+async function drawSignature(pdfPage, anno, frame, env) {
+  // WHY cache by dataUrl: "Paraf → Semua Hal." stamps the SAME image on every
+  // page — embed it once, reference it N times (smaller file, faster export).
+  let img = env.imageCache.get(anno.image);
+  if (!img) {
+    // Format-aware embedding: JPEG re-encoded as PNG would bloat the file.
+    img = anno.image.startsWith('data:image/jpeg')
+      ? await env.newDoc.embedJpg(anno.image)
+      : await env.newDoc.embedPng(anno.image);
+    env.imageCache.set(anno.image, img);
+  }
+  const width = anno.width || img.width;
+  // WHY: page-view.js renders signatures with height:auto — `height` may be
+  // absent on the annotation. Derive it from the embedded image's intrinsic
+  // aspect ratio so the export never distorts the signature.
+  const height = anno.height || width * (img.height / img.width);
+  // Anchor pdf-lib drawImage at the view-space BOTTOM-LEFT of the image:
+  // transformed through the page rotation, this lands the visible image
+  // exactly where the user placed it in the rotated view.
+  const yV = anno.y + height;
+  const { x, y } = transformAnnotationCoords(frame.rotation, anno.x, yV, frame.wU, frame.hU);
+  pdfPage.drawImage(img, { x, y, width, height, rotate: env.PDFLib.degrees(frame.rotation) });
+}
+
+async function drawWatermark(pdfPage, anno, frame, env) {
+  const font = await env.getFont('Helvetica', false, false);
+  const size = anno.fontSize || 48;
+  // Watermark has its own user-specified tilt; combine with the page rotation
+  // so the visible tilt matches what the user saw in the editor.
+  const totalDeg = frame.rotation + (anno.rotation || 0);
+  const rad = (totalDeg * Math.PI) / 180;
+  // WHY centering math: the editor preview draws the watermark with
+  // textAlign:center + textBaseline:middle — (x, y) is the text CENTER.
+  // pdf-lib anchors at baseline-LEFT and rotates AROUND that anchor, so back
+  // the anchor off by half the text extent, rotated by the total tilt.
+  // 0.35em ≈ cap-height/2 (baseline→optical-center distance).
+  const halfW = font.widthOfTextAtSize(anno.text || '', size) / 2;
+  const halfCap = size * 0.35;
+  const { x: cx, y: cy } = transformAnnotationCoords(frame.rotation, anno.x, anno.y, frame.wU, frame.hU);
+  pdfPage.drawText(anno.text || '', {
+    x: cx - halfW * Math.cos(rad) + halfCap * Math.sin(rad),
+    y: cy - halfW * Math.sin(rad) - halfCap * Math.cos(rad),
+    size,
+    font,
+    color: parseHexColor(env.PDFLib, anno.color),
+    opacity: anno.opacity ?? 0.3,
+    rotate: env.PDFLib.degrees(totalDeg),
+  });
+}
+
+async function drawPageNumber(pdfPage, anno, frame, env) {
+  // A pageNumber is a single-line label with the same coordinate contract as
+  // text (y = top of the line box). The old export silently DROPPED this type
+  // (missing branch in embedAnnotationsOnPage) — fixed in this port.
+  const font = await env.getFont('Helvetica', false, false);
+  const size = anno.fontSize || 12;
+  const yV = anno.y + size * TEXT_BASELINE_RATIO;
+  const { x, y } = transformAnnotationCoords(frame.rotation, anno.x, yV, frame.wU, frame.hU);
+  pdfPage.drawText(anno.text || '', {
+    x, y, size, font,
+    color: parseHexColor(env.PDFLib, anno.color),
+    rotate: env.PDFLib.degrees(frame.rotation),
+  });
+}
+
+// Handler map instead of an if/else chain (same pattern as the SonarQube
+// sprint's handler maps). Unknown types warn-and-skip so one bad annotation
+// can't kill a whole export.
+const ANNOTATION_DRAWERS = {
+  whiteout: drawWhiteout,
+  text: drawText,
+  signature: drawSignature,
+  watermark: drawWatermark,
+  pageNumber: drawPageNumber,
+};
+
+// ---- image pages -------------------------------------------------------------
+
+function sniffImageFormat(bytes) {
+  if (bytes.length > 3 && bytes[0] === 0xff && bytes[1] === 0xd8) return 'jpg';
+  if (bytes.length > 3 && bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47) return 'png';
+  return null;
+}
+
+// A page whose source is an IMAGE file: create a blank PDF page at the page's
+// point size and draw the image edge-to-edge.
+async function addImagePage(env, page, source) {
+  const fmt = sniffImageFormat(source.bytes);
+  // WHY throw: pdf-lib decodes only PNG and JPEG. WEBP/GIF sources must be
+  // transcoded to PNG at import time (canvas → toBlob) — by the time bytes
+  // reach export they must be one of the two. Fail loudly instead of emitting
+  // a broken PDF.
+  if (!fmt) throw new Error(`buildPdfBytes: image source "${source.name}" is not PNG/JPEG`);
+  const img = fmt === 'jpg' ? await env.newDoc.embedJpg(source.bytes) : await env.newDoc.embedPng(source.bytes);
+  const pdfPage = env.newDoc.addPage([page.width, page.height]);
+  pdfPage.drawImage(img, { x: 0, y: 0, width: page.width, height: page.height });
+  return pdfPage;
+}
+
+// ---- the adapter ---------------------------------------------------------------
+
+// Build final PDF bytes for a core Doc. `deps` injects the vendor libs so the
+// module stays vendor-import-free (browser: omit deps, globals are picked up;
+// Node: pass { PDFLib, fontkit } explicitly).
+export async function buildPdfBytes(doc, deps = {}) {
+  const PDFLib = deps.PDFLib || globalThis.PDFLib;
+  const fontkit = deps.fontkit || globalThis.fontkit;
+  if (!PDFLib) throw new Error('buildPdfBytes: PDFLib is required (inject via deps or load the vendor script)');
+
+  const newDoc = await PDFLib.PDFDocument.create();
+  // fontkit is only needed for custom fonts (Montserrat/Carlito); standard
+  // fonts work without it — see the guard in embedCustomFont.
+  if (fontkit) newDoc.registerFontkit(fontkit);
+
+  const env = { PDFLib, fontkit, newDoc, fontCache: {}, imageCache: new Map() };
+  env.getFont = (family, bold, italic) => getFont(env, family, bold, italic);
+
+  // WHY cache: the old exporter re-parsed the source PDF for EVERY page
+  // (O(pages × parse)). One pdf-lib load per source is strictly better.
+  const srcDocCache = new Map(); // sourceId → Promise<PDFDocument>
+  function getSrcDoc(source) {
+    if (!srcDocCache.has(source.id)) srcDocCache.set(source.id, PDFLib.PDFDocument.load(source.bytes));
+    return srcDocCache.get(source.id);
+  }
+
+  for (const { page, source, annotations } of buildExportPlan(doc)) {
+    if (!source) throw new Error(`buildPdfBytes: page ${page.id} references missing source ${page.sourceId}`);
+
+    let pdfPage;
+    if (page.isFromImage) {
+      pdfPage = await addImagePage(env, page, source);
+    } else {
+      const srcDoc = await getSrcDoc(source);
+      const [copied] = await newDoc.copyPages(srcDoc, [page.sourcePageNum]);
+      pdfPage = newDoc.addPage(copied);
+    }
+    if (page.rotation) pdfPage.setRotation(PDFLib.degrees(page.rotation));
+
+    if (annotations.length === 0) continue;
+    // wU/hU: UNROTATED page dims (MediaBox) — setRotation is metadata only,
+    // drawing happens in this frame. See transformAnnotationCoords.
+    const { width: wU, height: hU } = pdfPage.getSize();
+    const frame = { rotation: page.rotation || 0, wU, hU };
+    for (const anno of annotations) {
+      const draw = ANNOTATION_DRAWERS[anno.type];
+      if (!draw) {
+        console.warn('[core/export] Unknown annotation type, skipping:', anno.type);
+        continue;
+      }
+      await draw(pdfPage, anno, frame, env);
+    }
+  }
+
+  return newDoc.save({ useObjectStreams: true, addDefaultPage: false });
+}

--- a/js/core/history.js
+++ b/js/core/history.js
@@ -1,0 +1,78 @@
+/*
+ * PDFLokal — core/history.js  (HEADLESS — unified undo/redo)
+ * ============================================================================
+ * ONE history for everything (page ops AND annotation edits). The old editor
+ * needed two stacks + an imageRegistry because its state was six parallel
+ * index-keyed maps and snapshots had to dodge base64 blobs. On the Doc model
+ * none of that is needed:
+ *
+ *   - Snapshots are shallow-ish copies: pages and annotations are copied as
+ *     fresh objects, but their STRING fields (signature dataUrls — the big
+ *     stuff) are immutable in JS and shared by reference. Free.
+ *   - Sources (raw PDF bytes) are append-only and never mutated → shared by
+ *     reference, never cloned.
+ *   - page.raster is a render-layer cache, carried by reference; the render
+ *     layer re-rasterizes when missing/stale. Undo never re-renders PDFs.
+ *
+ * Contract: call record(h, doc) BEFORE a user-level mutation (one per gesture,
+ * not per pointermove). undo/redo swap wholesale snapshots — no re-keying, no
+ * index math, no special cases.
+ */
+
+const DEFAULT_LIMIT = 50;
+
+// WHY a snapshot and not a command log: the op set is still growing (v2 build)
+// and wholesale restore is impossible to get subtly wrong. Snapshot cost is
+// O(pages + annotations) small objects — bytes/dataUrls/rasters are shared.
+function snapshot(doc) {
+  return {
+    pages: doc.pages.map((p) => ({
+      ...p,
+      annotations: p.annotations.map((a) => ({ ...a })),
+    })),
+    sources: doc.sources, // append-only; shared by reference on purpose
+    selection: { ...doc.selection },
+  };
+}
+
+function restore(doc, snap) {
+  // Restore hands back the snapshot's own objects (they are private copies —
+  // record() never reuses them), re-copying so a later undo of THIS state
+  // still has a pristine copy to return to.
+  doc.pages = snap.pages.map((p) => ({
+    ...p,
+    annotations: p.annotations.map((a) => ({ ...a })),
+  }));
+  doc.sources = snap.sources;
+  doc.selection = { ...snap.selection };
+}
+
+export function createHistory(limit = DEFAULT_LIMIT) {
+  return { undoStack: [], redoStack: [], limit };
+}
+
+// Call BEFORE mutating. Clears redo (no branching timelines).
+export function record(history, doc) {
+  history.undoStack.push(snapshot(doc));
+  if (history.undoStack.length > history.limit) history.undoStack.shift();
+  history.redoStack.length = 0;
+}
+
+export function undo(history, doc) {
+  const snap = history.undoStack.pop();
+  if (!snap) return false;
+  history.redoStack.push(snapshot(doc));
+  restore(doc, snap);
+  return true;
+}
+
+export function redo(history, doc) {
+  const snap = history.redoStack.pop();
+  if (!snap) return false;
+  history.undoStack.push(snapshot(doc));
+  restore(doc, snap);
+  return true;
+}
+
+export function canUndo(history) { return history.undoStack.length > 0; }
+export function canRedo(history) { return history.redoStack.length > 0; }

--- a/js/core/import.js
+++ b/js/core/import.js
@@ -42,6 +42,55 @@ export async function importPdf(doc, { name, bytes }) {
   return pages;
 }
 
+// pdf-lib (the export adapter) can only embed PNG and JPEG. Anything else
+// (WEBP/GIF/BMP/…) is transcoded to PNG HERE, at the browser edge, so the bytes
+// stored on the Source are always export-safe and export never has to sniff for
+// a format it can't handle.
+const EMBEDDABLE_IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/jpg']);
+
+// bytes (a raw image file) → append a Source + ONE image page to `doc`.
+// Sizing convention: the page's point size EQUALS the image's pixel dimensions,
+// and export draws the image full-bleed edge-to-edge. This matches BOTH the old
+// editor (utils.js convertImageToPdf: addPage([img.width, img.height]) + a
+// filling drawImage) AND core/export.js addImagePage — so a JPG dropped into the
+// new core produces the same PDF page the old editor did. Chosen over
+// fit-in-A4 because it is what shipped and what export already expects; keeping
+// the pair consistent is worth more than a paper-size default here.
+export async function importImage(doc, { name, bytes, mimeType }) {
+  // createImageBitmap decodes PNG/JPEG/WEBP/GIF(first frame) and gives us the
+  // intrinsic pixel size — which becomes the page's point size (see above).
+  const type = (mimeType || '').toLowerCase();
+  const blob = new Blob([bytes.slice()], type ? { type } : undefined);
+  const bitmap = await window.createImageBitmap(blob);
+  const width = bitmap.width;
+  const height = bitmap.height;
+
+  let storeBytes = bytes;
+  if (!EMBEDDABLE_IMAGE_TYPES.has(type)) {
+    // Transcode to PNG so export's embedPng always succeeds. We already have the
+    // decoded bitmap, so this is one canvas draw + toBlob.
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    canvas.getContext('2d').drawImage(bitmap, 0, 0);
+    const pngBlob = await new Promise((resolve) => canvas.toBlob(resolve, 'image/png'));
+    storeBytes = new Uint8Array(await pngBlob.arrayBuffer());
+  }
+  if (typeof bitmap.close === 'function') bitmap.close();
+
+  const source = addSource(doc, createSource({ name, bytes: storeBytes, numPages: 1 }));
+  const page = createPage({
+    source,
+    sourcePageNum: 0,
+    width,
+    height,
+    rotation: 0,
+    isFromImage: true,
+  });
+  addPages(doc, [page]);
+  return [page];
+}
+
 // Rasterize ONE page to a PNG image at `scale`. Lazy: the render layer calls
 // this on demand. Result is stashed on `page.raster` so the DOM can show an
 // <img> that survives the mobile GPU-backing-store purge (unlike a live canvas).
@@ -60,6 +109,7 @@ export async function rasterizePage(doc, page, opts = {}) {
 // document size within a bounded memory budget.
 export function createPageRasterizer(doc) {
   const docCache = new Map(); // sourceId -> PDF.js document promise
+  const imgCache = new Map(); // sourceId -> ImageBitmap promise (image sources)
 
   function getPdf(sourceId) {
     if (!docCache.has(sourceId)) {
@@ -69,7 +119,15 @@ export function createPageRasterizer(doc) {
     return docCache.get(sourceId);
   }
 
-  async function renderToCanvas(page, scale) {
+  function getImageBitmap(sourceId) {
+    if (!imgCache.has(sourceId)) {
+      const source = getSource(doc, sourceId);
+      imgCache.set(sourceId, window.createImageBitmap(new Blob([source.bytes.slice()])));
+    }
+    return imgCache.get(sourceId);
+  }
+
+  async function renderPdfToCanvas(page, scale) {
     const pdf = await getPdf(page.sourceId);
     const pdfPage = await pdf.getPage(page.sourcePageNum + 1);
     // Intrinsic /Rotate + the user's rotation (PDF.js `rotation:` is absolute).
@@ -80,6 +138,32 @@ export function createPageRasterizer(doc) {
     canvas.height = Math.ceil(vp.height);
     await pdfPage.render({ canvasContext: canvas.getContext('2d'), viewport: vp }).promise;
     return canvas;
+  }
+
+  // Image sources have no PDF.js document — draw the decoded bitmap to a canvas
+  // at `scale` (page point size × scale, matching the PDF path's raster px) and
+  // bake in the page rotation. Image pages carry no intrinsic /Rotate, so only
+  // page.rotation applies. Rotation is clockwise, matching PDF.js viewports.
+  async function renderImageToCanvas(page, scale) {
+    const bitmap = await getImageBitmap(page.sourceId);
+    const rotation = (page.rotation || 0) % 360;
+    const drawW = page.width * scale;   // unrotated draw size in px
+    const drawH = page.height * scale;
+    const rotated = rotation % 180 !== 0; // 90/270 swap the canvas dimensions
+    const canvas = document.createElement('canvas');
+    canvas.width = Math.ceil(rotated ? drawH : drawW);
+    canvas.height = Math.ceil(rotated ? drawW : drawH);
+    const ctx = canvas.getContext('2d');
+    // Rotate about the canvas centre, then draw the image centred: the swapped
+    // canvas dims mean the rotated image lands edge-to-edge for every quadrant.
+    ctx.translate(canvas.width / 2, canvas.height / 2);
+    ctx.rotate((rotation * Math.PI) / 180);
+    ctx.drawImage(bitmap, -drawW / 2, -drawH / 2, drawW, drawH);
+    return canvas;
+  }
+
+  function renderToCanvas(page, scale) {
+    return page.isFromImage ? renderImageToCanvas(page, scale) : renderPdfToCanvas(page, scale);
   }
 
   return {
@@ -99,6 +183,8 @@ export function createPageRasterizer(doc) {
     async destroy() {
       for (const p of docCache.values()) { try { (await p).destroy(); } catch { /* already gone */ } }
       docCache.clear();
+      for (const p of imgCache.values()) { try { (await p).close(); } catch { /* already gone */ } }
+      imgCache.clear();
     },
   };
 }

--- a/js/core/import.js
+++ b/js/core/import.js
@@ -23,14 +23,19 @@ export async function importPdf(doc, { name, bytes }) {
   const pages = [];
   for (let n = 1; n <= pdf.numPages; n += 1) {
     const pdfPage = await pdf.getPage(n);
-    const vp = pdfPage.getViewport({ scale: 1 }); // intrinsic, unrotated size
-    pages.push(createPage({
+    const vp = pdfPage.getViewport({ scale: 1 }); // honors the PDF's intrinsic /Rotate
+    const page = createPage({
       source,
       sourcePageNum: n - 1,
       width: vp.width,
       height: vp.height,
       rotation: 0,
-    }));
+    });
+    // WHY: scanned/landscape PDFs carry an intrinsic /Rotate. PDF.js's explicit
+    // `rotation:` param OVERRIDES it (not additive), so rasterize must pass
+    // intrinsic + user rotation or pre-rotated documents render sideways.
+    page.baseRotation = pdfPage.rotate || 0;
+    pages.push(page);
   }
   addPages(doc, pages);
   await pdf.destroy();
@@ -64,17 +69,32 @@ export function createPageRasterizer(doc) {
     return docCache.get(sourceId);
   }
 
+  async function renderToCanvas(page, scale) {
+    const pdf = await getPdf(page.sourceId);
+    const pdfPage = await pdf.getPage(page.sourcePageNum + 1);
+    // Intrinsic /Rotate + the user's rotation (PDF.js `rotation:` is absolute).
+    const rotation = ((page.baseRotation || 0) + (page.rotation || 0)) % 360;
+    const vp = pdfPage.getViewport({ scale, rotation });
+    const canvas = document.createElement('canvas');
+    canvas.width = Math.ceil(vp.width);
+    canvas.height = Math.ceil(vp.height);
+    await pdfPage.render({ canvasContext: canvas.getContext('2d'), viewport: vp }).promise;
+    return canvas;
+  }
+
   return {
     async rasterize(page, { scale = 2 } = {}) {
-      const pdf = await getPdf(page.sourceId);
-      const pdfPage = await pdf.getPage(page.sourcePageNum + 1);
-      const vp = pdfPage.getViewport({ scale, rotation: page.rotation });
-      const canvas = document.createElement('canvas');
-      canvas.width = Math.ceil(vp.width);
-      canvas.height = Math.ceil(vp.height);
-      await pdfPage.render({ canvasContext: canvas.getContext('2d'), viewport: vp }).promise;
+      const canvas = await renderToCanvas(page, scale);
       page.raster = { dataUrl: canvas.toDataURL('image/png'), width: canvas.width, height: canvas.height, scale };
       return page.raster;
+    },
+    // Small render for page-manager tiles. Does NOT touch page.raster (the main
+    // view's streaming state) — callers cache the result themselves by page.id.
+    async rasterizeThumb(page, { width = 150 } = {}) {
+      const rotated = (page.rotation || 0) % 180 !== 0;
+      const pageW = rotated ? page.height : page.width;
+      const canvas = await renderToCanvas(page, width / pageW);
+      return { dataUrl: canvas.toDataURL('image/png'), width: canvas.width, height: canvas.height };
     },
     async destroy() {
       for (const p of docCache.values()) { try { (await p).destroy(); } catch { /* already gone */ } }

--- a/js/core/operations.js
+++ b/js/core/operations.js
@@ -94,10 +94,14 @@ export function moveAnnotation(doc, annotationId, dx, dy) {
   const found = findAnnotation(doc, annotationId);
   if (!found) return null;
   const { page, annotation } = found;
+  // Annotations live in the ROTATED view frame — the clamp box swaps at 90/270.
+  const rotated = (page.rotation || 0) % 180 !== 0;
+  const frameW = rotated ? page.height : page.width;
+  const frameH = rotated ? page.width : page.height;
   const w = annotation.width || 0;
   const h = annotation.height || 0;
-  annotation.x = clamp((annotation.x || 0) + dx, 0, Math.max(0, page.width - w));
-  annotation.y = clamp((annotation.y || 0) + dy, 0, Math.max(0, page.height - h));
+  annotation.x = clamp((annotation.x || 0) + dx, 0, Math.max(0, frameW - w));
+  annotation.y = clamp((annotation.y || 0) + dy, 0, Math.max(0, frameH - h));
   return annotation;
 }
 

--- a/js/core/operations.js
+++ b/js/core/operations.js
@@ -83,6 +83,37 @@ export function removeAnnotation(doc, annotationId) {
   return found.annotation;
 }
 
+// Minimum annotation edge in page points — small enough for a tight whiteout,
+// large enough that a resize handle can't collapse the object to untouchable.
+const MIN_ANNO_SIZE = 8;
+
+// Move by delta in PAGE space (the UI converts screen→page first). The anchor
+// clamps inside the page so an annotation can never be dragged unrecoverably
+// off-canvas — the failure mode behind several old "invisible annotation" bugs.
+export function moveAnnotation(doc, annotationId, dx, dy) {
+  const found = findAnnotation(doc, annotationId);
+  if (!found) return null;
+  const { page, annotation } = found;
+  const w = annotation.width || 0;
+  const h = annotation.height || 0;
+  annotation.x = clamp((annotation.x || 0) + dx, 0, Math.max(0, page.width - w));
+  annotation.y = clamp((annotation.y || 0) + dy, 0, Math.max(0, page.height - h));
+  return annotation;
+}
+
+// Set bounds atomically (any subset of x/y/width/height). Sizes are floored at
+// MIN_ANNO_SIZE so resize handles can't produce a zero-size object.
+export function resizeAnnotation(doc, annotationId, bounds = {}) {
+  const found = findAnnotation(doc, annotationId);
+  if (!found) return null;
+  const a = found.annotation;
+  if (bounds.x !== undefined) a.x = bounds.x;
+  if (bounds.y !== undefined) a.y = bounds.y;
+  if (bounds.width !== undefined) a.width = Math.max(MIN_ANNO_SIZE, bounds.width);
+  if (bounds.height !== undefined) a.height = Math.max(MIN_ANNO_SIZE, bounds.height);
+  return a;
+}
+
 // ---- selection (by id — cannot go stale) -----------------------------------
 
 export function selectPage(doc, pageId) {

--- a/js/lab.js
+++ b/js/lab.js
@@ -1,22 +1,21 @@
 /*
- * PDFLokal — js/lab.js  (Phase-1/2 render preview — NOT part of the app)
+ * PDFLokal — js/lab.js  (render-engine preview — NOT part of the app)
  * ============================================================================
- * Streaming render harness so the founder can feel the real strategy on a phone
- * BEFORE the live editor is touched. The model:
- *   - Open INSTANTLY: read all page sizes (cheap), lay out every page slot at
- *     the correct dimensions immediately. Scrollbar is right from t=0; nothing
- *     reflows. Only pixels stream in.
- *   - STREAM like GTA maps: rasterize only pages near the viewport; release the
- *     far ones to free memory. Memory stays bounded on ANY document size — the
- *     only thing that survives "1 juta phones" (mostly low-end Android).
- *   - Placeholders, never blank → fast-scroll reads as loading, not flicker.
- *
- * Nothing here touches the live app (separate page, noindex, unlinked).
+ * Phone-openable harness for the render engine (pdflokal.id/lab.html). The
+ * engine itself now lives in real modules — this file is ONLY wiring:
+ *   - streaming window        → js/render/viewport.js  (extracted Jul 2026)
+ *   - page views / slots      → js/render/page-view.js
+ *   - input (drag/resize/tap) → js/render/interaction.js
+ * If lab behavior regresses after an engine change, the engine broke — that is
+ * the point of keeping this page alive.
  */
 import { createDoc, createAnnotation } from './core/model.js';
 import { addAnnotation } from './core/operations.js';
+import { createHistory } from './core/history.js';
 import { importPdf, createPageRasterizer } from './core/import.js';
-import { renderPageView, setPageRaster, clearPageRaster } from './render/page-view.js';
+import { createPageSlot } from './render/page-view.js';
+import { createViewportStream } from './render/viewport.js';
+import { createInteraction } from './render/interaction.js';
 
 window.pdfjsLib.GlobalWorkerOptions.workerSrc = '/js/vendor/pdf.worker.min.js';
 
@@ -26,24 +25,52 @@ const statusEl = document.getElementById('lab-status');
 const setStatus = (s) => { statusEl.textContent = s; };
 
 let zoom = 1;
-function applyZoom() { stage.style.transform = `scale(${zoom})`; updateWindow(0); }
+let doc = createDoc();
+let slots = [];
+let rasterizer = null;
+const history = createHistory();
+
+function applyZoom() { stage.style.transform = `scale(${zoom})`; stream.refresh(0); }
 document.getElementById('z-in').onclick = () => { zoom = Math.min(zoom + 0.2, 3); applyZoom(); };
 document.getElementById('z-out').onclick = () => { zoom = Math.max(zoom - 0.2, 0.3); applyZoom(); };
 
-let slots = [];          // [{ page, view }]
-let rasterizer = null;   // per-source PDF.js doc cache
-let ticking = false;
+// Telegraph #2 — position pill ("42 / 340"), shown on scroll, fades on idle.
+const pill = document.getElementById('pv-pill');
+let pillTimer = null;
+function showPill(current, total) {
+  pill.textContent = `${current} / ${total}`;
+  pill.classList.add('show');
+  clearTimeout(pillTimer);
+  pillTimer = setTimeout(() => pill.classList.remove('show'), 750);
+}
+
+const stream = createViewportStream({
+  scrollEl,
+  slots: () => slots,
+  rasterize: (page) => rasterizer.rasterize(page, { scale: 2 }),
+  onPosition: showPill,
+});
+stream.attach();
+
+createInteraction({
+  stage,
+  getDoc: () => doc,
+  getZoom: () => zoom,
+  getTool: () => 'select',
+  history,
+  onChange: () => {},
+});
 
 async function loadDoc(name, bytes) {
   if (rasterizer) await rasterizer.destroy();
   slots = []; stage.innerHTML = '';
   setStatus('membuka…');
 
-  const doc = createDoc();
+  doc = createDoc();
   const pages = await importPdf(doc, { name, bytes }); // instant: metadata only
 
-  // A draggable demo annotation on page 1 — proves "active object always on top",
-  // and that it stays put even while the page image streams in/out underneath.
+  // A draggable demo annotation on page 1 — proves "active object always on
+  // top" AND exercises the real interaction layer (select → drag → undo path).
   const demo = addAnnotation(doc, pages[0].id, createAnnotation('text', {
     text: 'Seret aku ✍️ (selalu di atas)', x: 48, y: 120, fontSize: 22, color: '#111', bold: true,
   }));
@@ -51,115 +78,16 @@ async function loadDoc(name, bytes) {
   const fit = Math.min(1, (scrollEl.clientWidth - 32) / pages[0].width);
   zoom = fit; stage.style.transform = `scale(${zoom})`;
 
-  // Lay out EVERY slot immediately (correct size + numbered placeholder). Instant open.
+  // Lay out EVERY slot immediately (correct size + numbered placeholder).
   pages.forEach((page, i) => {
-    const view = renderPageView(page, { activeId: demo.id, label: `Hal ${i + 1}` });
-    stage.appendChild(view);
-    slots.push({ page, view });
+    const slot = createPageSlot(page, { activeId: demo.id, label: `Hal ${i + 1}` });
+    stage.appendChild(slot.view);
+    slots.push(slot);
   });
-  wireDemoDrag(doc, demo);
 
   rasterizer = createPageRasterizer(doc);
   setStatus(`${pages.length} halaman — dibuka langsung, isi mengalir saat scroll`);
-  updateWindow(); // rasterize whatever's on screen now
-}
-
-// The GTA-streaming core: rasterize pages within ~2 screens of the viewport,
-// release pages beyond ~4 screens (bounded memory, any doc size).
-//
-// RENDER-ON-SETTLE: while the finger is flinging fast, we DON'T rasterize — you
-// aren't reading, you're travelling, and we'd never keep up anyway. We still
-// RELEASE far pages (keep memory bounded) and show numbered placeholders. The
-// moment the scroll settles, we catch up and sharpen. Never fights the user;
-// saves the weak phone's battery on pages you fling past.
-const FLING = 45; // px/frame above which we treat it as "travelling", not reading
-
-function updateWindow(velocity = 0) {
-  if (!rasterizer || slots.length === 0) return;
-  const sc = scrollEl.getBoundingClientRect();
-  const loadPad = sc.height * 2;
-  const keepPad = sc.height * 4;
-  const flinging = velocity > FLING;
-
-  for (const slot of slots) {
-    const r = slot.view.getBoundingClientRect();
-    const near = r.bottom > sc.top - loadPad && r.top < sc.bottom + loadPad;
-    const far = r.bottom < sc.top - keepPad || r.top > sc.bottom + keepPad;
-
-    if (far && slot.page.raster) {
-      clearPageRaster(slot.view);   // release always — bounds memory even mid-fling
-      slot.page.raster = null;
-    } else if (near && !flinging && !slot.page.raster && !slot.loading) {
-      slot.loading = true;          // rasterize only when NOT flinging
-      rasterizer.rasterize(slot.page, { scale: 2 })
-        .then((raster) => { setPageRaster(slot.view, raster); slot.loading = false; })
-        .catch(() => { slot.loading = false; });
-    }
-  }
-}
-
-// Telegraph #2 — position pill. Show the center-most page ("42 / 340") while
-// scrolling; fade it out when the finger rests. Tells the user where they are
-// in a big doc and that the app is tracking them.
-const pill = document.getElementById('pv-pill');
-let pillTimer = null;
-function updatePill() {
-  if (slots.length === 0) return;
-  const mid = scrollEl.getBoundingClientRect().top + scrollEl.clientHeight / 2;
-  let current = 1;
-  for (let i = 0; i < slots.length; i += 1) {
-    if (slots[i].view.getBoundingClientRect().top <= mid) current = i + 1; else break;
-  }
-  pill.textContent = `${current} / ${slots.length}`;
-  pill.classList.add('show');
-  clearTimeout(pillTimer);
-  pillTimer = setTimeout(() => pill.classList.remove('show'), 750);
-}
-
-let lastTop = 0, settleTimer = null;
-function onScroll() {
-  if (!ticking) {
-    ticking = true;
-    requestAnimationFrame(() => {
-      ticking = false;
-      const top = scrollEl.scrollTop;
-      const v = Math.abs(top - lastTop);
-      lastTop = top;
-      updateWindow(v);            // gated: skips rasterizing during a fast fling
-      updatePill();
-    });
-  }
-  clearTimeout(settleTimer);
-  settleTimer = setTimeout(() => updateWindow(0), 130); // catch up once it settles
-}
-scrollEl.addEventListener('scroll', onScroll, { passive: true });
-window.addEventListener('resize', () => updateWindow(0));
-
-// Pointer-based drag (mouse + touch). Updates the core model, moves the element.
-// Screen delta ÷ zoom so it tracks the finger 1:1 at any zoom.
-function wireDemoDrag(doc, anno) {
-  const el = stage.querySelector(`[data-anno-id="${anno.id}"]`);
-  if (!el) return;
-  el.style.cursor = 'grab';
-  el.style.touchAction = 'none';
-  let startX = 0, startY = 0, baseX = 0, baseY = 0, dragging = false;
-
-  el.addEventListener('pointerdown', (e) => {
-    dragging = true; el.setPointerCapture(e.pointerId);
-    startX = e.clientX; startY = e.clientY; baseX = anno.x; baseY = anno.y;
-    el.style.zIndex = '1000'; el.style.cursor = 'grabbing';
-    e.preventDefault();
-  });
-  el.addEventListener('pointermove', (e) => {
-    if (!dragging) return;
-    anno.x = baseX + (e.clientX - startX) / zoom;
-    anno.y = baseY + (e.clientY - startY) / zoom;
-    el.style.left = anno.x + 'px';
-    el.style.top = anno.y + 'px';
-  });
-  const end = () => { dragging = false; el.style.cursor = 'grab'; };
-  el.addEventListener('pointerup', end);
-  el.addEventListener('pointercancel', end);
+  stream.refresh(0);
 }
 
 document.getElementById('lab-file').addEventListener('change', async (e) => {

--- a/js/render/interaction.js
+++ b/js/render/interaction.js
@@ -114,6 +114,11 @@ export function createInteraction(ctx) {
     const p = toPage(e, pageView);
     gesture = {
       kind: 'draw', pointerId: e.pointerId, pageView, page,
+      // zoom/startX/startY MUST be here like every gesture: onPointerMove's
+      // shared delta math reads them. Their absence made dx NaN and silently
+      // killed whiteout-draw entirely (caught by the founder, Jul 2).
+      zoom: ctx.getZoom(),
+      startX: e.clientX, startY: e.clientY,
       originX: p.x, originY: p.y,
       el: null, anno: null, moved: false,
     };

--- a/js/render/interaction.js
+++ b/js/render/interaction.js
@@ -1,0 +1,268 @@
+/*
+ * PDFLokal — render/interaction.js  (RENDER LAYER — the ONE input path)
+ * ============================================================================
+ * Pointer events only (mouse + touch + pen unified) — invariant #4: mobile and
+ * desktop share the same input path, different ergonomics. Delegated on the
+ * stage container; nothing here is hover-only.
+ *
+ * Hit-testing is DOM-based (closest('.pv-anno') / closest('.pv-page')) because
+ * annotations ARE elements in the new render layer. The old editor needed
+ * ~200 lines of canvas pixel math for this; that entire class of code is gone.
+ *
+ * Mutations go through core/operations (invariant #5). Undo is recorded ONCE
+ * per gesture, lazily on the first real movement — a plain tap never pollutes
+ * the undo stack.
+ *
+ * Gesture-continuity rule: while a pointer is captured we NEVER rebuild the
+ * overlay (that would destroy the captured element). Selection is decorated
+ * in place; structural re-syncs happen on gesture end via onChange.
+ */
+
+import { selectAnnotation, clearSelection, moveAnnotation, resizeAnnotation } from '../core/operations.js';
+import { record } from '../core/history.js';
+import { decorateSelected, undecorateSelected } from './page-view.js';
+
+const DOUBLE_TAP_MS = 300;
+const DOUBLE_TAP_DIST = 30;
+
+// ctx = {
+//   stage:      container holding .pv-page views
+//   getDoc:     () => Doc
+//   getZoom:    () => number (CSS scale on the stage)
+//   getTool:    () => 'select' | 'text' | 'whiteout' | 'signature' | 'paraf'
+//   history:    core history (or null to disable undo recording)
+//   onChange:   (kind, payload) => void   — 'select' | 'move' | 'resize' | 'draw'
+//   onPlace:    (tool, {pageId, x, y}) => void — tap-to-place for text/signature
+//   onEditText: (annotationId) => void — double-tap on a text annotation
+// }
+export function createInteraction(ctx) {
+  const { stage } = ctx;
+  let gesture = null;        // the active pointer gesture (one at a time)
+  let selectedEl = null;     // decorated element (kept in sync with doc.selection)
+  let lastTap = { t: 0, x: 0, y: 0, annoId: null };
+
+  // ---- coordinate mapping (screen → page-space points) ----------------------
+  function toPage(e, pageView) {
+    const r = pageView.getBoundingClientRect();
+    const zoom = ctx.getZoom();
+    return { x: (e.clientX - r.left) / zoom, y: (e.clientY - r.top) / zoom };
+  }
+
+  // ---- selection (surgical decorate/undecorate; no overlay rebuild) ---------
+  function setSelected(annoEl, anno) {
+    if (selectedEl && selectedEl !== annoEl) undecorateSelected(selectedEl);
+    selectedEl = annoEl || null;
+    const doc = ctx.getDoc();
+    if (anno) {
+      selectAnnotation(doc, anno.id);
+      if (annoEl) {
+        annoEl.style.zIndex = '1000'; // active object is ALWAYS top-most (§6.2)
+        if (!annoEl.classList.contains('pv-selected')) decorateSelected(annoEl, anno);
+      }
+    } else {
+      clearSelection(doc);
+    }
+    ctx.onChange?.('select', { annotation: anno || null });
+  }
+
+  // Re-apply selection chrome after an external overlay rebuild (undo, add…).
+  function refreshSelection() {
+    selectedEl = null;
+    const doc = ctx.getDoc();
+    const id = doc.selection.annotationId;
+    if (!id) return;
+    const el = stage.querySelector(`[data-anno-id="${id}"]`);
+    if (el) selectedEl = el;
+  }
+
+  function findAnno(doc, annoId) {
+    for (const page of doc.pages) {
+      const a = page.annotations.find((x) => x.id === annoId);
+      if (a) return { page, anno: a };
+    }
+    return null;
+  }
+
+  // ---- gestures --------------------------------------------------------------
+
+  function startDrag(e, annoEl, page, anno) {
+    const zoom = ctx.getZoom();
+    gesture = {
+      kind: 'move', pointerId: e.pointerId, annoEl, page, anno, zoom,
+      startX: e.clientX, startY: e.clientY,
+      baseX: anno.x || 0, baseY: anno.y || 0,
+      moved: false,
+    };
+    annoEl.setPointerCapture(e.pointerId);
+  }
+
+  function startResize(e, annoEl, page, anno) {
+    const zoom = ctx.getZoom();
+    // Signatures resize aspect-locked (image); whiteouts resize freely.
+    const aspect = anno.type === 'signature' && anno.width && anno.height
+      ? anno.width / anno.height : null;
+    gesture = {
+      kind: 'resize', pointerId: e.pointerId, annoEl, page, anno, zoom, aspect,
+      startX: e.clientX, startY: e.clientY,
+      baseW: anno.width || 0, baseH: anno.height || 0,
+      moved: false,
+    };
+    annoEl.setPointerCapture(e.pointerId);
+  }
+
+  function startDraw(e, pageView, page) {
+    const p = toPage(e, pageView);
+    gesture = {
+      kind: 'draw', pointerId: e.pointerId, pageView, page,
+      originX: p.x, originY: p.y,
+      el: null, anno: null, moved: false,
+    };
+    pageView.setPointerCapture(e.pointerId);
+  }
+
+  function onPointerDown(e) {
+    if (gesture) return;                    // one gesture at a time
+    if (e.button !== undefined && e.button !== 0 && e.pointerType === 'mouse') return;
+    const doc = ctx.getDoc();
+    const tool = ctx.getTool();
+
+    const handleEl = e.target.closest?.('.pv-handle');
+    const annoEl = e.target.closest?.('.pv-anno');
+    const pageView = e.target.closest?.('.pv-page');
+    if (!pageView) return;
+    const pageId = pageView.dataset.pageId;
+    const page = doc.pages.find((pg) => pg.id === pageId);
+    if (!page) return;
+
+    // 1) Resize handle beats everything.
+    if (handleEl && selectedEl && selectedEl.contains(handleEl)) {
+      const found = findAnno(doc, selectedEl.dataset.annoId);
+      if (found) {
+        e.preventDefault();
+        startResize(e, selectedEl, found.page, found.anno);
+        return;
+      }
+    }
+
+    // 2) Annotation hit → select + maybe drag (any tool: touching wins).
+    if (annoEl) {
+      const anno = page.annotations.find((a) => a.id === annoEl.dataset.annoId);
+      if (anno) {
+        e.preventDefault();                 // annotation hit: block scroll, we drag
+
+        // Double-tap on text → edit (works for touch AND mouse double-click).
+        const now = Date.now();
+        const isDouble = anno.id === lastTap.annoId &&
+          now - lastTap.t < DOUBLE_TAP_MS &&
+          Math.hypot(e.clientX - lastTap.x, e.clientY - lastTap.y) < DOUBLE_TAP_DIST;
+        lastTap = { t: now, x: e.clientX, y: e.clientY, annoId: anno.id };
+
+        setSelected(annoEl, anno);
+        if (isDouble && anno.type === 'text') {
+          ctx.onEditText?.(anno.id);
+          return;
+        }
+        startDrag(e, annoEl, page, anno);
+        return;
+      }
+    }
+
+    // 3) Empty page space: tool decides.
+    if (tool === 'whiteout') {
+      e.preventDefault();
+      startDraw(e, pageView, page);
+    } else if (tool === 'text' || tool === 'signature' || tool === 'paraf') {
+      const p = toPage(e, pageView);
+      ctx.onPlace?.(tool, { pageId: page.id, x: p.x, y: p.y });
+    } else {
+      setSelected(null, null);              // select tool: tap empty = deselect
+    }
+  }
+
+  function onPointerMove(e) {
+    if (!gesture || e.pointerId !== gesture.pointerId) return;
+    const doc = ctx.getDoc();
+    const dx = (e.clientX - gesture.startX) / gesture.zoom;
+    const dy = (e.clientY - gesture.startY) / gesture.zoom;
+
+    if (gesture.kind === 'move') {
+      if (!gesture.moved && (dx || dy)) {
+        gesture.moved = true;
+        if (ctx.history) record(ctx.history, doc);   // one undo step per gesture
+      }
+      if (!gesture.moved) return;
+      // Through the single mutation path (clamps to page), then surgical DOM.
+      const a = moveAnnotation(doc, gesture.anno.id,
+        (gesture.baseX + dx) - (gesture.anno.x || 0),
+        (gesture.baseY + dy) - (gesture.anno.y || 0));
+      if (a) {
+        gesture.annoEl.style.left = a.x + 'px';
+        gesture.annoEl.style.top = a.y + 'px';
+      }
+    } else if (gesture.kind === 'resize') {
+      if (!gesture.moved && (dx || dy)) {
+        gesture.moved = true;
+        if (ctx.history) record(ctx.history, doc);
+      }
+      if (!gesture.moved) return;
+      const w = gesture.baseW + dx;
+      const h = gesture.aspect ? w / gesture.aspect : gesture.baseH + dy;
+      const a = resizeAnnotation(doc, gesture.anno.id, { width: w, height: h });
+      if (a) {
+        gesture.annoEl.style.width = a.width + 'px';
+        if (gesture.anno.type === 'whiteout') gesture.annoEl.style.height = a.height + 'px';
+        const img = gesture.annoEl.querySelector('img');
+        if (img) img.style.width = a.width + 'px';
+      }
+    } else if (gesture.kind === 'draw') {
+      // Whiteout draw: create lazily on first movement (a stray tap draws nothing).
+      if (!gesture.anno) {
+        if (!dx && !dy) return;
+        if (ctx.history) record(ctx.history, doc);
+        gesture.moved = true;
+        // The editor owns creation (it has the factory); we hand it geometry.
+        const created = ctx.onDrawStart?.({
+          pageId: gesture.page.id, x: gesture.originX, y: gesture.originY,
+        });
+        if (!created) { gesture = null; return; }
+        gesture.anno = created;
+        gesture.el = gesture.pageView.querySelector(`[data-anno-id="${created.id}"]`);
+      }
+      const p = toPage(e, gesture.pageView);
+      const x = Math.min(gesture.originX, p.x);
+      const y = Math.min(gesture.originY, p.y);
+      const w = Math.abs(p.x - gesture.originX);
+      const h = Math.abs(p.y - gesture.originY);
+      const a = resizeAnnotation(doc, gesture.anno.id, { x, y, width: w, height: h });
+      if (a && gesture.el) {
+        gesture.el.style.left = a.x + 'px';
+        gesture.el.style.top = a.y + 'px';
+        gesture.el.style.width = a.width + 'px';
+        gesture.el.style.height = a.height + 'px';
+      }
+    }
+  }
+
+  function onPointerEnd(e) {
+    if (!gesture || e.pointerId !== gesture.pointerId) return;
+    const g = gesture;
+    gesture = null;
+    if (!g.moved) return;                    // taps already handled on down
+    const kind = g.kind === 'draw' ? 'draw' : g.kind;
+    ctx.onChange?.(kind, { annotation: g.anno });
+  }
+
+  stage.addEventListener('pointerdown', onPointerDown);
+  stage.addEventListener('pointermove', onPointerMove);
+  stage.addEventListener('pointerup', onPointerEnd);
+  stage.addEventListener('pointercancel', onPointerEnd);
+
+  function destroy() {
+    stage.removeEventListener('pointerdown', onPointerDown);
+    stage.removeEventListener('pointermove', onPointerMove);
+    stage.removeEventListener('pointerup', onPointerEnd);
+    stage.removeEventListener('pointercancel', onPointerEnd);
+  }
+
+  return { destroy, setSelected, refreshSelection };
+}

--- a/js/render/interaction.js
+++ b/js/render/interaction.js
@@ -172,6 +172,11 @@ export function createInteraction(ctx) {
       e.preventDefault();
       startDraw(e, pageView, page);
     } else if (tool === 'text' || tool === 'signature' || tool === 'paraf') {
+      // WHY preventDefault: onPlace may create + focus an inline editor NOW.
+      // Canceling pointerdown suppresses the compatibility mousedown that
+      // would otherwise fire right after and BLUR it (mouse only — touch
+      // orders compat events after pointerup, which is why only desktop broke).
+      e.preventDefault();
       const p = toPage(e, pageView);
       ctx.onPlace?.(tool, { pageId: page.id, x: p.x, y: p.y });
     } else {

--- a/js/render/page-view.js
+++ b/js/render/page-view.js
@@ -132,6 +132,11 @@ export function renderAnnotationEl(anno) {
     el.style.color = anno.color || '#000';
     el.style.whiteSpace = 'pre';
     el.style.lineHeight = '1.2';
+    // Finger-sized hit area without moving the visual position: small text at
+    // page zoom ~0.6 is a <20px target — padding grows the hit box, the
+    // negative margin cancels the layout shift. (≥44px rule, product def §6.5.)
+    el.style.padding = '10px';
+    el.style.margin = '-10px';
   } else if (anno.type === 'whiteout') {
     el.style.width = (anno.width || 0) + 'px';
     el.style.height = (anno.height || 0) + 'px';

--- a/js/render/page-view.js
+++ b/js/render/page-view.js
@@ -91,6 +91,23 @@ export function clearPageRaster(view) {
   attachPlaceholder(view);
 }
 
+// Render-side font map. Canonical names match core annotations AND the export
+// adapter's PDF font resolution — same keys as the old CSS_FONT_MAP, duplicated
+// here on purpose: the render layer must not import old-editor modules.
+export const FONT_CSS = {
+  'Helvetica': 'Helvetica, Arial, sans-serif',
+  'Times-Roman': '"Times New Roman", Times, serif',
+  'Courier': '"Courier New", Courier, monospace',
+  'Montserrat': 'Montserrat, sans-serif',
+  'Carlito': 'Carlito, Calibri, sans-serif',
+};
+
+// SSOT for a text annotation's CSS font string (page-view + inline editor).
+export function textFontCss(anno) {
+  const family = FONT_CSS[anno.fontFamily] || FONT_CSS['Helvetica'];
+  return `${anno.italic ? 'italic ' : ''}${anno.bold ? '700 ' : '400 '}${anno.fontSize || 24}px ${family}`;
+}
+
 // One annotation as a positioned DOM element (page-space px).
 export function renderAnnotationEl(anno) {
   const el = document.createElement('div');
@@ -106,9 +123,7 @@ export function renderAnnotationEl(anno) {
 
   if (anno.type === 'text') {
     el.textContent = anno.text || '';
-    el.style.font =
-      `${anno.italic ? 'italic ' : ''}${anno.bold ? '700 ' : '400 '}` +
-      `${anno.fontSize || 24}px ${anno.fontFamily || 'Helvetica, Arial, sans-serif'}`;
+    el.style.font = textFontCss(anno);
     el.style.color = anno.color || '#000';
     el.style.whiteSpace = 'pre';
     el.style.lineHeight = '1.2';

--- a/js/render/page-view.js
+++ b/js/render/page-view.js
@@ -97,6 +97,12 @@ export function renderAnnotationEl(anno) {
   el.className = 'pv-anno pv-anno-' + anno.type;
   el.dataset.annoId = anno.id;
   el.style.cssText = `position:absolute;left:${anno.x || 0}px;top:${anno.y || 0}px`;
+  // WHY: on touch, preventDefault in pointerdown does NOT stop the browser
+  // hijacking the gesture for scroll — only touch-action does. Without this,
+  // dragging an annotation on a phone scrolls the page instead (old bug class).
+  if (anno.type === 'text' || anno.type === 'whiteout' || anno.type === 'signature') {
+    el.style.touchAction = 'none';
+  }
 
   if (anno.type === 'text') {
     el.textContent = anno.text || '';
@@ -113,8 +119,98 @@ export function renderAnnotationEl(anno) {
   } else if (anno.type === 'signature' && anno.image) {
     const im = document.createElement('img');
     im.src = anno.image;
-    im.style.cssText = `display:block;width:${anno.width || 150}px;height:auto`;
+    im.draggable = false;
+    im.style.cssText = `display:block;width:${anno.width || 150}px;height:auto;pointer-events:none;user-select:none`;
     el.appendChild(im);
+  } else if (anno.type === 'watermark') {
+    el.textContent = anno.text || '';
+    el.style.font = `700 ${anno.fontSize || 48}px Helvetica, Arial, sans-serif`;
+    el.style.color = anno.color || '#888';
+    el.style.opacity = String(anno.opacity ?? 0.3);
+    el.style.transform = `rotate(${anno.rotation ?? -45}deg)`;
+    el.style.transformOrigin = 'center';
+    el.style.whiteSpace = 'nowrap';
+    el.style.pointerEvents = 'none'; // watermarks are page-level, not draggable
+  } else if (anno.type === 'pageNumber') {
+    el.textContent = anno.text || '';
+    el.style.font = `${anno.fontSize || 12}px Helvetica, Arial, sans-serif`;
+    el.style.color = anno.color || '#000';
+    el.style.pointerEvents = 'none';
   }
   return el;
+}
+
+// ---- surgical sync (model → DOM without touching the page image) -----------
+
+// Rebuild ONLY the overlay from the model. Cheap (a handful of annos per page)
+// and never disturbs the raster <img> — so a selection change or an added
+// annotation can never cause a page flash. The drag hot path bypasses even
+// this (interaction.js updates left/top style directly).
+export function syncOverlay(page, view, opts = {}) {
+  const { activeId = null } = opts;
+  const overlay = view.querySelector('.pv-overlay');
+  if (!overlay) return;
+  overlay.innerHTML = '';
+  for (const anno of page.annotations) {
+    const el = renderAnnotationEl(anno);
+    const active = anno.id === activeId;
+    el.style.zIndex = active ? '1000' : '1';
+    if (active) decorateSelected(el, anno);
+    overlay.appendChild(el);
+  }
+}
+
+// Selection chrome: outline + resize handle, ALL inside the annotation element
+// so it inherits the element's stacking (top-most with it — invariant §6.2).
+// 22px handle hit-area (44px effective with padding at typical zoom) for touch.
+// Exported: interaction.js decorates IN PLACE during gestures — rebuilding the
+// overlay mid-gesture would destroy the element holding the pointer capture.
+export function decorateSelected(el, anno) {
+  el.classList.add('pv-selected');
+  el.style.outline = '1.5px solid #4f8ef7';
+  el.style.outlineOffset = '2px';
+  const resizable = anno.type === 'whiteout' || anno.type === 'signature';
+  if (!resizable) return;
+  const h = document.createElement('div');
+  h.className = 'pv-handle';
+  h.dataset.handle = 'se';
+  h.style.cssText =
+    'position:absolute;right:-11px;bottom:-11px;width:22px;height:22px;' +
+    'display:flex;align-items:center;justify-content:center;cursor:nwse-resize;touch-action:none';
+  const dot = document.createElement('div');
+  dot.style.cssText =
+    'width:12px;height:12px;border-radius:50%;background:#4f8ef7;border:2px solid #fff;' +
+    'box-shadow:0 1px 4px rgba(0,0,0,.35)';
+  h.appendChild(dot);
+  el.appendChild(h);
+}
+
+export function undecorateSelected(el) {
+  el.classList.remove('pv-selected');
+  el.style.outline = '';
+  el.style.outlineOffset = '';
+  el.style.zIndex = '1';
+  el.querySelector('.pv-handle')?.remove();
+}
+
+// ---- slot factory (page + view + streaming hooks travel together) -----------
+
+// A slot pairs a core Page with its DOM view and owns the raster attach/release
+// pair, so the viewport-stream engine (viewport.js) never reaches into either.
+export function createPageSlot(page, opts = {}) {
+  const view = renderPageView(page, opts);
+  const slot = {
+    page,
+    view,
+    loading: false,
+    attach(raster) {
+      page.raster = raster;
+      setPageRaster(view, raster);
+    },
+    release() {
+      page.raster = null;
+      clearPageRaster(view);
+    },
+  };
+  return slot;
 }

--- a/js/render/page-view.js
+++ b/js/render/page-view.js
@@ -25,8 +25,13 @@ export function renderPageView(page, opts = {}) {
   const view = document.createElement('div');
   view.className = 'pv-page';
   view.dataset.pageId = page.id;
+  // Displayed size swaps for 90/270 — the raster is rendered pre-rotated, so
+  // the view (and every annotation coordinate) lives in the ROTATED frame.
+  const rotated = (page.rotation || 0) % 180 !== 0;
+  const w = rotated ? page.height : page.width;
+  const h = rotated ? page.width : page.height;
   view.style.cssText =
-    `position:relative;flex:0 0 auto;width:${page.width}px;height:${page.height}px;` +
+    `position:relative;flex:0 0 auto;width:${w}px;height:${h}px;` +
     'background:#fff;box-shadow:0 2px 14px rgba(0,0,0,.14);border-radius:2px';
 
   // Intentional placeholder text (e.g. "Hal 42") so a flung-past page reads as

--- a/js/render/viewport.js
+++ b/js/render/viewport.js
@@ -1,0 +1,110 @@
+/*
+ * PDFLokal — render/viewport.js  (RENDER LAYER — streaming window)
+ * ============================================================================
+ * The GTA-maps streaming engine, extracted from the lab harness after it was
+ * validated on a real Android (Jul 2026). Owns WHEN pages rasterize/release;
+ * owns nothing about HOW they look (page-view.js) or WHAT they mean (core/).
+ *
+ * The three locked behaviors (memory/render-architecture-2026-07.md):
+ *   1. STREAM — rasterize only pages within `loadScreens` of the viewport,
+ *      release beyond `keepScreens`. Memory stays bounded on ANY doc size —
+ *      the only approach that survives low-end Android ("1 juta phones").
+ *   2. RENDER-ON-SETTLE — while flinging faster than `fling` px/frame we do
+ *      NOT rasterize (travelling, not reading) but we still RELEASE far pages.
+ *      On settle (`settleMs`) we catch up and sharpen. Never fight the finger.
+ *   3. TELEGRAPH — position changes are reported so the UI can show a pill;
+ *      placeholders are page-view.js's job. This module stays chrome-free.
+ *
+ * Container-scroll (not body-scroll) by design: `overscroll-behavior: contain`
+ * on the scroll element kills the edge-overscroll recomposition flicker that
+ * body scroll can never avoid (old editor's known limitation).
+ */
+
+// slots: () => [{ page, view, loading }] — owned by the editor, read here.
+// rasterize: (page) => Promise<raster> — adapter around createPageRasterizer.
+export function createViewportStream({
+  scrollEl,
+  slots,
+  rasterize,
+  loadScreens = 2,
+  keepScreens = 4,
+  fling = 45,
+  settleMs = 130,
+  onPosition = null, // (currentPageNumber, total) — fires on scroll for the pill
+}) {
+  let ticking = false;
+  let lastTop = 0;
+  let settleTimer = null;
+  let attached = false;
+
+  function refresh(velocity = 0) {
+    const list = slots();
+    if (list.length === 0) return;
+    const sc = scrollEl.getBoundingClientRect();
+    const loadPad = sc.height * loadScreens;
+    const keepPad = sc.height * keepScreens;
+    const flinging = velocity > fling;
+
+    for (const slot of list) {
+      const r = slot.view.getBoundingClientRect();
+      const near = r.bottom > sc.top - loadPad && r.top < sc.bottom + loadPad;
+      const far = r.bottom < sc.top - keepPad || r.top > sc.bottom + keepPad;
+
+      if (far && slot.page.raster) {
+        slot.release();               // release always — bounds memory even mid-fling
+      } else if (near && !flinging && !slot.page.raster && !slot.loading) {
+        slot.loading = true;          // rasterize only when NOT flinging
+        rasterize(slot.page)
+          .then((raster) => { slot.attach(raster); slot.loading = false; })
+          .catch(() => { slot.loading = false; });
+      }
+    }
+  }
+
+  function reportPosition() {
+    if (!onPosition) return;
+    const list = slots();
+    if (list.length === 0) return;
+    const mid = scrollEl.getBoundingClientRect().top + scrollEl.clientHeight / 2;
+    let current = 1;
+    for (let i = 0; i < list.length; i += 1) {
+      if (list[i].view.getBoundingClientRect().top <= mid) current = i + 1; else break;
+    }
+    onPosition(current, list.length);
+  }
+
+  function onScroll() {
+    if (!ticking) {
+      ticking = true;
+      requestAnimationFrame(() => {
+        ticking = false;
+        const top = scrollEl.scrollTop;
+        const v = Math.abs(top - lastTop);
+        lastTop = top;
+        refresh(v);                   // gated: skips rasterizing during a fast fling
+        reportPosition();
+      });
+    }
+    clearTimeout(settleTimer);
+    settleTimer = setTimeout(() => refresh(0), settleMs); // catch up once settled
+  }
+
+  const onResize = () => refresh(0);
+
+  function attach() {
+    if (attached) return;
+    attached = true;
+    scrollEl.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onResize);
+  }
+
+  function detach() {
+    if (!attached) return;
+    attached = false;
+    scrollEl.removeEventListener('scroll', onScroll);
+    window.removeEventListener('resize', onResize);
+    clearTimeout(settleTimer);
+  }
+
+  return { refresh, attach, detach, reportPosition };
+}

--- a/js/v2/app.js
+++ b/js/v2/app.js
@@ -27,6 +27,7 @@ import { createViewportStream } from '../render/viewport.js';
 import { createInteraction } from '../render/interaction.js';
 import { createFormatBar } from './format-bar.js';
 import { createPageManager } from './page-manager.js';
+import { createSignatureModal } from './signature-modal.js';
 
 window.pdfjsLib.GlobalWorkerOptions.workerSrc = '/js/vendor/pdf.worker.min.js';
 
@@ -125,6 +126,7 @@ function refreshChrome() {
   document.getElementById('btn-pages').disabled = doc.pages.length === 0;
   document.getElementById('btn-delete-anno').disabled = !doc.selection.annotationId;
   syncFormatBar();
+  syncSigBar();
 }
 
 // ---- format bar ----------------------------------------------------------------
@@ -183,7 +185,7 @@ function setTool(next) {
 for (const btn of document.querySelectorAll('#toolbar .tool[data-tool]')) {
   btn.addEventListener('click', () => {
     const t = btn.dataset.tool;
-    if (t === 'signature' && !storedSignature) { openSigModal(); return; }
+    if (t === 'signature' && !storedSignature) { signatureModal.open(); return; }
     setTool(t);
     if (t === 'text') toast('Ketuk halaman untuk menulis');
     if (t === 'whiteout') toast('Seret di halaman untuk menutup teks');
@@ -207,12 +209,14 @@ const interaction = createInteraction({
       openTextEditor({ pageId, x, y, anno: null });
     } else if (t === 'signature' && storedSignature) {
       record(history, doc);
-      const w = 150;
+      // Paraf places small (initials), signature at document scale.
+      const w = storedSignature.subtype === 'paraf' ? 80 : 150;
       const h = w * (storedSignature.height / storedSignature.width);
-      addAnnotation(doc, pageId, createAnnotation('signature', {
-        image: storedSignature.dataUrl,
+      const created = addAnnotation(doc, pageId, createAnnotation('signature', {
+        image: storedSignature.dataUrl, subtype: storedSignature.subtype,
         x: Math.max(0, x - w / 2), y: Math.max(0, y - h / 2), width: w, height: h,
       }));
+      selectAnnotation(doc, created.id); // selected → "Semua Hal." is one tap away
       syncPage(pageId);
       setTool('select'); // tools are verbs; back home
     }
@@ -337,29 +341,57 @@ function openTextEditor({ pageId, x, y, anno }) {
   sel.collapseToEnd();
 }
 
-// ---- signature modal ------------------------------------------------------------------
-const sigModal = document.getElementById('sig-modal');
-let sigPad = null;
-function openSigModal() {
-  sigModal.showModal();
-  const canvas = document.getElementById('sig-canvas');
-  const dpr = Math.min(window.devicePixelRatio || 1, 2);
-  canvas.width = canvas.offsetWidth * dpr;
-  canvas.height = canvas.offsetHeight * dpr;
-  canvas.getContext('2d').scale(dpr, dpr);
-  sigPad = new window.SignaturePad(canvas, { minWidth: 1, maxWidth: 2.4 });
+// ---- signature modal (draw / upload / paraf) --------------------------------------------
+const signatureModal = createSignatureModal({
+  modal: document.getElementById('sig-modal'),
+  toast,
+  onReady: (sig) => {
+    storedSignature = sig; // { dataUrl, width, height, subtype }
+    setTool('signature');
+    toast(sig.subtype === 'paraf'
+      ? 'Ketuk halaman untuk menempatkan paraf'
+      : 'Ketuk halaman untuk menempatkan tanda tangan');
+  },
+});
+
+// ---- "Semua Hal." — copy the selected signature/paraf to every page ----------------------
+function selectedSignatureAnno() {
+  const id = doc.selection.annotationId;
+  if (!id) return null;
+  for (const page of doc.pages) {
+    const a = page.annotations.find((x) => x.id === id);
+    if (a) return a.type === 'signature' ? { page, anno: a } : null;
+  }
+  return null;
 }
-document.getElementById('sig-clear').onclick = () => sigPad?.clear();
-document.getElementById('sig-cancel').onclick = () => sigModal.close();
-document.getElementById('sig-use').onclick = () => {
-  if (!sigPad || sigPad.isEmpty()) { toast('Gambar tanda tanganmu dulu ya'); return; }
-  const canvas = document.getElementById('sig-canvas');
-  storedSignature = { dataUrl: canvas.toDataURL('image/png'), width: canvas.width, height: canvas.height };
-  sigModal.close();
-  setTool('signature');
-  toast('Ketuk halaman untuk menempatkan tanda tangan');
-};
-sigModal.addEventListener('click', (e) => { if (e.target === sigModal) sigModal.close(); });
+
+function syncSigBar() {
+  const found = selectedSignatureAnno();
+  const bar = document.getElementById('sig-bar');
+  bar.classList.toggle('show', !!found && doc.pages.length > 1);
+  if (found) {
+    document.getElementById('sig-bar-label').textContent =
+      found.anno.subtype === 'paraf' ? 'Paraf terpilih' : 'Tanda tangan terpilih';
+  }
+}
+
+document.getElementById('btn-all-pages').addEventListener('click', () => {
+  const found = selectedSignatureAnno();
+  if (!found) return;
+  const { page: home, anno } = found;
+  record(history, doc);
+  for (const page of doc.pages) {
+    if (page.id === home.id) continue;
+    // Same position on every page; each copy is its OWN object (new id) so it
+    // moves/deletes independently afterwards.
+    addAnnotation(doc, page.id, createAnnotation('signature', {
+      image: anno.image, subtype: anno.subtype,
+      x: anno.x, y: anno.y, width: anno.width, height: anno.height,
+    }));
+  }
+  rebuildStage();
+  toast(`Diterapkan ke ${doc.pages.length - 1} halaman lain ✓`);
+});
 
 // ---- delete / undo / redo ------------------------------------------------------------
 function deleteSelected() {

--- a/js/v2/app.js
+++ b/js/v2/app.js
@@ -26,6 +26,7 @@ import { createPageSlot, syncOverlay, textFontCss } from '../render/page-view.js
 import { createViewportStream } from '../render/viewport.js';
 import { createInteraction } from '../render/interaction.js';
 import { createFormatBar } from './format-bar.js';
+import { createPageManager } from './page-manager.js';
 
 window.pdfjsLib.GlobalWorkerOptions.workerSrc = '/js/vendor/pdf.worker.min.js';
 
@@ -121,6 +122,7 @@ function refreshChrome() {
   document.getElementById('btn-undo').disabled = !canUndo(history);
   document.getElementById('btn-redo').disabled = !canRedo(history);
   document.getElementById('btn-download').disabled = doc.pages.length === 0;
+  document.getElementById('btn-pages').disabled = doc.pages.length === 0;
   document.getElementById('btn-delete-anno').disabled = !doc.selection.annotationId;
   syncFormatBar();
 }
@@ -230,6 +232,35 @@ const interaction = createInteraction({
     }
   },
 });
+
+// ---- page manager (Halaman sheet) -----------------------------------------------
+const pageManager = createPageManager({
+  sheet: document.getElementById('pm-sheet'),
+  grid: document.getElementById('pm-grid'),
+  bulkBar: document.getElementById('pm-bulk'),
+  getDoc: () => doc,
+  history,
+  getRasterizer: () => rasterizer,
+  onDocChanged: rebuildStage,
+  onAddFiles: () => document.getElementById('file-input').click(),
+  onExtract: async (pages) => {
+    // Export ONLY the selected pages: a shallow Doc sharing the same sources.
+    try {
+      toast('Menyiapkan PDF…');
+      const { buildPdfBytes } = await import('../core/export.js');
+      const subset = { sources: doc.sources, pages, selection: { pageId: null, annotationId: null } };
+      const bytes = await buildPdfBytes(subset, { PDFLib: window.PDFLib, fontkit: window.fontkit });
+      download(new Blob([bytes], { type: 'application/pdf' }), `${baseName}-halaman-${pages.length}.pdf`);
+      toast(`${pages.length} halaman diekstrak ✓`);
+    } catch (err) {
+      console.error(err);
+      toast('Gagal mengekstrak — coba lagi ya');
+    }
+  },
+  toast,
+});
+document.getElementById('btn-pages').addEventListener('click', () => pageManager.open());
+document.getElementById('pm-close').addEventListener('click', () => pageManager.close());
 
 // ---- inline text editing ------------------------------------------------------------
 // One code path for "place new text" and "edit existing text": a contenteditable
@@ -383,6 +414,8 @@ async function loadFiles(files) {
   }
   rebuildStage();
   if (!firstLoad) toast(`${pdfs.length} file ditambahkan`);
+  // If the Halaman sheet triggered this add, refresh its grid in place.
+  if (document.getElementById('pm-sheet').open) pageManager.render();
 }
 
 const fileInput = document.getElementById('file-input');

--- a/js/v2/app.js
+++ b/js/v2/app.js
@@ -68,11 +68,16 @@ function download(blob, filename) {
 }
 
 // ---- zoom ---------------------------------------------------------------------
-// CSS `zoom` (standardized 2024), NOT transform: it participates in layout, so
-// the scroll container sizes correctly at any zoom — no sizer-div math. gBCR
-// returns zoomed values, which is exactly what interaction.js divides out.
+// transform:scale + a sizer that carries the scaled layout size. NOT CSS zoom:
+// zoom's coordinate reporting was quirky pre-Chrome-128, and old Androids are
+// exactly who we build for. gBCR under transform returns visual coords on every
+// engine ever — which is what interaction.js divides by zoom.
+const sizer = document.getElementById('v2-sizer');
 function applyZoom() {
-  stage.style.zoom = zoom;
+  stage.style.transform = `scale(${zoom})`;
+  // offsetWidth/Height are layout (pre-transform) sizes — scale them ourselves.
+  sizer.style.width = Math.ceil(stage.offsetWidth * zoom) + 'px';
+  sizer.style.height = Math.ceil(stage.offsetHeight * zoom) + 'px';
   stream.refresh(0);
 }
 document.getElementById('z-in').onclick = () => { zoom = Math.min(zoom + 0.25, 3); applyZoom(); };
@@ -109,7 +114,7 @@ function rebuildStage() {
   });
   interaction.refreshSelection();
   refreshChrome();
-  stream.refresh(0);
+  applyZoom(); // stage layout size changed → re-size the sizer (also refreshes)
 }
 
 // Re-render one page's overlay after a structural annotation change.
@@ -490,9 +495,8 @@ async function loadFiles(files) {
 
   if (firstLoad) {
     zoom = Math.min(1, (scrollEl.clientWidth - 16) / doc.pages[0].width);
-    stage.style.zoom = zoom;
   }
-  rebuildStage();
+  rebuildStage(); // applies zoom + sizer at the end
   if (!firstLoad) toast(`${usable.length} file ditambahkan`);
   // If the Halaman sheet triggered this add, refresh its grid in place.
   if (document.getElementById('pm-sheet').open) pageManager.render();

--- a/js/v2/app.js
+++ b/js/v2/app.js
@@ -22,7 +22,7 @@ import {
   moveAnnotation,
 } from '../core/operations.js';
 import { createHistory, record, undo, redo, canUndo, canRedo } from '../core/history.js';
-import { importPdf, createPageRasterizer } from '../core/import.js';
+import { importPdf, importImage, createPageRasterizer } from '../core/import.js';
 import { createPageSlot, syncOverlay, textFontCss } from '../render/page-view.js';
 import { createViewportStream } from '../render/viewport.js';
 import { createInteraction } from '../render/interaction.js';
@@ -469,17 +469,21 @@ const SIZE_WARN = 20 * 1024 * 1024;
 const SIZE_BLOCK = 100 * 1024 * 1024;
 
 async function loadFiles(files) {
-  const pdfs = [...files].filter((f) => f.type === 'application/pdf' || /\.pdf$/i.test(f.name));
-  if (pdfs.length === 0) { toast('Pilih file PDF ya'); return; }
-  const oversize = pdfs.find((f) => f.size > SIZE_BLOCK);
+  const isPdf = (f) => f.type === 'application/pdf' || /\.pdf$/i.test(f.name);
+  const isImg = (f) => f.type.startsWith('image/');
+  // In picker order: PDFs append their pages, images become one page each.
+  const usable = [...files].filter((f) => isPdf(f) || isImg(f));
+  if (usable.length === 0) { toast('Pilih file PDF atau gambar ya'); return; }
+  const oversize = usable.find((f) => f.size > SIZE_BLOCK);
   if (oversize) { toast(`"${oversize.name}" terlalu besar (maks 100MB)`); return; }
-  if (pdfs.some((f) => f.size > SIZE_WARN)) toast('File besar — proses bisa agak lama ya');
+  if (usable.some((f) => f.size > SIZE_WARN)) toast('File besar — proses bisa agak lama ya');
   const firstLoad = doc.pages.length === 0;
-  if (firstLoad) baseName = pdfs[0].name.replace(/\.pdf$/i, '');
+  if (firstLoad) baseName = usable[0].name.replace(/\.[^.]+$/, '');
 
-  for (const f of pdfs) {
+  for (const f of usable) {
     const bytes = new Uint8Array(await f.arrayBuffer());
-    await importPdf(doc, { name: f.name, bytes }); // appends pages → merge
+    if (isPdf(f)) await importPdf(doc, { name: f.name, bytes });
+    else await importImage(doc, { name: f.name, bytes, mimeType: f.type });
   }
   if (!rasterizer) rasterizer = createPageRasterizer(doc);
   emptyEl.style.display = 'none';
@@ -489,7 +493,7 @@ async function loadFiles(files) {
     stage.style.zoom = zoom;
   }
   rebuildStage();
-  if (!firstLoad) toast(`${pdfs.length} file ditambahkan`);
+  if (!firstLoad) toast(`${usable.length} file ditambahkan`);
   // If the Halaman sheet triggered this add, refresh its grid in place.
   if (document.getElementById('pm-sheet').open) pageManager.render();
 }

--- a/js/v2/app.js
+++ b/js/v2/app.js
@@ -1,0 +1,373 @@
+/*
+ * PDFLokal — v2/app.js  (EDITOR V2 SHELL — the clean rebuild)
+ * ============================================================================
+ * The application layer: owns the Doc, the history, the tool state, and the
+ * DOM chrome. All heavy lifting is delegated:
+ *   - model + mutations  → js/core/  (headless, tested in Node)
+ *   - page views / slots → js/render/page-view.js
+ *   - streaming window   → js/render/viewport.js  (phone-validated)
+ *   - input              → js/render/interaction.js (one pointer path)
+ *   - PDF I/O            → js/core/import.js + js/core/export.js
+ *
+ * Interaction rules implemented here (product-definition §6):
+ *   - tools are verbs; Pilih is home (text/signature return to it after use;
+ *     whiteout stays sticky — the honest multi-stamp exception)
+ *   - every action reversible; no confirm dialogs
+ *   - nothing hover-only; touch targets ≥44px
+ */
+
+import { createDoc, createAnnotation } from '../core/model.js';
+import {
+  addAnnotation, removeAnnotation, updateAnnotation, clearSelection,
+} from '../core/operations.js';
+import { createHistory, record, undo, redo, canUndo, canRedo } from '../core/history.js';
+import { importPdf, createPageRasterizer } from '../core/import.js';
+import { createPageSlot, syncOverlay } from '../render/page-view.js';
+import { createViewportStream } from '../render/viewport.js';
+import { createInteraction } from '../render/interaction.js';
+
+window.pdfjsLib.GlobalWorkerOptions.workerSrc = '/js/vendor/pdf.worker.min.js';
+
+// ---- state (ONE doc, ONE history — everything else is DOM or derived) -------
+const doc = createDoc();
+const history = createHistory();
+let slots = [];
+let rasterizer = null;
+let zoom = 1;
+let tool = 'select';
+let storedSignature = null;   // { dataUrl, width, height } from the sig modal
+let baseName = 'dokumen';
+
+const scrollEl = document.getElementById('v2-scroll');
+const stage = document.getElementById('v2-stage');
+const emptyEl = document.getElementById('empty');
+const pill = document.getElementById('v2-pill');
+const toastEl = document.getElementById('toast');
+
+// ---- small helpers -----------------------------------------------------------
+let toastTimer = null;
+function toast(msg) {
+  toastEl.textContent = msg;
+  toastEl.classList.add('show');
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => toastEl.classList.remove('show'), 2600);
+}
+
+function download(blob, filename) {
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = filename;
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(a.href), 4000);
+}
+
+// ---- zoom ---------------------------------------------------------------------
+// CSS `zoom` (standardized 2024), NOT transform: it participates in layout, so
+// the scroll container sizes correctly at any zoom — no sizer-div math. gBCR
+// returns zoomed values, which is exactly what interaction.js divides out.
+function applyZoom() {
+  stage.style.zoom = zoom;
+  stream.refresh(0);
+}
+document.getElementById('z-in').onclick = () => { zoom = Math.min(zoom + 0.25, 3); applyZoom(); };
+document.getElementById('z-out').onclick = () => { zoom = Math.max(zoom - 0.25, 0.3); applyZoom(); };
+
+// ---- streaming viewport --------------------------------------------------------
+let pillTimer = null;
+const stream = createViewportStream({
+  scrollEl,
+  slots: () => slots,
+  rasterize: (page) => rasterizer.rasterize(page, { scale: 2 }),
+  onPosition: (current, total) => {
+    pill.textContent = `${current} / ${total}`;
+    pill.classList.add('show');
+    clearTimeout(pillTimer);
+    pillTimer = setTimeout(() => pill.classList.remove('show'), 750);
+  },
+});
+stream.attach();
+
+// ---- stage sync ----------------------------------------------------------------
+// Full rebuild from the model. Cheap in practice: rasters ride on page objects
+// (shared through history snapshots), so undo/redo re-shows pages instantly —
+// no PDF.js work. Per-gesture hot paths never come through here.
+function rebuildStage() {
+  stage.innerHTML = '';
+  slots = doc.pages.map((page, i) => {
+    const slot = createPageSlot(page, {
+      activeId: doc.selection.annotationId,
+      label: `Hal ${i + 1}`,
+    });
+    stage.appendChild(slot.view);
+    return slot;
+  });
+  interaction.refreshSelection();
+  refreshChrome();
+  stream.refresh(0);
+}
+
+// Re-render one page's overlay after a structural annotation change.
+function syncPage(pageId) {
+  const slot = slots.find((s) => s.page.id === pageId);
+  if (slot) syncOverlay(slot.page, slot.view, { activeId: doc.selection.annotationId });
+  interaction.refreshSelection();
+  refreshChrome();
+}
+
+function refreshChrome() {
+  document.getElementById('btn-undo').disabled = !canUndo(history);
+  document.getElementById('btn-redo').disabled = !canRedo(history);
+  document.getElementById('btn-download').disabled = doc.pages.length === 0;
+  document.getElementById('btn-delete-anno').disabled = !doc.selection.annotationId;
+}
+
+// ---- tools ----------------------------------------------------------------------
+function setTool(next) {
+  tool = next;
+  for (const btn of document.querySelectorAll('#toolbar .tool[data-tool]')) {
+    const active = btn.dataset.tool === next;
+    btn.classList.toggle('active', active);
+    btn.setAttribute('aria-pressed', String(active));
+  }
+  // While a placement tool is active the page must not pan under the finger.
+  stage.style.touchAction = next === 'select' ? '' : 'none';
+}
+for (const btn of document.querySelectorAll('#toolbar .tool[data-tool]')) {
+  btn.addEventListener('click', () => {
+    const t = btn.dataset.tool;
+    if (t === 'signature' && !storedSignature) { openSigModal(); return; }
+    setTool(t);
+    if (t === 'text') toast('Ketuk halaman untuk menulis');
+    if (t === 'whiteout') toast('Seret di halaman untuk menutup teks');
+    if (t === 'signature') toast('Ketuk halaman untuk menempatkan tanda tangan');
+  });
+}
+
+// ---- interaction wiring ------------------------------------------------------------
+const interaction = createInteraction({
+  stage,
+  getDoc: () => doc,
+  getZoom: () => zoom,
+  getTool: () => tool,
+  history,
+  onChange: (kind) => {
+    if (kind === 'select') refreshChrome();
+    else refreshChrome(); // move/resize/draw: chrome only; DOM was updated surgically
+  },
+  onPlace: (t, { pageId, x, y }) => {
+    if (t === 'text') {
+      openTextEditor({ pageId, x, y, anno: null });
+    } else if (t === 'signature' && storedSignature) {
+      record(history, doc);
+      const w = 150;
+      const h = w * (storedSignature.height / storedSignature.width);
+      addAnnotation(doc, pageId, createAnnotation('signature', {
+        image: storedSignature.dataUrl,
+        x: Math.max(0, x - w / 2), y: Math.max(0, y - h / 2), width: w, height: h,
+      }));
+      syncPage(pageId);
+      setTool('select'); // tools are verbs; back home
+    }
+  },
+  onDrawStart: ({ pageId, x, y }) => {
+    // Whiteout drag-to-draw. interaction.js already recorded history.
+    const anno = addAnnotation(doc, pageId, createAnnotation('whiteout', {
+      x, y, width: 8, height: 8,
+    }));
+    syncPage(pageId);
+    return anno; // whiteout stays sticky (multi-stamp exception)
+  },
+  onEditText: (annoId) => {
+    for (const page of doc.pages) {
+      const anno = page.annotations.find((a) => a.id === annoId);
+      if (anno) { openTextEditor({ pageId: page.id, x: anno.x, y: anno.y, anno }); return; }
+    }
+  },
+});
+
+// ---- inline text editing ------------------------------------------------------------
+// One code path for "place new text" and "edit existing text": a contenteditable
+// positioned in the page overlay at page coords. Commit on blur / Enter.
+function openTextEditor({ pageId, x, y, anno }) {
+  const slot = slots.find((s) => s.page.id === pageId);
+  if (!slot) return;
+  const overlay = slot.view.querySelector('.pv-overlay');
+  const fontSize = anno?.fontSize || 18;
+
+  const ed = document.createElement('div');
+  ed.className = 'v2-text-edit';
+  ed.contentEditable = 'true';
+  ed.style.left = (anno ? anno.x : x) + 'px';
+  ed.style.top = (anno ? anno.y : y) + 'px';
+  ed.style.font = `${anno?.italic ? 'italic ' : ''}${anno?.bold ? '700 ' : '400 '}${fontSize}px Helvetica, Arial, sans-serif`;
+  ed.style.color = anno?.color || '#000';
+  ed.textContent = anno?.text || '';
+
+  // Hide the original while editing (the editor visually replaces it).
+  const origEl = anno ? overlay.querySelector(`[data-anno-id="${anno.id}"]`) : null;
+  if (origEl) origEl.style.visibility = 'hidden';
+
+  let committed = false; // guard: blur fires after Enter-commit too
+  const commit = () => {
+    if (committed) return;
+    committed = true;
+    const text = ed.textContent.trim();
+    ed.remove();
+    if (anno) {
+      if (text && text !== anno.text) {
+        record(history, doc);
+        updateAnnotation(doc, anno.id, { text });
+      } else if (!text) {
+        record(history, doc);
+        removeAnnotation(doc, anno.id);
+      }
+    } else if (text) {
+      record(history, doc);
+      addAnnotation(doc, pageId, createAnnotation('text', {
+        text, x, y, fontSize, color: '#000',
+      }));
+    }
+    syncPage(pageId);
+    setTool('select');
+  };
+
+  ed.addEventListener('blur', commit);
+  ed.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); ed.blur(); }
+    if (e.key === 'Escape') { ed.textContent = anno?.text || ''; ed.blur(); }
+    e.stopPropagation(); // don't trigger app shortcuts while typing
+  });
+  ed.addEventListener('pointerdown', (e) => e.stopPropagation());
+
+  overlay.appendChild(ed);
+  ed.focus();
+  // Place the caret at the end (mobile keyboards otherwise start at 0).
+  const sel = window.getSelection();
+  sel.selectAllChildren(ed);
+  sel.collapseToEnd();
+}
+
+// ---- signature modal ------------------------------------------------------------------
+const sigModal = document.getElementById('sig-modal');
+let sigPad = null;
+function openSigModal() {
+  sigModal.showModal();
+  const canvas = document.getElementById('sig-canvas');
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  canvas.width = canvas.offsetWidth * dpr;
+  canvas.height = canvas.offsetHeight * dpr;
+  canvas.getContext('2d').scale(dpr, dpr);
+  sigPad = new window.SignaturePad(canvas, { minWidth: 1, maxWidth: 2.4 });
+}
+document.getElementById('sig-clear').onclick = () => sigPad?.clear();
+document.getElementById('sig-cancel').onclick = () => sigModal.close();
+document.getElementById('sig-use').onclick = () => {
+  if (!sigPad || sigPad.isEmpty()) { toast('Gambar tanda tanganmu dulu ya'); return; }
+  const canvas = document.getElementById('sig-canvas');
+  storedSignature = { dataUrl: canvas.toDataURL('image/png'), width: canvas.width, height: canvas.height };
+  sigModal.close();
+  setTool('signature');
+  toast('Ketuk halaman untuk menempatkan tanda tangan');
+};
+sigModal.addEventListener('click', (e) => { if (e.target === sigModal) sigModal.close(); });
+
+// ---- delete / undo / redo ------------------------------------------------------------
+function deleteSelected() {
+  const id = doc.selection.annotationId;
+  if (!id) return;
+  let pageId = null;
+  for (const page of doc.pages) {
+    if (page.annotations.some((a) => a.id === id)) { pageId = page.id; break; }
+  }
+  record(history, doc);
+  removeAnnotation(doc, id);
+  if (pageId) syncPage(pageId);
+}
+document.getElementById('btn-delete-anno').addEventListener('click', deleteSelected);
+
+function doUndo() { if (undo(history, doc)) rebuildStage(); }
+function doRedo() { if (redo(history, doc)) rebuildStage(); }
+document.getElementById('btn-undo').addEventListener('click', doUndo);
+document.getElementById('btn-redo').addEventListener('click', doRedo);
+
+document.addEventListener('keydown', (e) => {
+  const mod = e.ctrlKey || e.metaKey;
+  if (mod && e.key === 'z') { e.preventDefault(); e.shiftKey ? doRedo() : doUndo(); }
+  else if (mod && e.key === 'y') { e.preventDefault(); doRedo(); }
+  else if (mod && e.key === 's') { e.preventDefault(); doDownload(); }
+  else if ((e.key === 'Delete' || e.key === 'Backspace') && doc.selection.annotationId) {
+    e.preventDefault(); deleteSelected();
+  } else if (e.key === 'Escape') {
+    clearSelection(doc);
+    interaction.setSelected(null, null);
+    setTool('select');
+  }
+});
+
+// ---- file loading (multi-file = merge, by construction) --------------------------------
+async function loadFiles(files) {
+  const pdfs = [...files].filter((f) => f.type === 'application/pdf' || /\.pdf$/i.test(f.name));
+  if (pdfs.length === 0) { toast('Pilih file PDF ya'); return; }
+  const firstLoad = doc.pages.length === 0;
+  if (firstLoad) baseName = pdfs[0].name.replace(/\.pdf$/i, '');
+
+  for (const f of pdfs) {
+    const bytes = new Uint8Array(await f.arrayBuffer());
+    await importPdf(doc, { name: f.name, bytes }); // appends pages → merge
+  }
+  if (!rasterizer) rasterizer = createPageRasterizer(doc);
+  emptyEl.style.display = 'none';
+
+  if (firstLoad) {
+    zoom = Math.min(1, (scrollEl.clientWidth - 16) / doc.pages[0].width);
+    stage.style.zoom = zoom;
+  }
+  rebuildStage();
+  if (!firstLoad) toast(`${pdfs.length} file ditambahkan`);
+}
+
+const fileInput = document.getElementById('file-input');
+document.getElementById('btn-open').addEventListener('click', () => fileInput.click());
+fileInput.addEventListener('change', async (e) => {
+  const files = e.target.files;
+  if (files?.length) await loadFiles(files).catch((err) => { console.error(err); toast('Gagal membuka file'); });
+  fileInput.value = '';
+});
+
+// Drag & drop anywhere (desktop).
+document.addEventListener('dragover', (e) => e.preventDefault());
+document.addEventListener('drop', (e) => {
+  e.preventDefault();
+  if (e.dataTransfer?.files?.length) loadFiles(e.dataTransfer.files);
+});
+
+// ---- download ---------------------------------------------------------------------------
+async function doDownload() {
+  if (doc.pages.length === 0) return;
+  const btn = document.getElementById('btn-download');
+  btn.disabled = true;
+  btn.textContent = 'Menyiapkan…';
+  try {
+    const { buildPdfBytes } = await import('../core/export.js');
+    const bytes = await buildPdfBytes(doc, { PDFLib: window.PDFLib, fontkit: window.fontkit });
+    download(new Blob([bytes], { type: 'application/pdf' }), `${baseName}-pdflokal.pdf`);
+    toast('PDF berhasil dibuat ✓');
+  } catch (err) {
+    console.error(err);
+    toast('Gagal membuat PDF — coba lagi ya');
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Unduh';
+  }
+}
+document.getElementById('btn-download').addEventListener('click', doDownload);
+
+// ---- test hooks (same pattern the old suite relies on) ----------------------------------
+window.v2 = {
+  getDoc: () => doc,
+  getSlots: () => slots,
+  loadFiles,
+  setTool,
+  getTool: () => tool,
+  history,
+};

--- a/js/v2/app.js
+++ b/js/v2/app.js
@@ -19,6 +19,7 @@
 import { createDoc, createAnnotation } from '../core/model.js';
 import {
   addAnnotation, removeAnnotation, updateAnnotation, clearSelection, selectAnnotation,
+  moveAnnotation,
 } from '../core/operations.js';
 import { createHistory, record, undo, redo, canUndo, canRedo } from '../core/history.js';
 import { importPdf, createPageRasterizer } from '../core/import.js';
@@ -413,6 +414,8 @@ document.getElementById('btn-undo').addEventListener('click', doUndo);
 document.getElementById('btn-redo').addEventListener('click', doRedo);
 
 document.addEventListener('keydown', (e) => {
+  // Never hijack typing surfaces (the inline editor stops propagation itself).
+  if (e.target.matches?.('input, select, textarea, [contenteditable="true"]')) return;
   const mod = e.ctrlKey || e.metaKey;
   if (mod && e.key === 'z') { e.preventDefault(); e.shiftKey ? doRedo() : doUndo(); }
   else if (mod && e.key === 'y') { e.preventDefault(); doRedo(); }
@@ -420,16 +423,57 @@ document.addEventListener('keydown', (e) => {
   else if ((e.key === 'Delete' || e.key === 'Backspace') && doc.selection.annotationId) {
     e.preventDefault(); deleteSelected();
   } else if (e.key === 'Escape') {
+    // Native <dialog> closes itself on Escape; this handles the editor surface.
     clearSelection(doc);
     interaction.setSelected(null, null);
     setTool('select');
+  } else if (!mod && doc.pages.length > 0) {
+    // Tool verbs — same keys as the old editor (muscle memory carries over).
+    const k = e.key.toLowerCase();
+    if (k === 'v') setTool('select');
+    else if (k === 't') setTool('text');
+    else if (k === 'w') setTool('whiteout');
+    else if (k === 's' || k === 'p') {
+      if (storedSignature) setTool('signature');
+      else signatureModal.open();
+    }
+  }
+});
+
+// Arrow-key nudge for the selected annotation (1px, Shift = 10px) — parity
+// with the live editor's #74. Separate listener: it must also work while a
+// tool other than Pilih is active.
+let nudgeLast = 0;
+document.addEventListener('keydown', (e) => {
+  if (!doc.selection.annotationId) return;
+  if (e.target.matches?.('input, select, textarea, [contenteditable="true"]')) return;
+  const dir = { ArrowLeft: [-1, 0], ArrowRight: [1, 0], ArrowUp: [0, -1], ArrowDown: [0, 1] }[e.key];
+  if (!dir) return;
+  e.preventDefault();
+  const step = e.shiftKey ? 10 : 1;
+  // One undo step per nudge burst: only record when the previous keydown was >600ms ago.
+  const now = Date.now();
+  if (!nudgeLast || now - nudgeLast > 600) record(history, doc);
+  nudgeLast = now;
+  const a = moveAnnotation(doc, doc.selection.annotationId, dir[0] * step, dir[1] * step);
+  if (a) {
+    const el = stage.querySelector(`[data-anno-id="${a.id}"]`);
+    if (el) { el.style.left = a.x + 'px'; el.style.top = a.y + 'px'; }
   }
 });
 
 // ---- file loading (multi-file = merge, by construction) --------------------------------
+// Size guards (carried from the live app): heads-up above 20MB, block at 100MB
+// — a 100MB+ file will OOM the weak phones we build for before it ever renders.
+const SIZE_WARN = 20 * 1024 * 1024;
+const SIZE_BLOCK = 100 * 1024 * 1024;
+
 async function loadFiles(files) {
   const pdfs = [...files].filter((f) => f.type === 'application/pdf' || /\.pdf$/i.test(f.name));
   if (pdfs.length === 0) { toast('Pilih file PDF ya'); return; }
+  const oversize = pdfs.find((f) => f.size > SIZE_BLOCK);
+  if (oversize) { toast(`"${oversize.name}" terlalu besar (maks 100MB)`); return; }
+  if (pdfs.some((f) => f.size > SIZE_WARN)) toast('File besar — proses bisa agak lama ya');
   const firstLoad = doc.pages.length === 0;
   if (firstLoad) baseName = pdfs[0].name.replace(/\.pdf$/i, '');
 

--- a/js/v2/app.js
+++ b/js/v2/app.js
@@ -18,13 +18,14 @@
 
 import { createDoc, createAnnotation } from '../core/model.js';
 import {
-  addAnnotation, removeAnnotation, updateAnnotation, clearSelection,
+  addAnnotation, removeAnnotation, updateAnnotation, clearSelection, selectAnnotation,
 } from '../core/operations.js';
 import { createHistory, record, undo, redo, canUndo, canRedo } from '../core/history.js';
 import { importPdf, createPageRasterizer } from '../core/import.js';
-import { createPageSlot, syncOverlay } from '../render/page-view.js';
+import { createPageSlot, syncOverlay, textFontCss } from '../render/page-view.js';
 import { createViewportStream } from '../render/viewport.js';
 import { createInteraction } from '../render/interaction.js';
+import { createFormatBar } from './format-bar.js';
 
 window.pdfjsLib.GlobalWorkerOptions.workerSrc = '/js/vendor/pdf.worker.min.js';
 
@@ -37,6 +38,8 @@ let zoom = 1;
 let tool = 'select';
 let storedSignature = null;   // { dataUrl, width, height } from the sig modal
 let baseName = 'dokumen';
+let editingAnno = null;       // text annotation currently in the inline editor
+let editingEl = null;         // its contenteditable (format bar restyles it live)
 
 const scrollEl = document.getElementById('v2-scroll');
 const stage = document.getElementById('v2-stage');
@@ -119,6 +122,48 @@ function refreshChrome() {
   document.getElementById('btn-redo').disabled = !canRedo(history);
   document.getElementById('btn-download').disabled = doc.pages.length === 0;
   document.getElementById('btn-delete-anno').disabled = !doc.selection.annotationId;
+  syncFormatBar();
+}
+
+// ---- format bar ----------------------------------------------------------------
+// Visible whenever text is in play: selected text anno, inline editing, or the
+// Teks tool armed. Sticky defaults feed new annotations.
+function selectedTextAnno() {
+  const id = doc.selection.annotationId;
+  if (!id) return null;
+  for (const page of doc.pages) {
+    const a = page.annotations.find((x) => x.id === id);
+    if (a) return a.type === 'text' ? a : null;
+  }
+  return null;
+}
+
+const formatBar = createFormatBar({
+  el: document.getElementById('format-bar'),
+  getDoc: () => doc,
+  history,
+  getTarget: () => editingAnno || selectedTextAnno(),
+  onStyled: (anno) => {
+    // Restyle the open inline editor live; re-render the committed element.
+    if (editingEl && editingAnno && anno.id === editingAnno.id) {
+      editingEl.style.font = textFontCss(anno);
+      editingEl.style.color = anno.color || '#000';
+    }
+    for (const page of doc.pages) {
+      if (page.annotations.some((a) => a.id === anno.id)) { syncPage(page.id); break; }
+    }
+  },
+  onDefaults: (d) => {
+    // Un-committed draft (new text, no annotation yet): restyle the editor live.
+    if (editingEl && !editingAnno) {
+      editingEl.style.font = textFontCss(d);
+      editingEl.style.color = d.color || '#000';
+    }
+  },
+});
+
+function syncFormatBar() {
+  formatBar.sync(!!(editingAnno || editingEl || selectedTextAnno() || tool === 'text'));
 }
 
 // ---- tools ----------------------------------------------------------------------
@@ -131,6 +176,7 @@ function setTool(next) {
   }
   // While a placement tool is active the page must not pan under the finger.
   stage.style.touchAction = next === 'select' ? '' : 'none';
+  syncFormatBar();
 }
 for (const btn of document.querySelectorAll('#toolbar .tool[data-tool]')) {
   btn.addEventListener('click', () => {
@@ -192,20 +238,25 @@ function openTextEditor({ pageId, x, y, anno }) {
   const slot = slots.find((s) => s.page.id === pageId);
   if (!slot) return;
   const overlay = slot.view.querySelector('.pv-overlay');
-  const fontSize = anno?.fontSize || 18;
+  // New text starts from the format bar's sticky defaults (Canva behavior).
+  const style = anno || formatBar.getDefaults();
 
   const ed = document.createElement('div');
   ed.className = 'v2-text-edit';
   ed.contentEditable = 'true';
   ed.style.left = (anno ? anno.x : x) + 'px';
   ed.style.top = (anno ? anno.y : y) + 'px';
-  ed.style.font = `${anno?.italic ? 'italic ' : ''}${anno?.bold ? '700 ' : '400 '}${fontSize}px Helvetica, Arial, sans-serif`;
-  ed.style.color = anno?.color || '#000';
+  ed.style.font = textFontCss(style);
+  ed.style.color = style.color || '#000';
   ed.textContent = anno?.text || '';
 
   // Hide the original while editing (the editor visually replaces it).
   const origEl = anno ? overlay.querySelector(`[data-anno-id="${anno.id}"]`) : null;
   if (origEl) origEl.style.visibility = 'hidden';
+
+  editingAnno = anno || null;
+  editingEl = ed;
+  syncFormatBar();
 
   let committed = false; // guard: blur fires after Enter-commit too
   const commit = () => {
@@ -213,6 +264,8 @@ function openTextEditor({ pageId, x, y, anno }) {
     committed = true;
     const text = ed.textContent.trim();
     ed.remove();
+    editingAnno = null;
+    editingEl = null;
     if (anno) {
       if (text && text !== anno.text) {
         record(history, doc);
@@ -223,9 +276,15 @@ function openTextEditor({ pageId, x, y, anno }) {
       }
     } else if (text) {
       record(history, doc);
-      addAnnotation(doc, pageId, createAnnotation('text', {
-        text, x, y, fontSize, color: '#000',
+      const d = formatBar.getDefaults();
+      const created = addAnnotation(doc, pageId, createAnnotation('text', {
+        text, x, y,
+        fontSize: d.fontSize, fontFamily: d.fontFamily,
+        bold: d.bold, italic: d.italic, color: d.color,
       }));
+      // Keep the fresh text SELECTED: the user sees it's an object, and a
+      // format-bar dropdown change right after the blur-commit still lands.
+      selectAnnotation(doc, created.id);
     }
     syncPage(pageId);
     setTool('select');

--- a/js/v2/format-bar.js
+++ b/js/v2/format-bar.js
@@ -1,0 +1,131 @@
+/*
+ * PDFLokal — v2/format-bar.js  (contextual text formatting)
+ * ============================================================================
+ * The Word/Figma-style bar for the #1 user action (text = ~30% of edits).
+ * Appears only when text is relevant: a text annotation is selected, the
+ * inline editor is open, or the Teks tool is armed (progressive disclosure —
+ * a crowded toolbar is a bug).
+ *
+ * Style is STICKY (Canva behavior): the bar's current values are the defaults
+ * for the next new text annotation. Editing a selected annotation records one
+ * undo step per discrete change and goes through updateAnnotation (invariant #5).
+ */
+
+import { updateAnnotation } from '../core/operations.js';
+import { record } from '../core/history.js';
+import { FONT_CSS } from '../render/page-view.js';
+
+const SIZES = [10, 12, 14, 18, 24, 32, 48, 64];
+const COLORS = ['#000000', '#d33131', '#1d6fdc', '#1d8a44', '#ffffff'];
+
+// deps = {
+//   el:        the bar container (in editor-v2.html)
+//   getDoc, history
+//   getTarget: () => text annotation currently selected/being edited (or null)
+//   onStyled:  (anno) => void — re-render after a committed style change
+// }
+export function createFormatBar(deps) {
+  const { el } = deps;
+  // Sticky defaults for the NEXT new text annotation.
+  const defaults = { fontFamily: 'Helvetica', fontSize: 18, bold: false, italic: false, color: '#000000' };
+
+  // ---- build the controls once ------------------------------------------------
+  el.innerHTML = '';
+
+  const fontSel = document.createElement('select');
+  fontSel.className = 'fb-font';
+  fontSel.setAttribute('aria-label', 'Jenis huruf');
+  for (const name of Object.keys(FONT_CSS)) {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name === 'Times-Roman' ? 'Times' : name;
+    opt.style.fontFamily = FONT_CSS[name];
+    fontSel.appendChild(opt);
+  }
+  el.appendChild(fontSel);
+
+  const sizeSel = document.createElement('select');
+  sizeSel.className = 'fb-size';
+  sizeSel.setAttribute('aria-label', 'Ukuran huruf');
+  for (const s of SIZES) {
+    const opt = document.createElement('option');
+    opt.value = String(s);
+    opt.textContent = String(s);
+    sizeSel.appendChild(opt);
+  }
+  el.appendChild(sizeSel);
+
+  const boldBtn = document.createElement('button');
+  boldBtn.className = 'fb-toggle fb-bold';
+  boldBtn.textContent = 'B';
+  boldBtn.setAttribute('aria-label', 'Tebal');
+  boldBtn.setAttribute('aria-pressed', 'false');
+  el.appendChild(boldBtn);
+
+  const italicBtn = document.createElement('button');
+  italicBtn.className = 'fb-toggle fb-italic';
+  italicBtn.textContent = 'I';
+  italicBtn.setAttribute('aria-label', 'Miring');
+  italicBtn.setAttribute('aria-pressed', 'false');
+  el.appendChild(italicBtn);
+
+  const swatches = [];
+  for (const c of COLORS) {
+    const b = document.createElement('button');
+    b.className = 'fb-color';
+    b.dataset.color = c;
+    b.style.background = c;
+    b.setAttribute('aria-label', `Warna ${c}`);
+    el.appendChild(b);
+    swatches.push(b);
+  }
+
+  // ---- state sync ---------------------------------------------------------------
+  function reflect(style) {
+    fontSel.value = style.fontFamily || 'Helvetica';
+    sizeSel.value = String(style.fontSize || 18);
+    boldBtn.classList.toggle('on', !!style.bold);
+    boldBtn.setAttribute('aria-pressed', String(!!style.bold));
+    italicBtn.classList.toggle('on', !!style.italic);
+    italicBtn.setAttribute('aria-pressed', String(!!style.italic));
+    for (const s of swatches) s.classList.toggle('on', s.dataset.color === (style.color || '#000000'));
+  }
+
+  function apply(patch) {
+    Object.assign(defaults, patch);          // sticky for the next new text
+    const anno = deps.getTarget();
+    if (anno) {
+      record(deps.history, deps.getDoc());
+      updateAnnotation(deps.getDoc(), anno.id, patch);
+      deps.onStyled?.(anno);
+    } else {
+      deps.onDefaults?.(defaults);           // restyle an open un-committed draft
+    }
+    reflect(anno || defaults);
+  }
+
+  fontSel.addEventListener('change', () => apply({ fontFamily: fontSel.value }));
+  sizeSel.addEventListener('change', () => apply({ fontSize: Number(sizeSel.value) }));
+  boldBtn.addEventListener('click', () => apply({ bold: !(deps.getTarget() || defaults).bold }));
+  italicBtn.addEventListener('click', () => apply({ italic: !(deps.getTarget() || defaults).italic }));
+  for (const s of swatches) s.addEventListener('click', () => apply({ color: s.dataset.color }));
+
+  // Keep taps inside the bar from bubbling into the stage (deselecting), and
+  // keep BUTTON taps from stealing focus (which would blur-commit an open
+  // inline editor). Selects are exempt — a dropdown needs focus to open; the
+  // draft commits-and-stays-selected instead (app.js), so the change still lands.
+  el.addEventListener('pointerdown', (e) => {
+    e.stopPropagation();
+    if (e.target.closest('button')) e.preventDefault();
+  });
+
+  return {
+    // Show when text is in play; reflect the target's style (or the defaults).
+    sync(visible) {
+      const anno = deps.getTarget();
+      el.classList.toggle('show', !!visible);
+      reflect(anno || defaults);
+    },
+    getDefaults: () => ({ ...defaults }),
+  };
+}

--- a/js/v2/page-manager.js
+++ b/js/v2/page-manager.js
@@ -1,0 +1,225 @@
+/*
+ * PDFLokal — v2/page-manager.js  ("Halaman" sheet: assemble = ~36% of actions)
+ * ============================================================================
+ * One touch-first surface for reorder / rotate / delete / extract / add —
+ * replacing BOTH the old sidebar and the old Kelola Halaman modal.
+ *
+ * Interaction model (carried from the liked #73 redesign, minus its debt):
+ *   - tap a tile        → toggle selection (always available, no mode switch)
+ *   - bulk bar          → Putar / Hapus / Ekstrak on the selection
+ *   - drag to reorder   → POINTER-based with long-press arm on touch (the old
+ *                         HTML5 DnD never fired on touch — that whole bug class
+ *                         is gone by construction)
+ *   - [+] tile          → append more PDFs (merge)
+ *
+ * Every mutation: record(history) once → core op → onDocChanged() (the app
+ * rebuilds the stage). Thumbnails are cached by page.id and NEVER touch
+ * page.raster (the main view's streaming state).
+ */
+
+import { removePage, reorderPage, rotatePage } from '../core/operations.js';
+import { record } from '../core/history.js';
+
+const LONG_PRESS_MS = 280;
+const DRAG_SLOP = 8; // px of movement that cancels a pending long-press
+
+// deps = {
+//   sheet:        the <dialog>
+//   grid:         tile container
+//   bulkBar:      bulk-action bar el
+//   getDoc, history,
+//   getRasterizer: () => rasterizer (has rasterizeThumb)
+//   onDocChanged: () => void       — app rebuilds the main stage
+//   onAddFiles:   () => void       — opens the file input (append/merge)
+//   onExtract:    (pages) => void  — download selected pages as a new PDF
+//   toast:        (msg) => void
+// }
+export function createPageManager(deps) {
+  const { sheet, grid, bulkBar } = deps;
+  const selected = new Set();          // page ids (UI-transient, not core state)
+  const thumbs = new Map();            // page.id -> dataUrl (invalidated on rotate)
+  let thumbQueue = Promise.resolve();  // serialize thumb renders (keep UI smooth)
+
+  // ---- open / close -----------------------------------------------------------
+  function open() {
+    selected.clear();
+    render();
+    sheet.showModal();
+  }
+  function close() { sheet.close(); }
+  sheet.addEventListener('click', (e) => { if (e.target === sheet) close(); });
+
+  // ---- rendering ----------------------------------------------------------------
+  function render() {
+    const doc = deps.getDoc();
+    grid.innerHTML = '';
+    doc.pages.forEach((page, i) => grid.appendChild(renderTile(page, i)));
+
+    // [+] add tile — merge more files without leaving the sheet.
+    const add = document.createElement('button');
+    add.className = 'pm-tile pm-add';
+    add.innerHTML = '<span>+</span>Tambah PDF';
+    add.addEventListener('click', () => deps.onAddFiles());
+    grid.appendChild(add);
+
+    renderBulkBar();
+  }
+
+  function renderTile(page, index) {
+    const tile = document.createElement('div');
+    tile.className = 'pm-tile';
+    tile.dataset.pageId = page.id;
+    if (selected.has(page.id)) tile.classList.add('sel');
+
+    const rotated = (page.rotation || 0) % 180 !== 0;
+    const ratio = rotated ? page.width / page.height : page.height / page.width;
+
+    const im = document.createElement('div');
+    im.className = 'pm-thumb';
+    im.style.aspectRatio = String(1 / ratio);
+    const cached = thumbs.get(page.id);
+    if (cached) im.style.backgroundImage = `url(${cached})`;
+    else queueThumb(page, im);
+    tile.appendChild(im);
+
+    const num = document.createElement('span');
+    num.className = 'pm-num';
+    num.textContent = String(index + 1);
+    tile.appendChild(num);
+
+    const check = document.createElement('span');
+    check.className = 'pm-check';
+    check.textContent = '✓';
+    tile.appendChild(check);
+
+    wireTile(tile, page);
+    return tile;
+  }
+
+  function queueThumb(page, el) {
+    thumbQueue = thumbQueue.then(async () => {
+      if (!sheet.open) return; // sheet closed mid-queue; skip quietly
+      try {
+        const t = await deps.getRasterizer().rasterizeThumb(page, { width: 150 });
+        thumbs.set(page.id, t.dataUrl);
+        el.style.backgroundImage = `url(${t.dataUrl})`;
+      } catch { /* tile keeps its blank placeholder */ }
+    });
+  }
+
+  function renderBulkBar() {
+    const n = selected.size;
+    bulkBar.classList.toggle('show', n > 0);
+    bulkBar.querySelector('.pm-count').textContent = `${n} dipilih`;
+    // Deleting every page is blocked (an empty doc is a dead end, not a state).
+    bulkBar.querySelector('[data-act="delete"]').disabled = n >= deps.getDoc().pages.length;
+  }
+
+  // ---- tile interaction: tap = select, long-press (touch) / drag (mouse) = reorder
+  function wireTile(tile, page) {
+    let pressTimer = null;
+    let start = null;
+    let dragging = false;
+
+    tile.addEventListener('pointerdown', (e) => {
+      if (e.target.closest('.pm-add')) return;
+      start = { x: e.clientX, y: e.clientY, id: e.pointerId };
+      if (e.pointerType === 'mouse') {
+        // Mouse: drag arms immediately on movement; click stays a click.
+        pressTimer = 0;
+      } else {
+        // Touch: long-press arms the drag (instant drag would fight scroll).
+        pressTimer = setTimeout(() => { armDrag(e); }, LONG_PRESS_MS);
+      }
+    });
+
+    function armDrag(e) {
+      dragging = true;
+      tile.classList.add('dragging');
+      tile.setPointerCapture(e.pointerId ?? start.id);
+      if (navigator.vibrate) navigator.vibrate(10);
+    }
+
+    tile.addEventListener('pointermove', (e) => {
+      if (!start) return;
+      const moved = Math.hypot(e.clientX - start.x, e.clientY - start.y);
+      if (!dragging) {
+        if (pressTimer === 0 && moved > DRAG_SLOP) armDrag(e);          // mouse
+        else if (moved > DRAG_SLOP) { clearTimeout(pressTimer); pressTimer = null; } // touch: became a scroll
+        return;
+      }
+      e.preventDefault();
+      // Live insertion hint: mark the tile currently under the pointer.
+      const over = document.elementFromPoint(e.clientX, e.clientY)?.closest('.pm-tile:not(.pm-add)');
+      for (const t of grid.querySelectorAll('.pm-tile.drop-hint')) t.classList.remove('drop-hint');
+      if (over && over !== tile) over.classList.add('drop-hint');
+    });
+
+    const end = (e) => {
+      clearTimeout(pressTimer);
+      if (dragging) {
+        dragging = false;
+        tile.classList.remove('dragging');
+        const over = document.elementFromPoint(e.clientX, e.clientY)?.closest('.pm-tile:not(.pm-add)');
+        for (const t of grid.querySelectorAll('.pm-tile.drop-hint')) t.classList.remove('drop-hint');
+        if (over && over !== tile) {
+          const doc = deps.getDoc();
+          const toIndex = doc.pages.findIndex((p) => p.id === over.dataset.pageId);
+          record(deps.history, doc);
+          reorderPage(doc, page.id, toIndex);
+          render();
+          deps.onDocChanged();
+        }
+      } else if (start && pressTimer !== null) {
+        // It was a tap → toggle selection.
+        if (selected.has(page.id)) selected.delete(page.id);
+        else selected.add(page.id);
+        tile.classList.toggle('sel', selected.has(page.id));
+        renderBulkBar();
+      }
+      start = null;
+      pressTimer = null;
+    };
+    tile.addEventListener('pointerup', end);
+    tile.addEventListener('pointercancel', () => {
+      clearTimeout(pressTimer);
+      dragging = false;
+      tile.classList.remove('dragging');
+      start = null; pressTimer = null;
+    });
+  }
+
+  // ---- bulk actions ---------------------------------------------------------------
+  bulkBar.addEventListener('click', (e) => {
+    const act = e.target.closest('[data-act]')?.dataset.act;
+    if (!act || selected.size === 0) return;
+    const doc = deps.getDoc();
+    const pages = doc.pages.filter((p) => selected.has(p.id));
+
+    if (act === 'rotate') {
+      record(deps.history, doc);
+      for (const p of pages) {
+        rotatePage(doc, p.id, 90);
+        p.raster = null;             // raster is now the wrong orientation
+        thumbs.delete(p.id);         // thumb too
+      }
+      render();
+      deps.onDocChanged();
+    } else if (act === 'delete') {
+      if (pages.length >= doc.pages.length) return; // guarded in UI as well
+      record(deps.history, doc);
+      for (const p of pages) removePage(doc, p.id);
+      selected.clear();
+      render();
+      deps.onDocChanged();
+      deps.toast(`${pages.length} halaman dihapus`);
+    } else if (act === 'extract') {
+      deps.onExtract(pages);
+    } else if (act === 'clear') {
+      selected.clear();
+      render();
+    }
+  });
+
+  return { open, close, render };
+}

--- a/js/v2/page-manager.js
+++ b/js/v2/page-manager.js
@@ -69,6 +69,22 @@ export function createPageManager(deps) {
     const tile = document.createElement('div');
     tile.className = 'pm-tile';
     tile.dataset.pageId = page.id;
+    // Keyboard path: tiles are toggle buttons (drag-reorder stays pointer-only;
+    // bulk actions cover the same jobs for keyboard users).
+    tile.setAttribute('role', 'button');
+    tile.setAttribute('tabindex', '0');
+    tile.setAttribute('aria-label', `Halaman ${index + 1}`);
+    tile.setAttribute('aria-pressed', String(selected.has(page.id)));
+    tile.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        if (selected.has(page.id)) selected.delete(page.id);
+        else selected.add(page.id);
+        tile.classList.toggle('sel', selected.has(page.id));
+        tile.setAttribute('aria-pressed', String(selected.has(page.id)));
+        renderBulkBar();
+      }
+    });
     if (selected.has(page.id)) tile.classList.add('sel');
 
     const rotated = (page.rotation || 0) % 180 !== 0;
@@ -175,6 +191,7 @@ export function createPageManager(deps) {
         if (selected.has(page.id)) selected.delete(page.id);
         else selected.add(page.id);
         tile.classList.toggle('sel', selected.has(page.id));
+        tile.setAttribute('aria-pressed', String(selected.has(page.id)));
         renderBulkBar();
       }
       start = null;

--- a/js/v2/signature-modal.js
+++ b/js/v2/signature-modal.js
@@ -1,0 +1,153 @@
+/*
+ * PDFLokal — v2/signature-modal.js  (TTD: draw / upload / paraf)
+ * ============================================================================
+ * Produces ONE thing: { dataUrl, width, height, subtype } handed to the app
+ * for tap-to-place. Two sources:
+ *   - Gambar: SignaturePad canvas, auto-trimmed to ink bounds (an untrimmed
+ *     460×180 pad placed at 150px wide looks comically small — trim first).
+ *   - Upload: an image file; white background stripped to transparency by
+ *     default (photos of wet-ink signatures — the dominant real-world case).
+ * Paraf is the same signature type with subtype 'paraf' and a smaller default
+ * placement width — zero extra branches downstream (render/export/undo).
+ */
+
+const WHITE_THRESHOLD = 235; // r,g,b all above this → transparent
+
+export function createSignatureModal({ modal, onReady, toast }) {
+  const canvas = modal.querySelector('#sig-canvas');
+  const fileInput = modal.querySelector('#sig-file');
+  const preview = modal.querySelector('#sig-preview');
+  const parafCheck = modal.querySelector('#sig-paraf');
+  const removeBgCheck = modal.querySelector('#sig-removebg');
+  const tabs = modal.querySelectorAll('.sig-tab');
+  let pad = null;
+  let uploadedImg = null; // HTMLImageElement of the chosen file
+
+  // ---- tabs -----------------------------------------------------------------
+  function showTab(name) {
+    for (const t of tabs) {
+      const on = t.dataset.tab === name;
+      t.classList.toggle('on', on);
+      t.setAttribute('aria-selected', String(on));
+    }
+    modal.querySelector('.sig-pane-draw').style.display = name === 'draw' ? '' : 'none';
+    modal.querySelector('.sig-pane-upload').style.display = name === 'upload' ? '' : 'none';
+  }
+  for (const t of tabs) t.addEventListener('click', () => showTab(t.dataset.tab));
+
+  // ---- draw pane ---------------------------------------------------------------
+  function initPad() {
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    canvas.width = canvas.offsetWidth * dpr;
+    canvas.height = canvas.offsetHeight * dpr;
+    canvas.getContext('2d').scale(dpr, dpr);
+    pad = new window.SignaturePad(canvas, { minWidth: 1, maxWidth: 2.4 });
+  }
+  modal.querySelector('#sig-clear').addEventListener('click', () => pad?.clear());
+
+  // ---- upload pane ---------------------------------------------------------------
+  fileInput.addEventListener('change', () => {
+    const f = fileInput.files?.[0];
+    fileInput.value = '';
+    if (!f || !f.type.startsWith('image/')) { toast('Pilih file gambar ya'); return; }
+    const img = new Image();
+    img.onload = () => {
+      uploadedImg = img;
+      renderUploadPreview();
+    };
+    img.onerror = () => toast('Gagal membaca gambar');
+    img.src = URL.createObjectURL(f);
+  });
+  removeBgCheck.addEventListener('change', renderUploadPreview);
+
+  function processUpload() {
+    if (!uploadedImg) return null;
+    // Cap the working size — a 4000px camera photo would bloat the PDF.
+    const scale = Math.min(1, 1200 / uploadedImg.naturalWidth);
+    const c = document.createElement('canvas');
+    c.width = Math.round(uploadedImg.naturalWidth * scale);
+    c.height = Math.round(uploadedImg.naturalHeight * scale);
+    const ctx = c.getContext('2d');
+    ctx.drawImage(uploadedImg, 0, 0, c.width, c.height);
+    if (removeBgCheck.checked) whiteToTransparent(c);
+    return trimToInk(c);
+  }
+
+  function renderUploadPreview() {
+    const c = processUpload();
+    preview.innerHTML = '';
+    if (c) preview.appendChild(c);
+  }
+
+  // ---- image processing ------------------------------------------------------------
+  function whiteToTransparent(c) {
+    const ctx = c.getContext('2d');
+    const data = ctx.getImageData(0, 0, c.width, c.height);
+    const px = data.data;
+    for (let i = 0; i < px.length; i += 4) {
+      if (px[i] > WHITE_THRESHOLD && px[i + 1] > WHITE_THRESHOLD && px[i + 2] > WHITE_THRESHOLD) {
+        px[i + 3] = 0;
+      }
+    }
+    ctx.putImageData(data, 0, 0);
+  }
+
+  // Crop to the bounding box of non-transparent pixels (+ a small margin).
+  function trimToInk(c) {
+    const ctx = c.getContext('2d');
+    const { data } = ctx.getImageData(0, 0, c.width, c.height);
+    let minX = c.width, minY = c.height, maxX = -1, maxY = -1;
+    for (let y = 0; y < c.height; y += 1) {
+      for (let x = 0; x < c.width; x += 1) {
+        if (data[(y * c.width + x) * 4 + 3] > 10) {
+          if (x < minX) minX = x;
+          if (x > maxX) maxX = x;
+          if (y < minY) minY = y;
+          if (y > maxY) maxY = y;
+        }
+      }
+    }
+    if (maxX < 0) return null; // fully transparent — nothing to place
+    const pad2 = 4;
+    minX = Math.max(0, minX - pad2); minY = Math.max(0, minY - pad2);
+    maxX = Math.min(c.width - 1, maxX + pad2); maxY = Math.min(c.height - 1, maxY + pad2);
+    const out = document.createElement('canvas');
+    out.width = maxX - minX + 1;
+    out.height = maxY - minY + 1;
+    out.getContext('2d').drawImage(c, minX, minY, out.width, out.height, 0, 0, out.width, out.height);
+    return out;
+  }
+
+  // ---- confirm -------------------------------------------------------------------
+  modal.querySelector('#sig-use').addEventListener('click', () => {
+    const drawVisible = modal.querySelector('.sig-pane-draw').style.display !== 'none';
+    let source = null;
+    if (drawVisible) {
+      if (!pad || pad.isEmpty()) { toast('Gambar tanda tanganmu dulu ya'); return; }
+      source = trimToInk(canvas);
+    } else {
+      source = processUpload();
+      if (!source) { toast('Upload gambar tanda tanganmu dulu ya'); return; }
+    }
+    if (!source) { toast('Tanda tangan kosong'); return; }
+    modal.close();
+    onReady({
+      dataUrl: source.toDataURL('image/png'),
+      width: source.width,
+      height: source.height,
+      subtype: parafCheck.checked ? 'paraf' : null,
+    });
+  });
+  modal.querySelector('#sig-cancel').addEventListener('click', () => modal.close());
+  modal.addEventListener('click', (e) => { if (e.target === modal) modal.close(); });
+
+  return {
+    open() {
+      modal.showModal();
+      showTab('draw');
+      initPad();
+      uploadedImg = null;
+      preview.innerHTML = '';
+    },
+  };
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "lint:fix": "eslint js/ --fix",
     "test:core": "node --test 'tests/core/**/*.test.mjs'",
     "test": "playwright test",
+    "test:mobile": "playwright test --project=mobile-chrome",
+    "verify": "npm run lint && npm run test:core && npm run test",
     "test:headed": "playwright test --headed",
     "test:ui": "playwright test --ui",
     "test:golden:update": "UPDATE_BASELINES=1 playwright test tests/golden",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -32,6 +32,16 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
+      // tests/mobile/ runs under the mobile-chrome project only
+      testIgnore: ['mobile/**'],
+    },
+    {
+      // Real touch events + mobile viewport + DPR ~2.6. Catches the
+      // layout/touch-logic bug class without a physical phone. The GPU/
+      // compositor class still needs the Android emulator or a real device.
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 7'] },
+      testMatch: 'mobile/**/*.spec.js',
     },
   ],
 

--- a/scripts/android-verify.mjs
+++ b/scripts/android-verify.mjs
@@ -1,0 +1,58 @@
+/*
+ * PDFLokal — scripts/android-verify.mjs
+ * ============================================================================
+ * Drive REAL Android Chrome (emulator or USB device) with Playwright over CDP.
+ * This is the tier-2 mobile verification loop: what Playwright's mobile
+ * emulation can't catch (real compositor, GPU raster, Android keyboard),
+ * this can — without needing the founder's phone.
+ *
+ * One-time setup (documented in docs/android-verification.md):
+ *   1. Emulator running:  $ANDROID_HOME/emulator/emulator -avd pdflokal-test
+ *   2. Local server:      npx serve -p 5050 .
+ *   3. This script does the rest (adb reverse + CDP forward + drive).
+ *
+ * Usage:
+ *   node scripts/android-verify.mjs [url-path] [screenshot-name]
+ *   node scripts/android-verify.mjs /editor-v2.html v2-loaded
+ */
+import { chromium } from '@playwright/test';
+import { execSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ADB = process.env.ADB || `${process.env.HOME}/Library/Android/sdk/platform-tools/adb`;
+const urlPath = process.argv[2] || '/editor-v2.html';
+const shotName = process.argv[3] || 'android-verify';
+const OUT = process.env.SHOT_DIR || '/tmp';
+
+function adb(cmd) { return execSync(`"${ADB}" ${cmd}`, { encoding: 'utf8' }).trim(); }
+
+// Plumb: app server into the device, DevTools socket out of it.
+adb('reverse tcp:5050 tcp:5050');
+adb('forward tcp:9222 localabstract:chrome_devtools_remote');
+// Make sure Chrome is up (idempotent).
+adb('shell am start -n com.android.chrome/com.google.android.apps.chrome.Main');
+await new Promise((r) => setTimeout(r, 1500));
+
+const browser = await chromium.connectOverCDP('http://localhost:9222');
+const context = browser.contexts()[0];
+const page = context.pages()[0] || (await context.newPage());
+
+await page.goto(`http://localhost:5050${urlPath}`);
+await page.waitForLoadState('networkidle');
+
+// If this is editor v2, run the core flow: load fixture → wait for raster.
+if (urlPath.includes('editor-v2')) {
+  const fixture = path.join(__dirname, '..', 'tests', 'fixtures', 'sample-2pages.pdf');
+  await page.setInputFiles('#file-input', fixture);
+  await page.waitForSelector('.pv-page .pv-bg', { timeout: 15000 });
+  console.log('pages:', await page.locator('.pv-page').count(),
+    '| rasters:', await page.locator('.pv-bg').count());
+}
+
+const shot = `${OUT}/${shotName}.png`;
+await page.screenshot({ path: shot });
+console.log('screenshot:', shot);
+console.log('UA:', await page.evaluate(() => navigator.userAgent));
+await browser.close();

--- a/tests/core-export.spec.js
+++ b/tests/core-export.spec.js
@@ -1,0 +1,224 @@
+/*
+ * PDFLokal — core export adapter (browser-tested, because it uses vendored pdf-lib).
+ *
+ * Verifies js/core/export.js `buildPdfBytes`: a Doc built purely through core
+ * modules round-trips to real PDF bytes that PDF.js can re-render, with
+ * annotations landing at the right PIXELS (not just "didn't throw"). Source
+ * PDFs are generated in-browser with pdf-lib so no fixture drift is possible —
+ * we know exactly which regions are dark/blue/white.
+ *
+ * Geometry cheat-sheet (600×800pt page, top-left page-space points):
+ *   dark block   x 50..250,  y 100..200   (drawn in the source PDF)
+ *   whiteout     x 60..140,  y 110..170   (over part of the dark block)
+ *   text 'XXXXX' x 300..,    y 400..      (36pt bold on white background)
+ *   signature    x 400..500, y 600..700   (solid red PNG)
+ */
+import { test, expect } from '@playwright/test';
+
+// Build the shared 2-page source Doc inside the browser and return core handles.
+// Page 1: 600×800 with a black block; Page 2: 600×800 with a blue square at
+// PDF coords x 100..200, y 100..200 (bottom-left frame).
+async function buildSourceDoc() {
+  const model = await import('/js/core/model.js');
+  const ops = await import('/js/core/operations.js');
+  const imp = await import('/js/core/import.js');
+  const exp = await import('/js/core/export.js');
+  const { PDFLib } = window;
+
+  const src = await PDFLib.PDFDocument.create();
+  const sp1 = src.addPage([600, 800]);
+  // top-left frame: x 50..250, y 100..200
+  sp1.drawRectangle({ x: 50, y: 600, width: 200, height: 100, color: PDFLib.rgb(0, 0, 0) });
+  const sp2 = src.addPage([600, 800]);
+  sp2.drawRectangle({ x: 100, y: 100, width: 100, height: 100, color: PDFLib.rgb(0, 0, 1) });
+  const srcBytes = await src.save();
+
+  const doc = model.createDoc();
+  await imp.importPdf(doc, { name: 'generated.pdf', bytes: srcBytes });
+  return { model, ops, exp, doc };
+}
+
+// Render page `pageNum` (1-based) of `pdfBytes` with PDF.js at `scale` and
+// return a sampler over the resulting canvas (same round-trip strategy as the
+// golden suite — rendered pixels are what the user actually sees).
+async function renderPage(pdfBytes, pageNum, scale) {
+  const out = await window.pdfjsLib.getDocument({ data: pdfBytes.slice() }).promise;
+  const pdfPage = await out.getPage(pageNum);
+  const vp = pdfPage.getViewport({ scale });
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.ceil(vp.width);
+  canvas.height = Math.ceil(vp.height);
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+  await pdfPage.render({ canvasContext: ctx, viewport: vp }).promise;
+
+  return {
+    numPages: out.numPages,
+    rotate: pdfPage.rotate,
+    vpWidth: Math.round(vp.width / scale),
+    vpHeight: Math.round(vp.height / scale),
+    // 1×1 sample at page-space point (x, y) → [r, g, b]
+    px(x, y) {
+      const d = ctx.getImageData(Math.round(x * scale), Math.round(y * scale), 1, 1).data;
+      return [d[0], d[1], d[2]];
+    },
+    // darkest luma inside a page-space rect — "is there ink here?"
+    regionMinLuma(x0, y0, x1, y1) {
+      const d = ctx.getImageData(
+        Math.round(x0 * scale), Math.round(y0 * scale),
+        Math.round((x1 - x0) * scale), Math.round((y1 - y0) * scale),
+      ).data;
+      let min = 255;
+      for (let i = 0; i < d.length; i += 4) {
+        const l = 0.299 * d[i] + 0.587 * d[i + 1] + 0.114 * d[i + 2];
+        if (l < min) min = l;
+      }
+      return min;
+    },
+  };
+}
+
+test.describe('core export adapter', () => {
+  test('buildPdfBytes: whiteout, text, signature land at the right pixels', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => !!window.pdfjsLib && !!window.PDFLib);
+
+    const r = await page.evaluate(`(async () => {
+      ${buildSourceDoc}
+      ${renderPage}
+      const { model, ops, exp, doc } = await buildSourceDoc();
+      const p0 = doc.pages[0];
+
+      // Whiteout covering part of the dark block.
+      ops.addAnnotation(doc, p0.id, model.createAnnotation('whiteout', {
+        x: 60, y: 110, width: 80, height: 60,
+      }));
+      // Bold black text on the white area below the block.
+      ops.addAnnotation(doc, p0.id, model.createAnnotation('text', {
+        text: 'XXXXX', x: 300, y: 400, fontSize: 36,
+        color: '#000000', fontFamily: 'Helvetica', bold: true, italic: false,
+      }));
+      // Signature: solid red PNG generated on the fly.
+      const sc = document.createElement('canvas');
+      sc.width = 20; sc.height = 20;
+      const sctx = sc.getContext('2d');
+      sctx.fillStyle = '#ff0000';
+      sctx.fillRect(0, 0, 20, 20);
+      ops.addAnnotation(doc, p0.id, model.createAnnotation('signature', {
+        image: sc.toDataURL('image/png'), x: 400, y: 600, width: 100, height: 100,
+      }));
+
+      const outBytes = await exp.buildPdfBytes(doc); // deps default to window globals
+      const s = await renderPage(outBytes, 1, 2);
+      return {
+        numPages: s.numPages,
+        whiteoutPx: s.px(100, 140),                       // inside whiteout, over dark block
+        darkPx: s.px(200, 150),                           // dark block, outside whiteout
+        textMinLuma: s.regionMinLuma(295, 398, 420, 445), // text bbox must contain ink
+        aboveTextMinLuma: s.regionMinLuma(295, 340, 420, 380), // must stay blank
+        sigPx: s.px(450, 650),                            // signature centre
+      };
+    })()`);
+
+    expect(r.numPages).toBe(2);
+
+    // Whiteout region is white even though the source page is black there.
+    for (const c of r.whiteoutPx) expect(c).toBeGreaterThan(245);
+    // The rest of the dark block survived.
+    for (const c of r.darkPx) expect(c).toBeLessThan(60);
+
+    // Text region contains dark glyph pixels; the area above it stays blank.
+    expect(r.textMinLuma).toBeLessThan(100);
+    expect(r.aboveTextMinLuma).toBeGreaterThan(240);
+
+    // Signature centre is solid red.
+    expect(r.sigPx[0]).toBeGreaterThan(200);
+    expect(r.sigPx[1]).toBeLessThan(80);
+    expect(r.sigPx[2]).toBeLessThan(80);
+  });
+
+  test('rotated page: /Rotate lands in output and annotations follow the rotated frame', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => !!window.pdfjsLib && !!window.PDFLib);
+
+    const r = await page.evaluate(`(async () => {
+      ${buildSourceDoc}
+      ${renderPage}
+      const { model, ops, exp, doc } = await buildSourceDoc();
+      const p1 = doc.pages[1];
+      ops.rotatePage(doc, p1.id, 90);
+
+      // In the rotated (90° cw) view the page is 800 wide × 600 tall and the
+      // blue square appears at view coords x 100..200, y 100..200. Cover its
+      // LEFT half (view x 100..150) with a whiteout — in the unrotated PDF
+      // frame that must become the BOTTOM half of the square.
+      ops.addAnnotation(doc, p1.id, model.createAnnotation('whiteout', {
+        x: 100, y: 100, width: 50, height: 100,
+      }));
+
+      const outBytes = await exp.buildPdfBytes(doc);
+      // PDF.js applies /Rotate in its default viewport → samples below are in
+      // the ROTATED view frame, i.e. exactly what the user placed against.
+      const s = await renderPage(outBytes, 2, 2);
+      return {
+        rotate: s.rotate,
+        vpWidth: s.vpWidth,
+        vpHeight: s.vpHeight,
+        whitedPx: s.px(125, 150), // inside the whiteout half
+        bluePx: s.px(175, 150),   // remaining half of the blue square
+      };
+    })()`);
+
+    // Rotation is real metadata in the output, and the viewport swaps dims.
+    expect(r.rotate).toBe(90);
+    expect(r.vpWidth).toBe(800);
+    expect(r.vpHeight).toBe(600);
+
+    // Whiteout landed on the intended half of the square in the ROTATED view.
+    for (const c of r.whitedPx) expect(c).toBeGreaterThan(245);
+    expect(r.bluePx[2]).toBeGreaterThan(200); // still blue
+    expect(r.bluePx[0]).toBeLessThan(80);
+  });
+
+  test('isFromImage page: raw image source becomes a full-page image', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => !!window.pdfjsLib && !!window.PDFLib);
+
+    const r = await page.evaluate(`(async () => {
+      ${renderPage}
+      const model = await import('/js/core/model.js');
+      const ops = await import('/js/core/operations.js');
+      const exp = await import('/js/core/export.js');
+
+      // A solid red 300×200 PNG as RAW FILE BYTES (what an image source holds).
+      const c = document.createElement('canvas');
+      c.width = 300; c.height = 200;
+      const cctx = c.getContext('2d');
+      cctx.fillStyle = '#ff0000';
+      cctx.fillRect(0, 0, 300, 200);
+      const blob = await new Promise((res) => c.toBlob(res, 'image/png'));
+      const bytes = new Uint8Array(await blob.arrayBuffer());
+
+      const doc = model.createDoc();
+      const source = ops.addSource(doc, model.createSource({ name: 'foto.png', bytes, numPages: 1 }));
+      ops.addPages(doc, [model.createPage({
+        source, sourcePageNum: 0, width: 300, height: 200, isFromImage: true,
+      })]);
+
+      const outBytes = await exp.buildPdfBytes(doc);
+      const s = await renderPage(outBytes, 1, 2);
+      return {
+        numPages: s.numPages,
+        vpWidth: s.vpWidth,
+        vpHeight: s.vpHeight,
+        centerPx: s.px(150, 100),
+      };
+    })()`);
+
+    expect(r.numPages).toBe(1);
+    expect(r.vpWidth).toBe(300);
+    expect(r.vpHeight).toBe(200);
+    expect(r.centerPx[0]).toBeGreaterThan(200); // full-bleed red
+    expect(r.centerPx[1]).toBeLessThan(80);
+    expect(r.centerPx[2]).toBeLessThan(80);
+  });
+});

--- a/tests/core-export.spec.js
+++ b/tests/core-export.spec.js
@@ -179,6 +179,149 @@ test.describe('core export adapter', () => {
     expect(r.bluePx[0]).toBeLessThan(80);
   });
 
+  test('custom fonts: Montserrat + Carlito-Bold embed from /fonts and render ink', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => !!window.pdfjsLib && !!window.PDFLib && !!window.fontkit);
+
+    const r = await page.evaluate(`(async () => {
+      ${buildSourceDoc}
+      ${renderPage}
+      const { model, ops, exp, doc } = await buildSourceDoc();
+      const p0 = doc.pages[0];
+
+      // Montserrat regular on the white area below the dark block.
+      ops.addAnnotation(doc, p0.id, model.createAnnotation('text', {
+        text: 'MMMMM', x: 300, y: 400, fontSize: 36,
+        color: '#000000', fontFamily: 'Montserrat', bold: false, italic: false,
+      }));
+      // Carlito bold, lower down on the same white area.
+      ops.addAnnotation(doc, p0.id, model.createAnnotation('text', {
+        text: 'CCCCC', x: 300, y: 500, fontSize: 36,
+        color: '#000000', fontFamily: 'Carlito', bold: true, italic: false,
+      }));
+
+      const outBytes = await exp.buildPdfBytes(doc); // deps default to window globals
+      const s = await renderPage(outBytes, 1, 2);
+      return {
+        montserratMinLuma: s.regionMinLuma(295, 398, 460, 445), // Montserrat text bbox
+        carlitoMinLuma: s.regionMinLuma(295, 498, 460, 545),    // Carlito-Bold text bbox
+        betweenMinLuma: s.regionMinLuma(295, 452, 460, 490),    // gap between lines stays blank
+      };
+    })()`);
+
+    // Both custom-font lines put real glyph ink on the page (fonts fetched and
+    // embedded via fontkit — not the Helvetica fallback, which would still be
+    // ink; this asserts embedding didn't throw and text rendered).
+    expect(r.montserratMinLuma).toBeLessThan(100);
+    expect(r.carlitoMinLuma).toBeLessThan(100);
+    // The gap between the two lines is untouched white.
+    expect(r.betweenMinLuma).toBeGreaterThan(240);
+  });
+
+  test('watermark: tilted text renders semi-transparent ink near page centre', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => !!window.pdfjsLib && !!window.PDFLib);
+
+    const r = await page.evaluate(`(async () => {
+      ${buildSourceDoc}
+      ${renderPage}
+      const { model, ops, exp, doc } = await buildSourceDoc();
+      const p0 = doc.pages[0];
+
+      // Watermark centred at (300, 400) — well below the dark block (y 100..200).
+      ops.addAnnotation(doc, p0.id, model.createAnnotation('watermark', {
+        text: 'RAHASIA', x: 300, y: 400, fontSize: 48,
+        color: '#000000', opacity: 0.5, rotation: 45,
+      }));
+
+      const outBytes = await exp.buildPdfBytes(doc);
+      const s = await renderPage(outBytes, 1, 2);
+      return {
+        centreMinLuma: s.regionMinLuma(150, 300, 450, 500), // generous box around centre
+        cornerMinLuma: s.regionMinLuma(40, 640, 240, 760),  // far corner stays blank
+      };
+    })()`);
+
+    // Some ink landed near the centre. opacity 0.5 over white → mid-grey, so the
+    // threshold is generous (not near-black like solid text).
+    expect(r.centreMinLuma).toBeLessThan(220);
+    // A corner far from the watermark stays white.
+    expect(r.cornerMinLuma).toBeGreaterThan(240);
+  });
+
+  test('pageNumber: label renders ink at its position (old exporter dropped this)', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => !!window.pdfjsLib && !!window.PDFLib);
+
+    const r = await page.evaluate(`(async () => {
+      ${buildSourceDoc}
+      ${renderPage}
+      const { model, ops, exp, doc } = await buildSourceDoc();
+      const p0 = doc.pages[0];
+
+      // Page-number label on the white area. Larger than the 12pt default so the
+      // thin '1' glyph is reliably sampled at scale 2.
+      ops.addAnnotation(doc, p0.id, model.createAnnotation('pageNumber', {
+        text: '1', x: 300, y: 400, fontSize: 24, color: '#000000',
+      }));
+
+      const outBytes = await exp.buildPdfBytes(doc);
+      const s = await renderPage(outBytes, 1, 2);
+      return {
+        labelMinLuma: s.regionMinLuma(296, 398, 330, 430), // '1' glyph bbox
+        besideMinLuma: s.regionMinLuma(360, 398, 460, 430), // to the right stays blank
+      };
+    })()`);
+
+    // The label put ink on the page — guards the fix for the old exporter, which
+    // had no pageNumber branch and silently dropped these.
+    expect(r.labelMinLuma).toBeLessThan(120);
+    // Space beside the single digit stays white.
+    expect(r.besideMinLuma).toBeGreaterThan(240);
+  });
+
+  test('rotated page: text annotation lands in the correct region of the rotated view', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => !!window.pdfjsLib && !!window.PDFLib);
+
+    const r = await page.evaluate(`(async () => {
+      ${buildSourceDoc}
+      ${renderPage}
+      const { model, ops, exp, doc } = await buildSourceDoc();
+      const p1 = doc.pages[1];
+      ops.rotatePage(doc, p1.id, 90);
+
+      // In the rotated (90° cw) view the page is 800 wide × 600 tall. Place text
+      // at view coords (300, 300) — clear of the blue square (view x 100..200,
+      // y 100..200). It must render there in the rotated output view.
+      ops.addAnnotation(doc, p1.id, model.createAnnotation('text', {
+        text: 'ROT', x: 300, y: 300, fontSize: 40,
+        color: '#000000', fontFamily: 'Helvetica', bold: true, italic: false,
+      }));
+
+      const outBytes = await exp.buildPdfBytes(doc);
+      // PDF.js applies /Rotate in its default viewport → samples are in the
+      // ROTATED view frame, exactly where the user placed the text.
+      const s = await renderPage(outBytes, 2, 2);
+      return {
+        rotate: s.rotate,
+        vpWidth: s.vpWidth,
+        vpHeight: s.vpHeight,
+        textMinLuma: s.regionMinLuma(295, 300, 420, 350), // text bbox in rotated view
+        aboveMinLuma: s.regionMinLuma(295, 240, 420, 285), // above the text stays blank
+      };
+    })()`);
+
+    // Rotation is real metadata and the viewport swaps dims.
+    expect(r.rotate).toBe(90);
+    expect(r.vpWidth).toBe(800);
+    expect(r.vpHeight).toBe(600);
+
+    // Text ink landed in the rotated-view region; the area above it stays blank.
+    expect(r.textMinLuma).toBeLessThan(100);
+    expect(r.aboveMinLuma).toBeGreaterThan(240);
+  });
+
   test('isFromImage page: raw image source becomes a full-page image', async ({ page }) => {
     await page.goto('/');
     await page.waitForFunction(() => !!window.pdfjsLib && !!window.PDFLib);

--- a/tests/core-image-import.spec.js
+++ b/tests/core-image-import.spec.js
@@ -1,0 +1,260 @@
+/*
+ * PDFLokal — core image-as-page import (browser-tested: uses createImageBitmap,
+ * vendored PDF.js for the rasterize round-trip, and pdf-lib for the export
+ * round-trip).
+ *
+ * ~15% of files users add are images (a JPG/PNG photo dropped in as a page). This
+ * proves js/core/import.js `importImage`:
+ *   - decodes the image and makes ONE `isFromImage` page whose POINT size equals
+ *     the image's PIXEL size (the convention the old editor + export already use),
+ *   - rasterizes that page to a real image (the purge-proof <img> the render layer
+ *     shows), honoring page.rotation,
+ *   - transcodes non-PNG/JPEG (WEBP) to PNG at import so export can always embed it,
+ *   - round-trips through buildPdfBytes to a full-bleed image in the output PDF.
+ */
+import { test, expect } from '@playwright/test';
+
+// Render page `pageNum` (1-based) of `pdfBytes` with PDF.js at `scale` and return
+// a sampler over the resulting canvas — same round-trip strategy as the export
+// suite (rendered pixels are what the user actually sees).
+async function renderPage(pdfBytes, pageNum, scale) {
+  const out = await window.pdfjsLib.getDocument({ data: pdfBytes.slice() }).promise;
+  const pdfPage = await out.getPage(pageNum);
+  const vp = pdfPage.getViewport({ scale });
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.ceil(vp.width);
+  canvas.height = Math.ceil(vp.height);
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+  await pdfPage.render({ canvasContext: ctx, viewport: vp }).promise;
+  return {
+    numPages: out.numPages,
+    rotate: pdfPage.rotate,
+    vpWidth: Math.round(vp.width / scale),
+    vpHeight: Math.round(vp.height / scale),
+    px(x, y) {
+      const d = ctx.getImageData(Math.round(x * scale), Math.round(y * scale), 1, 1).data;
+      return [d[0], d[1], d[2]];
+    },
+  };
+}
+
+// Sample a 1×1 pixel [r,g,b] from a rasterizer result's PNG dataUrl.
+async function samplePixelOfDataUrl(dataUrl, x, y) {
+  const img = new Image();
+  await new Promise((res, rej) => { img.onload = res; img.onerror = rej; img.src = dataUrl; });
+  const c = document.createElement('canvas');
+  c.width = img.width;
+  c.height = img.height;
+  const ctx = c.getContext('2d', { willReadFrequently: true });
+  ctx.drawImage(img, 0, 0);
+  const d = ctx.getImageData(x, y, 1, 1).data;
+  return [d[0], d[1], d[2]];
+}
+
+// A 300×200 PNG: LEFT half (x 0..150) red, RIGHT half (x 150..300) blue. The two
+// distinct halves let rotation orientation be asserted (a solid image can't).
+function makeHalfRedHalfBluePng() {
+  const c = document.createElement('canvas');
+  c.width = 300; c.height = 200;
+  const ctx = c.getContext('2d');
+  ctx.fillStyle = '#ff0000';
+  ctx.fillRect(0, 0, 150, 200);
+  ctx.fillStyle = '#0000ff';
+  ctx.fillRect(150, 0, 150, 200);
+  return c; // caller turns it into bytes
+}
+
+test.describe('core image import', () => {
+  test('importImage: one isFromImage page at pixel dims; rasterize produces matching pixels', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => !!window.pdfjsLib);
+
+    const r = await page.evaluate(`(async () => {
+      ${samplePixelOfDataUrl}
+      ${makeHalfRedHalfBluePng}
+      const model = await import('/js/core/model.js');
+      const imp = await import('/js/core/import.js');
+
+      const c = makeHalfRedHalfBluePng();
+      const blob = await new Promise((res) => c.toBlob(res, 'image/png'));
+      const bytes = new Uint8Array(await blob.arrayBuffer());
+
+      const doc = model.createDoc();
+      const pages = await imp.importImage(doc, { name: 'foto.png', bytes, mimeType: 'image/png' });
+      const p0 = doc.pages[0];
+
+      // Rasterize at scale 1 → raster px == point size (== image pixel size).
+      const raster = await imp.rasterizePage(doc, p0, { scale: 1 });
+      const leftPx = await samplePixelOfDataUrl(raster.dataUrl, 75, 100);   // red half
+      const rightPx = await samplePixelOfDataUrl(raster.dataUrl, 225, 100); // blue half
+
+      return {
+        returnedPages: pages.length,
+        pageCount: doc.pages.length,
+        sourceCount: doc.sources.length,
+        isFromImage: p0.isFromImage,
+        w: p0.width, h: p0.height,
+        rotation: p0.rotation,
+        sourceNumPages: doc.sources[0].numPages,
+        annotationsOwnedByPage: Array.isArray(p0.annotations),
+        rasterW: raster.width, rasterH: raster.height,
+        isPng: raster.dataUrl.startsWith('data:image/png'),
+        leftPx, rightPx,
+      };
+    })()`);
+
+    expect(r.returnedPages).toBe(1);
+    expect(r.pageCount).toBe(1);
+    expect(r.sourceCount).toBe(1);
+    expect(r.isFromImage).toBe(true);
+    expect(r.w).toBe(300);
+    expect(r.h).toBe(200);
+    expect(r.rotation).toBe(0);
+    expect(r.sourceNumPages).toBe(1);
+    expect(r.annotationsOwnedByPage).toBe(true);
+
+    // scale 1 → raster px equals the point size equals the image pixel size.
+    expect(r.rasterW).toBe(300);
+    expect(r.rasterH).toBe(200);
+    expect(r.isPng).toBe(true);
+    // Pixels: left half red, right half blue.
+    expect(r.leftPx[0]).toBeGreaterThan(200); expect(r.leftPx[2]).toBeLessThan(80);
+    expect(r.rightPx[2]).toBeGreaterThan(200); expect(r.rightPx[0]).toBeLessThan(80);
+  });
+
+  test('importImage → buildPdfBytes: image becomes a full-bleed page in the output PDF', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => !!window.pdfjsLib && !!window.PDFLib);
+
+    const r = await page.evaluate(`(async () => {
+      ${renderPage}
+      ${makeHalfRedHalfBluePng}
+      const model = await import('/js/core/model.js');
+      const imp = await import('/js/core/import.js');
+      const exp = await import('/js/core/export.js');
+
+      const c = makeHalfRedHalfBluePng();
+      const blob = await new Promise((res) => c.toBlob(res, 'image/png'));
+      const bytes = new Uint8Array(await blob.arrayBuffer());
+
+      const doc = model.createDoc();
+      await imp.importImage(doc, { name: 'foto.png', bytes, mimeType: 'image/png' });
+
+      const outBytes = await exp.buildPdfBytes(doc);
+      const s = await renderPage(outBytes, 1, 2);
+      return {
+        numPages: s.numPages,
+        vpWidth: s.vpWidth, vpHeight: s.vpHeight,
+        leftPx: s.px(75, 100),   // red half in the rendered PDF page
+        rightPx: s.px(225, 100), // blue half
+      };
+    })()`);
+
+    expect(r.numPages).toBe(1);
+    expect(r.vpWidth).toBe(300);  // page point size == image pixel size
+    expect(r.vpHeight).toBe(200);
+    // Full-bleed image ink survived the round-trip, halves in place.
+    expect(r.leftPx[0]).toBeGreaterThan(200); expect(r.leftPx[2]).toBeLessThan(80);
+    expect(r.rightPx[2]).toBeGreaterThan(200); expect(r.rightPx[0]).toBeLessThan(80);
+  });
+
+  test('importImage with rotation:90: rasterize and export honor the rotated frame', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => !!window.pdfjsLib && !!window.PDFLib);
+
+    const r = await page.evaluate(`(async () => {
+      ${renderPage}
+      ${samplePixelOfDataUrl}
+      ${makeHalfRedHalfBluePng}
+      const model = await import('/js/core/model.js');
+      const ops = await import('/js/core/operations.js');
+      const imp = await import('/js/core/import.js');
+      const exp = await import('/js/core/export.js');
+
+      const c = makeHalfRedHalfBluePng();
+      const blob = await new Promise((res) => c.toBlob(res, 'image/png'));
+      const bytes = new Uint8Array(await blob.arrayBuffer());
+
+      const doc = model.createDoc();
+      await imp.importImage(doc, { name: 'foto.png', bytes, mimeType: 'image/png' });
+      const p0 = doc.pages[0];
+      ops.rotatePage(doc, p0.id, 90); // 90° clockwise: the RED left edge moves to the TOP
+
+      // Rasterize the rotated page: canvas dims swap to 200×300; top half red.
+      const raster = await imp.rasterizePage(doc, p0, { scale: 1 });
+      const rasterTop = await samplePixelOfDataUrl(raster.dataUrl, 100, 50);    // red (was left)
+      const rasterBottom = await samplePixelOfDataUrl(raster.dataUrl, 100, 250); // blue (was right)
+
+      // Export: /Rotate 90 in the output; PDF.js default viewport applies it,
+      // so samples are in the same rotated view the user sees.
+      const outBytes = await exp.buildPdfBytes(doc);
+      const s = await renderPage(outBytes, 1, 2);
+      return {
+        rasterW: raster.width, rasterH: raster.height,
+        rasterTop, rasterBottom,
+        rotate: s.rotate,
+        vpWidth: s.vpWidth, vpHeight: s.vpHeight,
+        exportTop: s.px(100, 50),     // red (was left) in rotated PDF view
+        exportBottom: s.px(100, 250), // blue (was right)
+      };
+    })()`);
+
+    // Rasterized canvas swapped to 200 wide × 300 tall.
+    expect(r.rasterW).toBe(200);
+    expect(r.rasterH).toBe(300);
+    // 90° CW: original left (red) is now the top; original right (blue) the bottom.
+    expect(r.rasterTop[0]).toBeGreaterThan(200); expect(r.rasterTop[2]).toBeLessThan(80);
+    expect(r.rasterBottom[2]).toBeGreaterThan(200); expect(r.rasterBottom[0]).toBeLessThan(80);
+
+    // Export: rotation is real metadata, viewport swaps, orientation matches raster.
+    expect(r.rotate).toBe(90);
+    expect(r.vpWidth).toBe(200);
+    expect(r.vpHeight).toBe(300);
+    expect(r.exportTop[0]).toBeGreaterThan(200); expect(r.exportTop[2]).toBeLessThan(80);
+    expect(r.exportBottom[2]).toBeGreaterThan(200); expect(r.exportBottom[0]).toBeLessThan(80);
+  });
+
+  test('importImage transcodes non-PNG/JPEG (WEBP) to PNG bytes so export can embed it', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForFunction(() => !!window.pdfjsLib && !!window.PDFLib);
+
+    const r = await page.evaluate(`(async () => {
+      ${renderPage}
+      ${makeHalfRedHalfBluePng}
+      const model = await import('/js/core/model.js');
+      const imp = await import('/js/core/import.js');
+      const exp = await import('/js/core/export.js');
+
+      const c = makeHalfRedHalfBluePng();
+      const webpBlob = await new Promise((res) => c.toBlob(res, 'image/webp'));
+      const inputWasWebp = webpBlob.type === 'image/webp'; // guard: Chromium supports webp encode
+      const bytes = new Uint8Array(await webpBlob.arrayBuffer());
+
+      const doc = model.createDoc();
+      await imp.importImage(doc, { name: 'foto.webp', bytes, mimeType: 'image/webp' });
+
+      const stored = doc.sources[0].bytes;
+      // PNG magic: 89 50 4E 47 — the transcode must have run.
+      const storedIsPng = stored[0] === 0x89 && stored[1] === 0x50 && stored[2] === 0x4e && stored[3] === 0x47;
+
+      // Export must not throw (it would if bytes were still WEBP) and must render ink.
+      const outBytes = await exp.buildPdfBytes(doc);
+      const s = await renderPage(outBytes, 1, 2);
+      return {
+        inputWasWebp,
+        storedIsPng,
+        w: doc.pages[0].width, h: doc.pages[0].height,
+        leftPx: s.px(75, 100),
+        rightPx: s.px(225, 100),
+      };
+    })()`);
+
+    expect(r.inputWasWebp).toBe(true); // confirms we actually exercised the transcode path
+    expect(r.storedIsPng).toBe(true);  // source bytes were transcoded to PNG at import
+    expect(r.w).toBe(300);
+    expect(r.h).toBe(200);
+    // Round-trips to a valid, embeddable image with correct colors.
+    expect(r.leftPx[0]).toBeGreaterThan(200); expect(r.leftPx[2]).toBeLessThan(80);
+    expect(r.rightPx[2]).toBeGreaterThan(200); expect(r.rightPx[0]).toBeLessThan(80);
+  });
+});

--- a/tests/core/history.test.mjs
+++ b/tests/core/history.test.mjs
@@ -1,0 +1,143 @@
+/*
+ * Headless tests for core/history.js — unified undo/redo on the Doc model.
+ * Run: npm run test:core   (node --test, no browser)
+ *
+ * The contract: record() BEFORE a mutation (gesture-level, not per-frame),
+ * undo()/redo() swap full model snapshots. Sources (bytes) are shared by
+ * reference — never cloned. Annotation strings (signature dataUrls) are
+ * immutable in JS, so shallow copies share them for free (no imageRegistry).
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createDoc, createSource, createPage, createAnnotation, _resetIds } from '../../js/core/model.js';
+import { addSource, addPages, removePage, reorderPage, rotatePage, addAnnotation, updateAnnotation, removeAnnotation, selectAnnotation } from '../../js/core/operations.js';
+import { createHistory, record, undo, redo, canUndo, canRedo } from '../../js/core/history.js';
+
+function docWithTwoPages() {
+  _resetIds();
+  const doc = createDoc();
+  const src = addSource(doc, createSource({ name: 'a.pdf', bytes: new Uint8Array([1, 2, 3]), numPages: 2 }));
+  addPages(doc, [
+    createPage({ source: src, sourcePageNum: 0, width: 595, height: 842 }),
+    createPage({ source: src, sourcePageNum: 1, width: 595, height: 842 }),
+  ]);
+  return doc;
+}
+
+test('undo restores a removed page WITH its annotations', () => {
+  const doc = docWithTwoPages();
+  const [p1] = doc.pages;
+  const anno = addAnnotation(doc, p1.id, createAnnotation('text', { x: 10, y: 20, text: 'halo' }));
+
+  const h = createHistory();
+  record(h, doc);
+  removePage(doc, p1.id);
+  assert.equal(doc.pages.length, 1);
+
+  undo(h, doc);
+  assert.equal(doc.pages.length, 2);
+  assert.equal(doc.pages[0].id, p1.id);
+  assert.equal(doc.pages[0].annotations.length, 1);
+  assert.equal(doc.pages[0].annotations[0].id, anno.id);
+  assert.equal(doc.pages[0].annotations[0].text, 'halo');
+});
+
+test('undo/redo round-trips a reorder', () => {
+  const doc = docWithTwoPages();
+  const [p1, p2] = doc.pages;
+  const h = createHistory();
+
+  record(h, doc);
+  reorderPage(doc, p1.id, 1);
+  assert.deepEqual(doc.pages.map((p) => p.id), [p2.id, p1.id]);
+
+  undo(h, doc);
+  assert.deepEqual(doc.pages.map((p) => p.id), [p1.id, p2.id]);
+  redo(h, doc);
+  assert.deepEqual(doc.pages.map((p) => p.id), [p2.id, p1.id]);
+});
+
+test('undo of an annotation edit does not disturb later unrelated state', () => {
+  const doc = docWithTwoPages();
+  const [p1, p2] = doc.pages;
+  const anno = addAnnotation(doc, p1.id, createAnnotation('whiteout', { x: 0, y: 0, width: 50, height: 20 }));
+  const h = createHistory();
+
+  record(h, doc);
+  updateAnnotation(doc, anno.id, { x: 99 });
+  // A later, un-recorded change to page 2's rotation is NOT part of the undo step
+  // contract — undo restores the recorded snapshot wholesale. Verify exactly that.
+  rotatePage(doc, p2.id, 90);
+
+  undo(h, doc);
+  assert.equal(doc.pages[0].annotations[0].x, 0, 'annotation x restored');
+  assert.equal(doc.pages[1].rotation, 0, 'snapshot restore is wholesale');
+});
+
+test('new record() clears the redo stack (no branching)', () => {
+  const doc = docWithTwoPages();
+  const [p1] = doc.pages;
+  const h = createHistory();
+
+  record(h, doc);
+  rotatePage(doc, p1.id, 90);
+  undo(h, doc);
+  assert.equal(canRedo(h), true);
+
+  record(h, doc);
+  rotatePage(doc, p1.id, 180);
+  assert.equal(canRedo(h), false, 'divergent edit kills redo branch');
+});
+
+test('history is capped at its limit (oldest dropped)', () => {
+  const doc = docWithTwoPages();
+  const [p1] = doc.pages;
+  const h = createHistory(3);
+  for (let i = 0; i < 5; i++) {
+    record(h, doc);
+    rotatePage(doc, p1.id, 90);
+  }
+  assert.equal(h.undoStack.length, 3);
+  // 5 rotations = 450° → normalized 90. Undo x3 lands at rotation after 2 rotations = 180.
+  undo(h, doc); undo(h, doc); undo(h, doc);
+  assert.equal(canUndo(h), false);
+  assert.equal(doc.pages[0].rotation, 180);
+});
+
+test('snapshots share source bytes and signature dataUrls by reference (no clone)', () => {
+  const doc = docWithTwoPages();
+  const [p1] = doc.pages;
+  const bigString = 'data:image/png;base64,' + 'x'.repeat(1000);
+  addAnnotation(doc, p1.id, createAnnotation('signature', { x: 0, y: 0, width: 150, height: 60, image: bigString }));
+  const h = createHistory();
+  record(h, doc);
+
+  const snap = h.undoStack[0];
+  assert.equal(snap.pages[0].annotations[0].image, bigString, 'string shared');
+  assert.equal(doc.sources[0].bytes, snap.sources ? snap.sources[0].bytes : doc.sources[0].bytes, 'bytes never cloned');
+});
+
+test('undo restores selection as-of the snapshot', () => {
+  const doc = docWithTwoPages();
+  const [p1] = doc.pages;
+  const anno = addAnnotation(doc, p1.id, createAnnotation('text', { x: 1, y: 1, text: 'a' }));
+  selectAnnotation(doc, anno.id);
+
+  const h = createHistory();
+  record(h, doc);
+  removeAnnotation(doc, anno.id);
+  assert.equal(doc.selection.annotationId, null);
+
+  undo(h, doc);
+  assert.equal(doc.selection.annotationId, anno.id);
+});
+
+test('undo() / redo() on empty stacks are safe no-ops', () => {
+  const doc = docWithTwoPages();
+  const h = createHistory();
+  assert.equal(undo(h, doc), false);
+  assert.equal(redo(h, doc), false);
+  assert.equal(canUndo(h), false);
+  assert.equal(canRedo(h), false);
+});

--- a/tests/core/interactions.test.mjs
+++ b/tests/core/interactions.test.mjs
@@ -53,6 +53,15 @@ test('resizeAnnotation can set bounds (x, y, width, height) atomically', () => {
   assert.deepEqual({ x: anno.x, y: anno.y, width: anno.width, height: anno.height }, { x: 20, y: 30, width: 100, height: 40 });
 });
 
+test('moveAnnotation clamps against the ROTATED frame on 90/270 pages', () => {
+  const doc = docWithPage(); // 600 x 800
+  const anno = addAnnotation(doc, doc.pages[0].id, createAnnotation('whiteout', { x: 0, y: 0, width: 50, height: 20 }));
+  doc.pages[0].rotation = 90; // view frame becomes 800 x 600
+  moveAnnotation(doc, anno.id, 5000, 5000);
+  assert.equal(anno.x, 750, 'clamps to rotated width (800) - anno width');
+  assert.equal(anno.y, 580, 'clamps to rotated height (600) - anno height');
+});
+
 test('move/resize on unknown id are safe no-ops returning null', () => {
   const doc = docWithPage();
   assert.equal(moveAnnotation(doc, 'anno_nope', 1, 1), null);

--- a/tests/core/interactions.test.mjs
+++ b/tests/core/interactions.test.mjs
@@ -1,0 +1,60 @@
+/*
+ * Headless tests for the interaction-facing core ops: move / resize with
+ * clamping. These exist so drag/resize UI code goes through the SINGLE
+ * mutation path (invariant #5) instead of poking annotation.x directly
+ * (which is what js/lab.js's demo drag did — harness-only, now retired).
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createDoc, createSource, createPage, createAnnotation, _resetIds } from '../../js/core/model.js';
+import { addSource, addPages, addAnnotation, moveAnnotation, resizeAnnotation } from '../../js/core/operations.js';
+
+function docWithPage() {
+  _resetIds();
+  const doc = createDoc();
+  const src = addSource(doc, createSource({ name: 'a.pdf', bytes: new Uint8Array([1]), numPages: 1 }));
+  addPages(doc, [createPage({ source: src, sourcePageNum: 0, width: 600, height: 800 })]);
+  return doc;
+}
+
+test('moveAnnotation applies a delta in page space', () => {
+  const doc = docWithPage();
+  const anno = addAnnotation(doc, doc.pages[0].id, createAnnotation('text', { x: 100, y: 100, text: 'a' }));
+  moveAnnotation(doc, anno.id, 15, -30);
+  assert.equal(anno.x, 115);
+  assert.equal(anno.y, 70);
+});
+
+test('moveAnnotation keeps the annotation anchor inside the page bounds', () => {
+  const doc = docWithPage();
+  const anno = addAnnotation(doc, doc.pages[0].id, createAnnotation('whiteout', { x: 10, y: 10, width: 50, height: 20 }));
+  moveAnnotation(doc, anno.id, -500, -500);
+  assert.equal(anno.x, 0);
+  assert.equal(anno.y, 0);
+  moveAnnotation(doc, anno.id, 5000, 5000);
+  // Anchor clamps to page size minus the annotation's own size.
+  assert.equal(anno.x, 550);
+  assert.equal(anno.y, 780);
+});
+
+test('resizeAnnotation enforces a minimum size', () => {
+  const doc = docWithPage();
+  const anno = addAnnotation(doc, doc.pages[0].id, createAnnotation('signature', { x: 10, y: 10, width: 150, height: 60 }));
+  resizeAnnotation(doc, anno.id, { width: 2, height: 1 });
+  assert.ok(anno.width >= 8, `width ${anno.width} respects minimum`);
+  assert.ok(anno.height >= 8, `height ${anno.height} respects minimum`);
+});
+
+test('resizeAnnotation can set bounds (x, y, width, height) atomically', () => {
+  const doc = docWithPage();
+  const anno = addAnnotation(doc, doc.pages[0].id, createAnnotation('whiteout', { x: 10, y: 10, width: 50, height: 20 }));
+  resizeAnnotation(doc, anno.id, { x: 20, y: 30, width: 100, height: 40 });
+  assert.deepEqual({ x: anno.x, y: anno.y, width: anno.width, height: anno.height }, { x: 20, y: 30, width: 100, height: 40 });
+});
+
+test('move/resize on unknown id are safe no-ops returning null', () => {
+  const doc = docWithPage();
+  assert.equal(moveAnnotation(doc, 'anno_nope', 1, 1), null);
+  assert.equal(resizeAnnotation(doc, 'anno_nope', { width: 10 }), null);
+});

--- a/tests/editor-v2-desktop.spec.js
+++ b/tests/editor-v2-desktop.spec.js
@@ -1,0 +1,56 @@
+/*
+ * Editor v2 on DESKTOP (chromium project) — the mobile suite is the deep one;
+ * this guards that the unified pointer path really is unified: same flows,
+ * mouse instead of touch. Desktop is still 69% of today's organic traffic.
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(__dirname, 'fixtures', 'sample-2pages.pdf');
+
+test.describe('editor v2 — desktop', () => {
+  test('full flow: open → type → style → drag → download a valid PDF', async ({ page }) => {
+    await page.goto('/editor-v2.html');
+    await page.setInputFiles('#file-input', FIXTURE);
+    await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+
+    // Keyboard verb → click to place text → type → commit.
+    await page.keyboard.press('t');
+    await page.click('.pv-page >> nth=0', { position: { x: 200, y: 200 } });
+    await page.keyboard.type('Dari desktop');
+    await page.keyboard.press('Enter');
+    await expect(page.locator('.pv-anno-text')).toHaveText('Dari desktop');
+
+    // Style via the format bar (still visible: committed text stays selected).
+    await page.click('.fb-bold');
+    await expect(page.locator('.pv-anno-text')).toHaveCSS('font-weight', '700');
+
+    // Mouse-drag the annotation.
+    const before = await page.evaluate(() => window.v2.getDoc().pages[0].annotations[0].x);
+    const box = await page.locator('.pv-anno-text').boundingBox();
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width / 2 + 80, box.y + box.height / 2 + 30, { steps: 5 });
+    await page.mouse.up();
+    const after = await page.evaluate(() => window.v2.getDoc().pages[0].annotations[0].x);
+    expect(after).toBeGreaterThan(before);
+
+    // Download produces a real PDF.
+    const dl = page.waitForEvent('download');
+    await page.click('#btn-download');
+    const download = await dl;
+    expect(download.suggestedFilename()).toMatch(/pdflokal\.pdf$/);
+  });
+
+  test('page manager works with a mouse (click select, bulk rotate)', async ({ page }) => {
+    await page.goto('/editor-v2.html');
+    await page.setInputFiles('#file-input', FIXTURE);
+    await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+    await page.click('#btn-pages');
+    await page.click('.pm-tile >> nth=0');
+    await page.click('[data-act="rotate"]');
+    expect(await page.evaluate(() => window.v2.getDoc().pages[0].rotation)).toBe(90);
+  });
+});

--- a/tests/mobile/editor-v2.spec.js
+++ b/tests/mobile/editor-v2.spec.js
@@ -1,0 +1,116 @@
+/*
+ * Editor v2 on a phone (Pixel 7 emulation: touch, mobile viewport, DPR 2.6).
+ * Runs under the `mobile-chrome` Playwright project — see playwright.config.js.
+ *
+ * These are the FIRST touch tests in the repo. They exercise the one flow the
+ * business runs on (product-definition §4): open → edit → download, on mobile.
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(__dirname, '..', 'fixtures', 'sample-2pages.pdf');
+
+async function openWithFixture(page) {
+  await page.goto('/editor-v2.html');
+  await page.setInputFiles('#file-input', FIXTURE);
+  // Both pages get slots instantly; near pages rasterize to <img>.
+  await expect(page.locator('.pv-page')).toHaveCount(2);
+  await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+}
+
+test.describe('editor v2 — mobile', () => {
+  test('opens a PDF: instant slots, image-backed pages, no empty state', async ({ page }) => {
+    await openWithFixture(page);
+    await expect(page.locator('#empty')).toBeHidden();
+    // Pages are <img>, not <canvas> — the locked render decision.
+    expect(await page.locator('.pv-page canvas').count()).toBe(0);
+  });
+
+  test('tap-to-type: text tool places editable text via touch', async ({ page }) => {
+    await openWithFixture(page);
+    await page.tap('[data-tool="text"]');
+    await page.tap('.pv-page >> nth=0', { position: { x: 150, y: 200 } });
+    await expect(page.locator('.v2-text-edit')).toBeVisible();
+    await page.keyboard.type('Halo dari HP');
+    await page.keyboard.press('Enter');
+
+    const annos = await page.evaluate(() => window.v2.getDoc().pages[0].annotations);
+    expect(annos).toHaveLength(1);
+    expect(annos[0].type).toBe('text');
+    expect(annos[0].text).toBe('Halo dari HP');
+    // Tool returned home to Pilih (tools are verbs).
+    expect(await page.evaluate(() => window.v2.getTool())).toBe('select');
+    await expect(page.locator('.pv-anno-text')).toHaveText('Halo dari HP');
+  });
+
+  test('undo/redo round-trips an edit and updates button state', async ({ page }) => {
+    await openWithFixture(page);
+    await page.tap('[data-tool="text"]');
+    await page.tap('.pv-page >> nth=0', { position: { x: 100, y: 150 } });
+    await page.keyboard.type('sekali');
+    await page.keyboard.press('Enter');
+    await expect(page.locator('#btn-undo')).toBeEnabled();
+
+    await page.tap('#btn-undo');
+    expect(await page.evaluate(() => window.v2.getDoc().pages[0].annotations.length)).toBe(0);
+    await expect(page.locator('#btn-redo')).toBeEnabled();
+
+    await page.tap('#btn-redo');
+    expect(await page.evaluate(() => window.v2.getDoc().pages[0].annotations.length)).toBe(1);
+  });
+
+  test('drag moves an annotation and clamps inside the page', async ({ page }) => {
+    await openWithFixture(page);
+    // Place a text annotation programmatically (drag is what we're testing).
+    await page.evaluate(() => {
+      const doc = window.v2.getDoc();
+      return import('/js/core/model.js').then((m) =>
+        import('/js/core/operations.js').then((o) => {
+          o.addAnnotation(doc, doc.pages[0].id, m.createAnnotation('text', {
+            text: 'geser aku', x: 100, y: 100, fontSize: 20,
+          }));
+          window.v2.setTool('select');
+          window.dispatchEvent(new Event('resize'));
+        }));
+    });
+    await page.reloadStageForTest?.();
+    await page.evaluate(() => {
+      // Re-sync the stage after the direct model poke.
+      const doc = window.v2.getDoc();
+      const slot = window.v2.getSlots()[0];
+      return import('/js/render/page-view.js').then((pv) => pv.syncOverlay(doc.pages[0], slot.view, {}));
+    });
+
+    const anno = page.locator('.pv-anno-text');
+    await expect(anno).toBeVisible();
+    const before = await page.evaluate(() => {
+      const a = window.v2.getDoc().pages[0].annotations[0];
+      return { x: a.x, y: a.y };
+    });
+
+    // Touch-drag via dispatched pointer events (the unified input path).
+    const box = await anno.boundingBox();
+    const cx = box.x + box.width / 2;
+    const cy = box.y + box.height / 2;
+    await anno.dispatchEvent('pointerdown', { pointerId: 1, clientX: cx, clientY: cy, bubbles: true, isPrimary: true });
+    await page.locator('#v2-stage').dispatchEvent('pointermove', { pointerId: 1, clientX: cx + 60, clientY: cy + 40, bubbles: true });
+    await page.locator('#v2-stage').dispatchEvent('pointerup', { pointerId: 1, clientX: cx + 60, clientY: cy + 40, bubbles: true });
+
+    const after = await page.evaluate(() => {
+      const a = window.v2.getDoc().pages[0].annotations[0];
+      return { x: a.x, y: a.y };
+    });
+    expect(after.x).toBeGreaterThan(before.x);
+    expect(after.y).toBeGreaterThan(before.y);
+  });
+
+  test('merge: adding a second PDF appends its pages', async ({ page }) => {
+    await openWithFixture(page);
+    await page.setInputFiles('#file-input', FIXTURE);
+    await expect(page.locator('.pv-page')).toHaveCount(4);
+    const sources = await page.evaluate(() => window.v2.getDoc().sources.length);
+    expect(sources).toBe(2);
+  });
+});

--- a/tests/mobile/editor-v2.spec.js
+++ b/tests/mobile/editor-v2.spec.js
@@ -113,4 +113,22 @@ test.describe('editor v2 — mobile', () => {
     const sources = await page.evaluate(() => window.v2.getDoc().sources.length);
     expect(sources).toBe(2);
   });
+
+  test('adding an image appends it as one page (isFromImage)', async ({ page }) => {
+    await openWithFixture(page);
+    // 1×1 red PNG — the smallest possible image-as-page.
+    const redPixel = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+      'base64',
+    );
+    await page.setInputFiles('#file-input', { name: 'foto.png', mimeType: 'image/png', buffer: redPixel });
+    await expect(page.locator('.pv-page')).toHaveCount(3);
+    const last = await page.evaluate(() => {
+      const p = window.v2.getDoc().pages.at(-1);
+      return { isFromImage: p.isFromImage, w: p.width, h: p.height };
+    });
+    expect(last.isFromImage).toBe(true);
+    expect(last.w).toBe(1);
+    expect(last.h).toBe(1);
+  });
 });

--- a/tests/mobile/format-bar.spec.js
+++ b/tests/mobile/format-bar.spec.js
@@ -1,0 +1,80 @@
+/*
+ * Text format bar (v2) on a phone — text is the #1 in-editor action (~30%).
+ * Covers: contextual visibility, styling a selected annotation, sticky
+ * defaults for new text, live restyle of the inline draft.
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(__dirname, '..', 'fixtures', 'sample-2pages.pdf');
+
+async function openAndPlaceText(page, text) {
+  await page.goto('/editor-v2.html');
+  await page.setInputFiles('#file-input', FIXTURE);
+  await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+  await page.tap('[data-tool="text"]');
+  await page.tap('.pv-page >> nth=0', { position: { x: 120, y: 180 } });
+  await page.keyboard.type(text);
+  await page.keyboard.press('Enter');
+}
+
+test.describe('format bar — mobile', () => {
+  test('hidden by default; appears when the Teks tool is armed', async ({ page }) => {
+    await page.goto('/editor-v2.html');
+    await page.setInputFiles('#file-input', FIXTURE);
+    await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+    await expect(page.locator('#format-bar')).toBeHidden();
+    await page.tap('[data-tool="text"]');
+    await expect(page.locator('#format-bar')).toBeVisible();
+  });
+
+  test('new text stays selected after commit; bold applies to it', async ({ page }) => {
+    await openAndPlaceText(page, 'format aku');
+    // Committed text is still the selection → bar targets it.
+    await expect(page.locator('#format-bar')).toBeVisible();
+    const sel = await page.evaluate(() => window.v2.getDoc().selection.annotationId);
+    expect(sel).toBeTruthy();
+
+    await page.tap('.fb-bold');
+    const anno = await page.evaluate(() => window.v2.getDoc().pages[0].annotations[0]);
+    expect(anno.bold).toBe(true);
+    await expect(page.locator('.pv-anno-text')).toHaveCSS('font-weight', '700');
+  });
+
+  test('font family + color + size flow into the model and the DOM', async ({ page }) => {
+    await openAndPlaceText(page, 'gaya');
+    await page.selectOption('.fb-font', 'Montserrat');
+    await page.selectOption('.fb-size', '32');
+    await page.tap('.fb-color[data-color="#d33131"]');
+
+    const anno = await page.evaluate(() => window.v2.getDoc().pages[0].annotations[0]);
+    expect(anno.fontFamily).toBe('Montserrat');
+    expect(anno.fontSize).toBe(32);
+    expect(anno.color).toBe('#d33131');
+    await expect(page.locator('.pv-anno-text')).toHaveCSS('font-size', '32px');
+  });
+
+  test('styles are sticky: the NEXT text inherits them', async ({ page }) => {
+    await openAndPlaceText(page, 'pertama');
+    await page.tap('.fb-bold'); // also updates sticky defaults
+    // Place a second text somewhere else.
+    await page.tap('[data-tool="text"]');
+    await page.tap('.pv-page >> nth=0', { position: { x: 100, y: 320 } });
+    await page.keyboard.type('kedua');
+    await page.keyboard.press('Enter');
+
+    const annos = await page.evaluate(() => window.v2.getDoc().pages[0].annotations);
+    expect(annos).toHaveLength(2);
+    expect(annos[1].bold).toBe(true);
+  });
+
+  test('styling change is one undo step', async ({ page }) => {
+    await openAndPlaceText(page, 'undoable');
+    await page.tap('.fb-color[data-color="#1d6fdc"]');
+    expect((await page.evaluate(() => window.v2.getDoc().pages[0].annotations[0])).color).toBe('#1d6fdc');
+    await page.tap('#btn-undo');
+    expect((await page.evaluate(() => window.v2.getDoc().pages[0].annotations[0])).color).toBe('#000000');
+  });
+});

--- a/tests/mobile/page-manager.spec.js
+++ b/tests/mobile/page-manager.spec.js
@@ -1,0 +1,110 @@
+/*
+ * Page manager sheet (v2) on a phone — assemble is ~36% of in-editor actions.
+ * Covers: open/select/bulk-rotate/bulk-delete/undo, extract download, and the
+ * pointer-based reorder (the old HTML5-DnD version never worked on touch).
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(__dirname, '..', 'fixtures', 'sample-2pages.pdf');
+
+async function openSheet(page) {
+  await page.goto('/editor-v2.html');
+  await page.setInputFiles('#file-input', FIXTURE);
+  await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+  await page.tap('#btn-pages');
+  await expect(page.locator('#pm-sheet')).toBeVisible();
+  await expect(page.locator('.pm-tile:not(.pm-add)')).toHaveCount(2);
+}
+
+test.describe('page manager — mobile', () => {
+  test('opens with a tile per page + an add tile; thumbnails stream in', async ({ page }) => {
+    await openSheet(page);
+    await expect(page.locator('.pm-add')).toHaveCount(1);
+    // Thumbs render async; wait for the first background-image.
+    await expect(page.locator('.pm-thumb').first()).toHaveAttribute('style', /background-image/, { timeout: 10000 });
+  });
+
+  test('tap selects; bulk rotate goes through core + invalidates rasters', async ({ page }) => {
+    await openSheet(page);
+    await page.tap('.pm-tile >> nth=0');
+    await expect(page.locator('#pm-bulk')).toBeVisible();
+    await expect(page.locator('.pm-count')).toHaveText('1 dipilih');
+
+    await page.tap('[data-act="rotate"]');
+    const rot = await page.evaluate(() => window.v2.getDoc().pages[0].rotation);
+    expect(rot).toBe(90);
+    // Main stage rebuilt with swapped dims (rotated frame).
+    const dims = await page.evaluate(() => {
+      const pg = window.v2.getDoc().pages[0];
+      const view = document.querySelector(`[data-page-id="${pg.id}"]`);
+      return { css: view.style.width, pageH: pg.height + 'px' };
+    });
+    expect(dims.css).toBe(dims.pageH);
+  });
+
+  test('bulk delete removes pages; deleting ALL pages is blocked; undo restores', async ({ page }) => {
+    await openSheet(page);
+    // Select both → delete disabled (empty doc is a dead end).
+    await page.tap('.pm-tile >> nth=0');
+    await page.tap('.pm-tile >> nth=1');
+    await expect(page.locator('[data-act="delete"]')).toBeDisabled();
+
+    // Deselect one → delete the other.
+    await page.tap('.pm-tile >> nth=1');
+    await page.tap('[data-act="delete"]');
+    expect(await page.evaluate(() => window.v2.getDoc().pages.length)).toBe(1);
+    await expect(page.locator('.pm-tile:not(.pm-add)')).toHaveCount(1);
+
+    // Undo (sheet stays usable; model restored).
+    await page.tap('#pm-close');
+    await page.tap('#btn-undo');
+    expect(await page.evaluate(() => window.v2.getDoc().pages.length)).toBe(2);
+  });
+
+  test('pointer drag reorders pages (annotations travel, zero re-keying)', async ({ page }) => {
+    await openSheet(page);
+    // Pin an annotation to page 1 so we can prove it travels.
+    const p1id = await page.evaluate(() => {
+      const doc = window.v2.getDoc();
+      return import('/js/core/model.js').then((m) =>
+        import('/js/core/operations.js').then((o) => {
+          o.addAnnotation(doc, doc.pages[0].id, m.createAnnotation('text', { text: 'aku ikut', x: 10, y: 10 }));
+          return doc.pages[0].id;
+        }));
+    });
+
+    const first = page.locator('.pm-tile >> nth=0');
+    const second = page.locator('.pm-tile >> nth=1');
+    const a = await first.boundingBox();
+    const b = await second.boundingBox();
+
+    // Long-press (280ms) then drag onto the second tile — the touch path.
+    await first.dispatchEvent('pointerdown', {
+      pointerId: 7, pointerType: 'touch', clientX: a.x + 40, clientY: a.y + 40, bubbles: true, isPrimary: true,
+    });
+    await page.waitForTimeout(380);
+    await first.dispatchEvent('pointermove', {
+      pointerId: 7, pointerType: 'touch', clientX: b.x + 40, clientY: b.y + 40, bubbles: true,
+    });
+    await first.dispatchEvent('pointerup', {
+      pointerId: 7, pointerType: 'touch', clientX: b.x + 40, clientY: b.y + 40, bubbles: true,
+    });
+
+    const order = await page.evaluate(() => window.v2.getDoc().pages.map((p) => p.id));
+    expect(order[1]).toBe(p1id); // page 1 moved to position 2
+    const travelled = await page.evaluate(() => window.v2.getDoc().pages[1].annotations[0]?.text);
+    expect(travelled).toBe('aku ikut'); // its annotation came along — no re-keying
+  });
+
+  test('extract downloads the selected pages as a PDF', async ({ page }) => {
+    await openSheet(page);
+    await page.tap('.pm-tile >> nth=0');
+    const dl = page.waitForEvent('download');
+    await page.tap('[data-act="extract"]');
+    const download = await dl;
+    expect(download.suggestedFilename()).toMatch(/halaman-1\.pdf$/);
+  });
+});

--- a/tests/mobile/signature.spec.js
+++ b/tests/mobile/signature.spec.js
@@ -1,0 +1,104 @@
+/*
+ * Signature flow (v2) on a phone — sign = ~19% of in-editor actions.
+ * Covers: draw→place→selected, paraf sizing, "Semua Hal." fan-out, upload tab
+ * with white-background removal.
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(__dirname, '..', 'fixtures', 'sample-2pages.pdf');
+
+// 1×1 red pixel PNG — enough for the upload pipeline (opaque → survives trim).
+const RED_PIXEL = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+async function openDoc(page) {
+  await page.goto('/editor-v2.html');
+  await page.setInputFiles('#file-input', FIXTURE);
+  await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+}
+
+async function drawStroke(page) {
+  const box = await page.locator('#sig-canvas').boundingBox();
+  await page.mouse.move(box.x + 40, box.y + 60);
+  await page.mouse.down();
+  await page.mouse.move(box.x + 120, box.y + 90, { steps: 6 });
+  await page.mouse.move(box.x + 200, box.y + 50, { steps: 6 });
+  await page.mouse.up();
+}
+
+test.describe('signature — mobile', () => {
+  test('draw → place: annotation lands selected, Semua Hal. offered', async ({ page }) => {
+    await openDoc(page);
+    await page.tap('[data-tool="signature"]');
+    await expect(page.locator('#sig-modal')).toBeVisible();
+    await drawStroke(page);
+    await page.tap('#sig-use');
+    await page.tap('.pv-page >> nth=0', { position: { x: 150, y: 250 } });
+
+    const anno = await page.evaluate(() => window.v2.getDoc().pages[0].annotations[0]);
+    expect(anno.type).toBe('signature');
+    expect(anno.width).toBe(150);
+    expect(anno.image).toMatch(/^data:image\/png/);
+    // Placed → selected → the fan-out action is one tap away.
+    expect(await page.evaluate(() => window.v2.getDoc().selection.annotationId)).toBe(anno.id);
+    await expect(page.locator('#sig-bar')).toBeVisible();
+  });
+
+  test('Semua Hal. copies to every other page with independent ids', async ({ page }) => {
+    await openDoc(page);
+    await page.tap('[data-tool="signature"]');
+    await drawStroke(page);
+    await page.tap('#sig-use');
+    await page.tap('.pv-page >> nth=0', { position: { x: 150, y: 250 } });
+    await page.tap('#btn-all-pages');
+
+    const info = await page.evaluate(() => {
+      const d = window.v2.getDoc();
+      return {
+        p1: d.pages[0].annotations.map((a) => a.id),
+        p2: d.pages[1].annotations.map((a) => a.id),
+        pos: [d.pages[0].annotations[0], d.pages[1].annotations[0]].map((a) => [a.x, a.y]),
+      };
+    });
+    expect(info.p1).toHaveLength(1);
+    expect(info.p2).toHaveLength(1);
+    expect(info.p2[0]).not.toBe(info.p1[0]);        // own object, own id
+    expect(info.pos[1]).toEqual(info.pos[0]);        // same position
+    // One undo removes the fan-out.
+    await page.tap('#btn-undo');
+    expect(await page.evaluate(() => window.v2.getDoc().pages[1].annotations.length)).toBe(0);
+  });
+
+  test('paraf mode places small (80px) with subtype', async ({ page }) => {
+    await openDoc(page);
+    await page.tap('[data-tool="signature"]');
+    await drawStroke(page);
+    await page.tap('#sig-paraf');
+    await page.tap('#sig-use');
+    await page.tap('.pv-page >> nth=0', { position: { x: 120, y: 300 } });
+
+    const anno = await page.evaluate(() => window.v2.getDoc().pages[0].annotations[0]);
+    expect(anno.subtype).toBe('paraf');
+    expect(anno.width).toBe(80);
+    await expect(page.locator('#sig-bar-label')).toHaveText('Paraf terpilih');
+  });
+
+  test('upload tab: image file flows through bg-removal to placement', async ({ page }) => {
+    await openDoc(page);
+    await page.tap('[data-tool="signature"]');
+    await page.tap('.sig-tab[data-tab="upload"]');
+    await page.setInputFiles('#sig-file', { name: 'ttd.png', mimeType: 'image/png', buffer: RED_PIXEL });
+    await expect(page.locator('#sig-preview canvas')).toBeVisible();
+    await page.tap('#sig-use');
+    await page.tap('.pv-page >> nth=0', { position: { x: 180, y: 220 } });
+
+    const anno = await page.evaluate(() => window.v2.getDoc().pages[0].annotations[0]);
+    expect(anno.type).toBe('signature');
+    expect(anno.image).toMatch(/^data:image\/png/);
+  });
+});

--- a/tests/mobile/whiteout-drag.spec.js
+++ b/tests/mobile/whiteout-drag.spec.js
@@ -1,0 +1,99 @@
+/*
+ * The two gaps Ojan found on his phone (Jul 2): text couldn't be dragged,
+ * Tip-Ex (whiteout) didn't work. These reproduce the flows with REAL pointer
+ * sequences (touch-typed events incl. browser-realistic ordering), not just
+ * model pokes.
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(__dirname, '..', 'fixtures', 'sample-2pages.pdf');
+
+async function openDoc(page) {
+  await page.goto('/editor-v2.html');
+  await page.setInputFiles('#file-input', FIXTURE);
+  await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+}
+
+// Real-ish touch drag: pointerdown/move/up WITH pointerType touch AND the
+// coalesced single-touch semantics (isPrimary, same pointerId).
+async function touchDrag(page, fromX, fromY, toX, toY, steps = 6) {
+  await page.evaluate(async ({ fromX, fromY, toX, toY, steps }) => {
+    const target = document.elementFromPoint(fromX, fromY);
+    const fire = (type, el, x, y) => el.dispatchEvent(new PointerEvent(type, {
+      pointerId: 11, pointerType: 'touch', isPrimary: true,
+      clientX: x, clientY: y, bubbles: true, cancelable: true, composed: true,
+      button: type === 'pointerdown' ? 0 : -1, buttons: type === 'pointerup' ? 0 : 1,
+    }));
+    fire('pointerdown', target, fromX, fromY);
+    for (let i = 1; i <= steps; i += 1) {
+      const x = fromX + ((toX - fromX) * i) / steps;
+      const y = fromY + ((toY - fromY) * i) / steps;
+      // After setPointerCapture the browser retargets to the capture element;
+      // dispatching manually we emulate that by firing on the capture target.
+      fire('pointermove', document.elementFromPoint(x, y) || target, x, y);
+      await new Promise((r) => requestAnimationFrame(r));
+    }
+    fire('pointerup', document.elementFromPoint(toX, toY) || target, toX, toY);
+  }, { fromX, fromY, toX, toY, steps });
+}
+
+test.describe('whiteout + text drag — the real-phone gaps', () => {
+  test('Tip-Ex: touch drag on the page creates a whiteout with real size', async ({ page }) => {
+    await openDoc(page);
+    await page.tap('[data-tool="whiteout"]');
+    const pageBox = await page.locator('.pv-page >> nth=0').boundingBox();
+    await touchDrag(page,
+      pageBox.x + 60, pageBox.y + 120,
+      pageBox.x + 200, pageBox.y + 180);
+
+    const annos = await page.evaluate(() => window.v2.getDoc().pages[0].annotations);
+    expect(annos).toHaveLength(1);
+    expect(annos[0].type).toBe('whiteout');
+    expect(annos[0].width).toBeGreaterThan(50);
+    expect(annos[0].height).toBeGreaterThan(20);
+    // And it's visible in the DOM.
+    await expect(page.locator('.pv-anno-whiteout')).toBeVisible();
+  });
+
+  test('text: touch drag moves a placed text annotation', async ({ page }) => {
+    await openDoc(page);
+    await page.tap('[data-tool="text"]');
+    await page.tap('.pv-page >> nth=0', { position: { x: 120, y: 150 } });
+    await page.keyboard.type('geser aku');
+    await page.keyboard.press('Enter');
+    await expect(page.locator('.pv-anno-text')).toBeVisible();
+
+    const before = await page.evaluate(() => {
+      const a = window.v2.getDoc().pages[0].annotations[0];
+      return { x: a.x, y: a.y };
+    });
+    const box = await page.locator('.pv-anno-text').boundingBox();
+    await touchDrag(page,
+      box.x + box.width / 2, box.y + box.height / 2,
+      box.x + box.width / 2 + 70, box.y + box.height / 2 + 50);
+
+    const after = await page.evaluate(() => {
+      const a = window.v2.getDoc().pages[0].annotations[0];
+      return { x: a.x, y: a.y };
+    });
+    expect(after.x).toBeGreaterThan(before.x);
+    expect(after.y).toBeGreaterThan(before.y);
+  });
+
+  test('whiteout also works with a mouse on desktop-like input', async ({ page }) => {
+    await openDoc(page);
+    await page.click('[data-tool="whiteout"]');
+    const pageBox = await page.locator('.pv-page >> nth=0').boundingBox();
+    await page.mouse.move(pageBox.x + 50, pageBox.y + 300);
+    await page.mouse.down();
+    await page.mouse.move(pageBox.x + 180, pageBox.y + 340, { steps: 5 });
+    await page.mouse.up();
+
+    const annos = await page.evaluate(() => window.v2.getDoc().pages[0].annotations);
+    expect(annos).toHaveLength(1);
+    expect(annos[0].type).toBe('whiteout');
+  });
+});


### PR DESCRIPTION
## What
Editor v2, built clean on js/core + js/render (decision: decisions.md Jul 2, clean-rebuild-and-swap). **Additive-only: index.html and the live editor are untouched.** Ships pdflokal.id/editor-v2.html (unlinked, noindex) for real-phone testing.

## Included
- Engine: unified undo/redo, move/resize ops, export adapter (pixel-verified; found 2 live bugs in the old exporter), streaming viewport, one pointer input path
- v2: load/merge (PDF + images), text + format bar, whiteout, signatures (draw/upload/bg-removal/paraf/Semua Hal.), Kelola Halaman sheet (touch drag-reorder), undo/redo, keyboard verbs, size guards
- Mobile verification: Playwright mobile-chrome project (28 touch tests), Android emulator + CDP loop (docs/android-verification.md)
- Founder-reported bugs fixed + verified under real OS touch: whiteout NaN, tiny text targets, CSS zoom quirk → transform

## Verification
107/107 Playwright (chromium + mobile-chrome) · 21/21 headless core · lint clean · real-Android emulator feature pass · founder phone pass happens on prod URL after this merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSTkjTsoHVmrYm84C7MhLW