### PR TITLE
feat(v2): camera-first touch model, color-at-start Tip-Ex, write-over-tipex

### DIFF
--- a/js/render/interaction.js
+++ b/js/render/interaction.js
@@ -24,6 +24,7 @@ import { decorateSelected, undecorateSelected } from './page-view.js';
 
 const DOUBLE_TAP_MS = 300;
 const DOUBLE_TAP_DIST = 30;
+const TAP_SLOP = 12; // px of finger movement beyond which a press is not a tap
 
 // ctx = {
 //   stage:      container holding .pv-page views
@@ -38,6 +39,7 @@ const DOUBLE_TAP_DIST = 30;
 export function createInteraction(ctx) {
   const { stage } = ctx;
   let gesture = null;        // the active pointer gesture (one at a time)
+  let tapCandidate = null;   // touch press waiting to become a tap at RELEASE
   let selectedEl = null;     // decorated element (kept in sync with doc.selection)
   let lastTap = { t: 0, x: 0, y: 0, annoId: null };
 
@@ -128,11 +130,22 @@ export function createInteraction(ctx) {
     pageView.setPointerCapture(e.pointerId);
   }
 
+  // Was this tap the second of a double-tap? Also records it as the new "last".
+  function registerTap(annoId, x, y) {
+    const now = Date.now();
+    const isDouble = annoId && annoId === lastTap.annoId &&
+      now - lastTap.t < DOUBLE_TAP_MS &&
+      Math.hypot(x - lastTap.x, y - lastTap.y) < DOUBLE_TAP_DIST;
+    lastTap = { t: now, x, y, annoId };
+    return isDouble;
+  }
+
   function onPointerDown(e) {
-    if (gesture) return;                    // one gesture at a time
+    if (gesture || tapCandidate) return;    // one gesture at a time
     if (e.button !== undefined && e.button !== 0 && e.pointerType === 'mouse') return;
     const doc = ctx.getDoc();
     const tool = ctx.getTool();
+    const isTouch = e.pointerType !== 'mouse';
 
     const handleEl = e.target.closest?.('.pv-handle');
     const annoEl = e.target.closest?.('.pv-anno');
@@ -142,7 +155,7 @@ export function createInteraction(ctx) {
     const page = doc.pages.find((pg) => pg.id === pageId);
     if (!page) return;
 
-    // 1) Resize handle beats everything.
+    // 1) Resize handle beats everything (explicit chrome, unambiguous).
     if (handleEl && selectedEl && selectedEl.contains(handleEl)) {
       const found = findAnno(doc, selectedEl.dataset.annoId);
       if (found) {
@@ -152,41 +165,15 @@ export function createInteraction(ctx) {
       }
     }
 
-    // 2) Annotation hit → select + maybe drag (any tool: touching wins).
-    if (annoEl) {
-      const anno = page.annotations.find((a) => a.id === annoEl.dataset.annoId);
-      if (anno) {
-        e.preventDefault();                 // annotation hit: block scroll, we drag
-
-        // Delete tool armed: tapping an object removes it (founder ask — the
-        // reverse order of "select then Hapus" must also work).
-        if (tool === 'delete') {
-          ctx.onDeleteTap?.(anno.id, page.id);
-          return;
-        }
-
-        // Double-tap on text → edit (works for touch AND mouse double-click).
-        const now = Date.now();
-        const isDouble = anno.id === lastTap.annoId &&
-          now - lastTap.t < DOUBLE_TAP_MS &&
-          Math.hypot(e.clientX - lastTap.x, e.clientY - lastTap.y) < DOUBLE_TAP_DIST;
-        lastTap = { t: now, x: e.clientX, y: e.clientY, annoId: anno.id };
-
-        setSelected(annoEl, anno);
-        if (isDouble && anno.type === 'text') {
-          ctx.onEditText?.(anno.id);
-          return;
-        }
-        startDrag(e, annoEl, page, anno);
-        return;
-      }
-    }
-
-    // 3) Empty page space: tool decides.
+    // 2) An ARMED tool beats annotation hits — so Tip-Ex can cover a spot and
+    //    Teks can then write ON TOP of that cover (founder use case). Arming a
+    //    tool is explicit intent; every tool returns home after its verb.
     if (tool === 'whiteout') {
       e.preventDefault();
       startDraw(e, pageView, page);
-    } else if (tool === 'text' || tool === 'signature' || tool === 'paraf') {
+      return;
+    }
+    if (tool === 'text' || tool === 'signature' || tool === 'paraf') {
       // WHY preventDefault: onPlace may create + focus an inline editor NOW.
       // Canceling pointerdown suppresses the compatibility mousedown that
       // would otherwise fire right after and BLUR it (mouse only — touch
@@ -194,9 +181,52 @@ export function createInteraction(ctx) {
       e.preventDefault();
       const p = toPage(e, pageView);
       ctx.onPlace?.(tool, { pageId: page.id, x: p.x, y: p.y });
-    } else {
-      setSelected(null, null);              // select tool: tap empty = deselect
+      return;
     }
+
+    // 3) Annotation hit.
+    if (annoEl) {
+      const anno = page.annotations.find((a) => a.id === annoEl.dataset.annoId);
+      if (anno) {
+        if (tool === 'delete') {
+          e.preventDefault();
+          ctx.onDeleteTap?.(anno.id, page.id);
+          return;
+        }
+
+        if (!isTouch) {
+          // Mouse: select + drag immediately (no camera gesture to conflict with).
+          e.preventDefault();
+          const isDouble = registerTap(anno.id, e.clientX, e.clientY);
+          setSelected(annoEl, anno);
+          if (isDouble && anno.type === 'text') { ctx.onEditText?.(anno.id); return; }
+          startDrag(e, annoEl, page, anno);
+          return;
+        }
+
+        if (doc.selection.annotationId === anno.id) {
+          // Touch on the ALREADY-selected object: that's a deliberate grab —
+          // drag it. (decorateSelected set touch-action:none on it, so the
+          // browser won't steal the gesture for scrolling.)
+          e.preventDefault();
+          startDrag(e, annoEl, page, anno);
+          return;
+        }
+
+        // Touch on an UNSELECTED object: selection commits at RELEASE, never
+        // at press (founder's model). No preventDefault, no capture — if the
+        // finger moves, the browser takes it as CAMERA (scroll) and fires
+        // pointercancel, which clears the candidate. A clean press+release
+        // within the slop is a tap → select.
+        tapCandidate = { pointerId: e.pointerId, annoId: anno.id, annoEl, x: e.clientX, y: e.clientY };
+        return;
+      }
+    }
+
+    // 4) Empty page, Pilih tool: same release-commit rule — a tap deselects,
+    //    a drag is the camera. (Mouse deselects on press, as ever.)
+    if (!isTouch) setSelected(null, null);
+    else tapCandidate = { pointerId: e.pointerId, annoId: null, annoEl: null, x: e.clientX, y: e.clientY };
   }
 
   function onPointerMove(e) {
@@ -272,12 +302,73 @@ export function createInteraction(ctx) {
   }
 
   function onPointerEnd(e) {
+    // Release-commit for touch taps (founder's model: selection at UNPRESS).
+    // A scroll-take-over fires pointercancel → the candidate dies silently.
+    if (tapCandidate && e.pointerId === tapCandidate.pointerId) {
+      const tc = tapCandidate;
+      tapCandidate = null;
+      const isTap = e.type === 'pointerup' &&
+        Math.hypot(e.clientX - tc.x, e.clientY - tc.y) < TAP_SLOP;
+      if (!isTap) return;
+      if (tc.annoId) {
+        const doc = ctx.getDoc();
+        const found = findAnno(doc, tc.annoId);
+        if (found) {
+          const isDouble = registerTap(tc.annoId, e.clientX, e.clientY);
+          setSelected(tc.annoEl, found.anno);
+          if (isDouble && found.anno.type === 'text') ctx.onEditText?.(tc.annoId);
+        }
+      } else {
+        setSelected(null, null);
+      }
+      return;
+    }
+
     if (!gesture || e.pointerId !== gesture.pointerId) return;
     const g = gesture;
     gesture = null;
-    if (!g.moved) return;                    // taps already handled on down
+    if (!g.moved) {
+      // Touch tap on an already-selected text: second tap of a double → edit.
+      if (g.kind === 'move' && e.type === 'pointerup') {
+        const isDouble = registerTap(g.anno.id, e.clientX, e.clientY);
+        if (isDouble && g.anno.type === 'text') ctx.onEditText?.(g.anno.id);
+      }
+      return;
+    }
     const kind = g.kind === 'draw' ? 'draw' : g.kind;
     ctx.onChange?.(kind, { annotation: g.anno });
+  }
+
+  // Abort the in-flight gesture and put the object back — called by the app
+  // when a second finger lands (pinch): a finger that happened to start on a
+  // selected object must not fling it across the page.
+  function cancelGesture() {
+    tapCandidate = null;
+    if (!gesture) return;
+    const g = gesture;
+    gesture = null;
+    if (!g.moved) return;
+    const doc = ctx.getDoc();
+    if (g.kind === 'move') {
+      const a = moveAnnotation(doc, g.anno.id,
+        g.baseX - (g.anno.x || 0), g.baseY - (g.anno.y || 0));
+      if (a) { g.annoEl.style.left = a.x + 'px'; g.annoEl.style.top = a.y + 'px'; }
+    } else if (g.kind === 'resize') {
+      if (g.anno.type === 'text') {
+        updateAnnotation(doc, g.anno.id, { fontSize: g.baseFontSize });
+        g.annoEl.style.fontSize = g.baseFontSize + 'px';
+      } else {
+        const a = resizeAnnotation(doc, g.anno.id, { width: g.baseW, height: g.baseH });
+        if (a) {
+          g.annoEl.style.width = a.width + 'px';
+          if (g.anno.type === 'whiteout') g.annoEl.style.height = a.height + 'px';
+          const img = g.annoEl.querySelector('img');
+          if (img) img.style.width = a.width + 'px';
+        }
+      }
+    }
+    // A draw in progress is left as-is (undo removes it) — restoring a half-
+    // drawn whiteout mid-pinch would surprise more than it helps.
   }
 
   stage.addEventListener('pointerdown', onPointerDown);
@@ -292,5 +383,5 @@ export function createInteraction(ctx) {
     stage.removeEventListener('pointercancel', onPointerEnd);
   }
 
-  return { destroy, setSelected, refreshSelection };
+  return { destroy, setSelected, refreshSelection, cancelGesture };
 }

--- a/js/render/page-view.js
+++ b/js/render/page-view.js
@@ -119,12 +119,10 @@ export function renderAnnotationEl(anno) {
   el.className = 'pv-anno pv-anno-' + anno.type;
   el.dataset.annoId = anno.id;
   el.style.cssText = `position:absolute;left:${anno.x || 0}px;top:${anno.y || 0}px`;
-  // WHY: on touch, preventDefault in pointerdown does NOT stop the browser
-  // hijacking the gesture for scroll — only touch-action does. Without this,
-  // dragging an annotation on a phone scrolls the page instead (old bug class).
-  if (anno.type === 'text' || anno.type === 'whiteout' || anno.type === 'signature') {
-    el.style.touchAction = 'none';
-  }
+  // NOTE: no touch-action here on purpose. An UNSELECTED annotation must let
+  // the browser take the gesture as camera (scroll) — selection commits at
+  // release (interaction.js tap-candidate). decorateSelected() sets
+  // touch-action:none so the SELECTED object drags instead of scrolling.
 
   if (anno.type === 'text') {
     el.textContent = anno.text || '';
@@ -194,6 +192,9 @@ export function decorateSelected(el, anno) {
   el.classList.add('pv-selected');
   el.style.outline = '1.5px solid #4f8ef7';
   el.style.outlineOffset = '2px';
+  // Selected = grabbable: the browser must NOT take a drag on it as scroll.
+  // (touch-action must be set BEFORE the gesture starts — this is that moment.)
+  el.style.touchAction = 'none';
   // Text is resizable too: dragging its handle scales fontSize (founder ask).
   const resizable = anno.type === 'whiteout' || anno.type === 'signature' || anno.type === 'text';
   if (!resizable) return;
@@ -216,6 +217,7 @@ export function undecorateSelected(el) {
   el.style.outline = '';
   el.style.outlineOffset = '';
   el.style.zIndex = '1';
+  el.style.touchAction = ''; // back to camera-first (see decorateSelected)
   el.querySelector('.pv-handle')?.remove();
 }
 

--- a/js/v2/app.js
+++ b/js/v2/app.js
@@ -108,6 +108,9 @@ let pinchRaf = false;
 scrollEl.addEventListener('touchstart', (e) => {
   if (e.touches.length === 2) {
     e.preventDefault(); // ours, not the browser's
+    // A finger that landed on a selected object may have started a drag —
+    // abort it and put the object back. Pinching must never fling things.
+    interaction.cancelGesture();
     const [a, b] = e.touches;
     pinch = { d0: Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY) || 1, z0: zoom };
   }
@@ -264,13 +267,14 @@ document.getElementById('btn-delete-anno').addEventListener('click', () => {
 });
 
 // ---- Tip-Ex color matching -------------------------------------------------------
-// Zero-UI "colour matching tool": when a whiteout stroke finishes, sample the
-// page raster in a thin ring OUTSIDE the drawn rect and take the per-channel
-// median — on a cream/gray scan the cover-up matches the paper instead of
-// glowing white. Plain white documents stay white (median of white is white).
-async function matchWhiteoutColor(anno, pageId) {
+// Zero-UI "colour matching tool", decided AT STROKE START (founder: the user
+// should see the matched color WHILE drawing, not a white→color jump at the
+// end). Sample two rings around the press point from the page raster and take
+// the per-channel median — thin ink strokes lose the vote to the surrounding
+// paper, so covering text on a cream scan yields cream. White stays white.
+async function matchWhiteoutColor(anno, pageId, ox, oy) {
   const page = doc.pages.find((p) => p.id === pageId);
-  if (!page?.raster) return; // page released mid-gesture — keep default white
+  if (!page?.raster) return; // page not rasterized — keep default white
   try {
     const img = new Image();
     await new Promise((res, rej) => { img.onload = res; img.onerror = rej; img.src = page.raster.dataUrl; });
@@ -281,25 +285,27 @@ async function matchWhiteoutColor(anno, pageId) {
     const rotated = (page.rotation || 0) % 180 !== 0;
     const frameW = rotated ? page.height : page.width;
     const s = img.width / frameW;              // raster px per page point
-    const ring = 6 * s;                        // sample 6pt outside the rect
     const samples = { r: [], g: [], b: [] };
     const take = (x, y) => {
       if (x < 0 || y < 0 || x >= c.width || y >= c.height) return;
       const px = cx.getImageData(Math.round(x), Math.round(y), 1, 1).data;
       samples.r.push(px[0]); samples.g.push(px[1]); samples.b.push(px[2]);
     };
-    for (let i = 0; i <= 8; i += 1) {
-      const fx = (anno.x + (anno.width * i) / 8) * s;
-      const fy = (anno.y + (anno.height * i) / 8) * s;
-      take(fx, anno.y * s - ring); take(fx, (anno.y + anno.height) * s + ring); // above + below
-      take(anno.x * s - ring, fy); take((anno.x + anno.width) * s + ring, fy);  // left + right
+    for (const radius of [6 * s, 12 * s]) {
+      for (let i = 0; i < 10; i += 1) {
+        const ang = (Math.PI * 2 * i) / 10;
+        take(ox * s + radius * Math.cos(ang), oy * s + radius * Math.sin(ang));
+      }
     }
     if (samples.r.length < 8) return;
     const med = (arr) => arr.sort((a, b) => a - b)[Math.floor(arr.length / 2)];
     const hex = (n) => n.toString(16).padStart(2, '0');
     const color = `#${hex(med(samples.r))}${hex(med(samples.g))}${hex(med(samples.b))}`;
     updateAnnotation(doc, anno.id, { color });
-    syncPage(pageId);
+    // Mid-gesture: update the LIVE element directly — rebuilding the overlay
+    // here would destroy the element holding the pointer capture.
+    const el = stage.querySelector(`[data-anno-id="${anno.id}"]`);
+    if (el) el.style.background = color;
   } catch { /* sampling is best-effort; white stays */ }
 }
 
@@ -310,14 +316,10 @@ const interaction = createInteraction({
   getZoom: () => zoom,
   getTool: () => tool,
   history,
-  onChange: (kind, payload) => {
-    if (kind === 'draw' && payload?.annotation) {
-      // Tip-Ex stroke finished: color-match against the paper, then return
-      // home to Pilih (founder: whiteout should NOT stay sticky).
-      const pg = doc.pages.find((p) => p.annotations.some((a) => a.id === payload.annotation.id));
-      if (pg) matchWhiteoutColor(payload.annotation, pg.id);
-      setTool('select');
-    }
+  onChange: (kind) => {
+    // Tip-Ex stroke finished (color was already matched at stroke START):
+    // return home to Pilih (founder: whiteout should NOT stay sticky).
+    if (kind === 'draw') setTool('select');
     refreshChrome();
   },
   onDeleteTap: (annoId, pageId) => {
@@ -349,7 +351,8 @@ const interaction = createInteraction({
       x, y, width: 8, height: 8,
     }));
     syncPage(pageId);
-    return anno; // onChange('draw') color-matches + returns to Pilih at stroke end
+    matchWhiteoutColor(anno, pageId, x, y); // async; colors the rect while drawing
+    return anno;
   },
   onEditText: (annoId) => {
     for (const page of doc.pages) {

--- a/tests/mobile/camera-model.spec.js
+++ b/tests/mobile/camera-model.spec.js
@@ -1,0 +1,115 @@
+/*
+ * The camera-first touch model (founder's design, Jul 2 round 3):
+ *   - movement is ALWAYS camera unless the object was already selected
+ *   - selection commits at RELEASE (press+move ≠ tap → nothing selected)
+ *   - armed placement tools beat object hits (write ON TOP of a tip-ex)
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(__dirname, '..', 'fixtures', 'sample-2pages.pdf');
+
+async function openWithText(page) {
+  await page.goto('/editor-v2.html');
+  await page.setInputFiles('#file-input', FIXTURE);
+  await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+  await page.tap('[data-tool="text"]');
+  await page.tap('.pv-page >> nth=0', { position: { x: 120, y: 150 } });
+  await page.keyboard.type('objek uji');
+  await page.keyboard.press('Enter');
+  // Deselect (tap empty space) so tests start from the unselected state.
+  await page.tap('.pv-page >> nth=0', { position: { x: 300, y: 500 } });
+  expect(await page.evaluate(() => window.v2.getDoc().selection.annotationId)).toBe(null);
+}
+
+// Touch press + move + release across an element (pointerType touch).
+async function touchDragOn(page, selector, dx, dy) {
+  await page.evaluate(async ({ selector, dx, dy }) => {
+    const el = document.querySelector(selector);
+    const r = el.getBoundingClientRect();
+    const cx = r.left + r.width / 2;
+    const cy = r.top + r.height / 2;
+    const fire = (type, x, y) => el.dispatchEvent(new PointerEvent(type, {
+      pointerId: 31, pointerType: 'touch', isPrimary: true,
+      clientX: x, clientY: y, bubbles: true, cancelable: true,
+    }));
+    fire('pointerdown', cx, cy);
+    for (let i = 1; i <= 4; i += 1) {
+      fire('pointermove', cx + (dx * i) / 4, cy + (dy * i) / 4);
+      await new Promise((res) => requestAnimationFrame(res));
+    }
+    fire('pointerup', cx + dx, cy + dy);
+  }, { selector, dx, dy });
+}
+
+test.describe('camera-first touch model', () => {
+  test('press+move on an UNSELECTED object: no selection, no movement (camera)', async ({ page }) => {
+    await openWithText(page);
+    const before = await page.evaluate(() => {
+      const a = window.v2.getDoc().pages[0].annotations[0];
+      return { x: a.x, y: a.y };
+    });
+    await touchDragOn(page, '.pv-anno-text', 70, 50);
+    const after = await page.evaluate(() => {
+      const d = window.v2.getDoc();
+      const a = d.pages[0].annotations[0];
+      return { x: a.x, y: a.y, sel: d.selection.annotationId };
+    });
+    expect(after.x).toBe(before.x);   // object did not move
+    expect(after.y).toBe(before.y);
+    expect(after.sel).toBe(null);      // and was not selected (press+move ≠ tap)
+  });
+
+  test('clean tap on an unselected object selects it AT RELEASE', async ({ page }) => {
+    await openWithText(page);
+    await page.tap('.pv-anno-text');
+    const sel = await page.evaluate(() => window.v2.getDoc().selection.annotationId);
+    expect(sel).toBeTruthy();
+    await expect(page.locator('.pv-anno-text.pv-selected')).toHaveCount(1);
+  });
+
+  test('drag on the ALREADY-selected object moves it (deliberate grab)', async ({ page }) => {
+    await openWithText(page);
+    await page.tap('.pv-anno-text'); // select first
+    const before = await page.evaluate(() => window.v2.getDoc().pages[0].annotations[0].x);
+    await touchDragOn(page, '.pv-anno-text', 70, 40);
+    const after = await page.evaluate(() => window.v2.getDoc().pages[0].annotations[0].x);
+    expect(after).toBeGreaterThan(before);
+  });
+
+  test('armed Teks writes ON TOP of an existing whiteout', async ({ page }) => {
+    await page.goto('/editor-v2.html');
+    await page.setInputFiles('#file-input', FIXTURE);
+    await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+
+    // Draw a whiteout.
+    await page.tap('[data-tool="whiteout"]');
+    const pg = await page.locator('.pv-page >> nth=0').boundingBox();
+    await page.evaluate(async ({ x1, y1, x2, y2 }) => {
+      const el = document.elementFromPoint(x1, y1);
+      const fire = (type, x, y) => el.dispatchEvent(new PointerEvent(type, {
+        pointerId: 32, pointerType: 'touch', isPrimary: true,
+        clientX: x, clientY: y, bubbles: true, cancelable: true,
+      }));
+      fire('pointerdown', x1, y1);
+      for (let i = 1; i <= 4; i += 1) {
+        fire('pointermove', x1 + ((x2 - x1) * i) / 4, y1 + ((y2 - y1) * i) / 4);
+        await new Promise((r) => requestAnimationFrame(r));
+      }
+      fire('pointerup', x2, y2);
+    }, { x1: pg.x + 60, y1: pg.y + 140, x2: pg.x + 240, y2: pg.y + 190 });
+    expect(await page.evaluate(() => window.v2.getDoc().pages[0].annotations.length)).toBe(1);
+
+    // Arm Teks and tap INSIDE the whiteout: text places instead of selecting it.
+    await page.tap('[data-tool="text"]');
+    await page.tap('.pv-page >> nth=0', { position: { x: 150 / 1, y: 165 } });
+    await page.keyboard.type('di atas tip-ex');
+    await page.keyboard.press('Enter');
+
+    const annos = await page.evaluate(() => window.v2.getDoc().pages[0].annotations.map((a) => a.type));
+    expect(annos).toEqual(['whiteout', 'text']); // text AFTER whiteout → renders above
+    await expect(page.locator('.pv-anno-text')).toHaveText('di atas tip-ex');
+  });
+});

--- a/tests/mobile/editor-v2.spec.js
+++ b/tests/mobile/editor-v2.spec.js
@@ -90,7 +90,11 @@ test.describe('editor v2 — mobile', () => {
       return { x: a.x, y: a.y };
     });
 
-    // Touch-drag via dispatched pointer events (the unified input path).
+    // Camera-first touch model: tap SELECTS (commits at release)…
+    await page.tap('.pv-anno-text');
+    expect(await page.evaluate(() => window.v2.getDoc().selection.annotationId)).toBeTruthy();
+
+    // …then a drag on the SELECTED object moves it.
     const box = await anno.boundingBox();
     const cx = box.x + box.width / 2;
     const cy = box.y + box.height / 2;


### PR DESCRIPTION
Founder's round-3 feedback: selection commits at release, movement is always camera, pinch cancels in-flight drags, Tip-Ex colors from stroke start, placement tools beat object hits. 116/116 + 21/21 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSTkjTsoHVmrYm84C7MhLW