### PR TITLE
fix(v2): drag hardening — auto-scroll, stable insertion, row collapse

### DIFF
--- a/editor-v2.html
+++ b/editor-v2.html
@@ -216,8 +216,15 @@
     .pm-head h2 { flex: 0 0 auto; }
     .pm-hint { flex: 1; font-size: 10.5px; color: var(--muted); line-height: 1.3; }
     .pm-grid {
-      flex: 1; overflow-y: auto; overscroll-behavior: contain;
+      position: relative; /* tiles' offsetParent — the drag math depends on it */
+      flex: 1; min-height: 0; /* flex children never shrink below content without this */
+      overflow-y: auto; overscroll-behavior: contain;
       display: grid; grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+      /* WHY: with a definite container height, auto rows + aspect-ratio tiles
+         hit a cyclic-sizing behavior where rows shrink to exactly fill the
+         container (tiles overflow their rows; grid never scrolls). max-content
+         forces rows to follow the tiles. */
+      grid-auto-rows: max-content; align-content: start;
       gap: 10px; padding: 4px 2px 8px;
     }
     .pm-tile {
@@ -235,7 +242,7 @@
       border-style: dashed; border-color: var(--accent);
       background: rgba(79,142,247,.06);
     }
-    .pm-thumb { width: 100%; background-size: cover; background-position: top center; background-color: #fafafa; }
+    .pm-thumb { position: absolute; inset: 0; background-size: cover; background-position: top center; background-color: #fafafa; }
     .pm-num {
       position: absolute; left: 4px; bottom: 4px;
       background: rgba(26,29,33,.72); color: #fff; font-size: 10px; font-weight: 600;

--- a/js/v2/app.js
+++ b/js/v2/app.js
@@ -599,7 +599,19 @@ document.addEventListener('keydown', (e) => {
 const SIZE_WARN = 20 * 1024 * 1024;
 const SIZE_BLOCK = 100 * 1024 * 1024;
 
+let loadingFiles = false; // re-entry guard: double-taps and rapid picks interleave imports
+
 async function loadFiles(files) {
+  if (loadingFiles) { toast('Sabar ya, file sebelumnya masih dimuat…'); return; }
+  loadingFiles = true;
+  try {
+    await loadFilesInner(files);
+  } finally {
+    loadingFiles = false;
+  }
+}
+
+async function loadFilesInner(files) {
   const isPdf = (f) => f.type === 'application/pdf' || /\.pdf$/i.test(f.name);
   const isImg = (f) => f.type.startsWith('image/');
   // In picker order: PDFs append their pages, images become one page each.

--- a/js/v2/page-manager.js
+++ b/js/v2/page-manager.js
@@ -89,10 +89,14 @@ export function createPageManager(deps) {
 
     const rotated = (page.rotation || 0) % 180 !== 0;
     const ratio = rotated ? page.width / page.height : page.height / page.width;
+    // The TILE carries the aspect ratio (deterministic grid row sizing); the
+    // thumb just fills it. A width-dependent child height (aspect-ratio on the
+    // thumb) hit a grid auto-row cyclic-sizing quirk: rows collapsed under
+    // multi-row layouts while single rows measured fine.
+    tile.style.aspectRatio = String(1 / ratio);
 
     const im = document.createElement('div');
     im.className = 'pm-thumb';
-    im.style.aspectRatio = String(1 / ratio);
     const cached = thumbs.get(page.id);
     if (cached) im.style.backgroundImage = `url(${cached})`;
     else queueThumb(page, im);
@@ -159,10 +163,16 @@ export function createPageManager(deps) {
     }
   }
 
+  // Long-press on a tile must never pop the browser context menu mid-drag.
+  grid.addEventListener('contextmenu', (e) => e.preventDefault());
+
+  const SCROLL_EDGE = 56;   // px from the grid's top/bottom that auto-scrolls
+  const SCROLL_MAX = 14;    // px per frame at the deepest edge
+
   function wireTile(tile, page) {
     let pressTimer = null;
     let start = null;
-    let drag = null; // { placeholder, rect, lastX, lastY, raf }
+    let drag = null; // { placeholder, rect, lastX, lastY, slots, pIndex }
 
     tile.addEventListener('pointerdown', (e) => {
       if (e.target.closest('.pm-add')) return;
@@ -173,6 +183,19 @@ export function createPageManager(deps) {
         pressTimer = setTimeout(() => { armDrag(e); }, LONG_PRESS_MS); // touch: long-press
       }
     });
+
+    // Slot geometry cache — offsetLeft/Top are LAYOUT coordinates: immune to
+    // both in-flight FLIP transforms and grid scrolling. This is what makes
+    // the insertion decision stable (no arguing with our own animation) and
+    // auto-scroll free (content coords don't move when the grid scrolls).
+    function recacheSlots() {
+      const kids = [...grid.children].filter((c) =>
+        c !== tile && c.classList.contains('pm-tile') && !c.classList.contains('pm-add'));
+      drag.pIndex = kids.indexOf(drag.placeholder);
+      drag.slots = kids
+        .filter((c) => c !== drag.placeholder)
+        .map((el) => ({ el, left: el.offsetLeft, top: el.offsetTop, w: el.offsetWidth, h: el.offsetHeight }));
+    }
 
     function armDrag(e) {
       const rect = tile.getBoundingClientRect();
@@ -188,12 +211,50 @@ export function createPageManager(deps) {
       tile.style.top = rect.top + 'px';
       tile.style.width = rect.width + 'px';
       tile.style.zIndex = '50';
-      tile.style.pointerEvents = 'none'; // elementFromPoint must see through it
+      tile.style.pointerEvents = 'none';
 
-      drag = { placeholder, rect, lastX: e.clientX ?? start.x, lastY: e.clientY ?? start.y, raf: false };
+      drag = { placeholder, rect, lastX: e.clientX ?? start.x, lastY: e.clientY ?? start.y };
+      recacheSlots();
       // The pointer may be gone by the time the long-press timer fires.
       try { tile.setPointerCapture(e.pointerId ?? start.id); } catch { /* keep dragging uncaptured */ }
       if (navigator.vibrate) navigator.vibrate(10);
+      requestAnimationFrame(dragLoop);
+    }
+
+    // One continuous loop per drag (not per pointermove): the ghost follows the
+    // finger, the grid auto-scrolls near its edges — including while the finger
+    // rests there — and the insertion index is re-derived from cached layout.
+    function dragLoop() {
+      if (!drag) return;
+      tile.style.transform =
+        `translate(${drag.lastX - start.x}px, ${drag.lastY - start.y}px) scale(1.04)`;
+
+      // Auto-scroll: proportional to how deep the finger is in the edge zone.
+      const gr = grid.getBoundingClientRect();
+      if (grid.scrollHeight > grid.clientHeight) {
+        if (drag.lastY < gr.top + SCROLL_EDGE) {
+          grid.scrollTop -= SCROLL_MAX * ((gr.top + SCROLL_EDGE - drag.lastY) / SCROLL_EDGE);
+        } else if (drag.lastY > gr.bottom - SCROLL_EDGE) {
+          grid.scrollTop += SCROLL_MAX * ((drag.lastY - (gr.bottom - SCROLL_EDGE)) / SCROLL_EDGE);
+        }
+      }
+
+      // Insertion index from CONTENT coordinates (scroll- and animation-proof):
+      // a slot counts as "before the finger" if its row is fully above, or it's
+      // on the finger's row with its center to the left.
+      const px = drag.lastX - gr.left + grid.scrollLeft;
+      const py = drag.lastY - gr.top + grid.scrollTop;
+      let D = 0;
+      for (const s of drag.slots) {
+        if (s.top + s.h <= py) D += 1;
+        else if (py >= s.top && px > s.left + s.w / 2) D += 1;
+      }
+      if (D !== drag.pIndex) {
+        const target = drag.slots[D]?.el ?? grid.querySelector('.pm-add');
+        flipTiles(() => grid.insertBefore(drag.placeholder, target));
+        recacheSlots(); // layout changed → new truth
+      }
+      requestAnimationFrame(dragLoop);
     }
 
     tile.addEventListener('pointermove', (e) => {
@@ -207,40 +268,22 @@ export function createPageManager(deps) {
       e.preventDefault();
       drag.lastX = e.clientX;
       drag.lastY = e.clientY;
-      if (drag.raf) return;
-      drag.raf = true;
-      requestAnimationFrame(() => {
-        if (!drag) return;
-        drag.raf = false;
-        // The page rides the finger.
-        tile.style.transform =
-          `translate(${drag.lastX - start.x}px, ${drag.lastY - start.y}px) scale(1.04)`;
-        // Crossing a neighbor opens its slot: placeholder moves, tiles glide.
-        const over = document.elementFromPoint(drag.lastX, drag.lastY)
-          ?.closest('.pm-tile:not(.pm-add):not(.pm-placeholder)');
-        if (over) {
-          const r = over.getBoundingClientRect();
-          const after = drag.lastX > r.left + r.width / 2; // grid flows left→right
-          const target = after ? over.nextSibling : over;
-          if (target !== drag.placeholder) {
-            flipTiles(() => grid.insertBefore(drag.placeholder, target));
-          }
-        }
-      });
     });
 
     const end = (e) => {
       clearTimeout(pressTimer);
       if (drag) {
         const d = drag;
-        drag = null;
-        // Settle the page into the open slot (fixed → slot rect)…
-        const slotRect = d.placeholder.getBoundingClientRect();
+        drag = null; // stops the loop
+        // Settle target from LAYOUT coords (a mid-glide placeholder's gBCR lies).
+        const gr = grid.getBoundingClientRect();
+        const slotLeft = gr.left + d.placeholder.offsetLeft - grid.scrollLeft;
+        const slotTop = gr.top + d.placeholder.offsetTop - grid.scrollTop;
         let settled = false;
         const settle = () => {
           if (settled) return;
           settled = true;
-          // …then commit: the model index = placeholder's position in the grid.
+          // Commit: the model index = placeholder's position in the grid.
           const tiles = [...grid.querySelectorAll('.pm-tile:not(.pm-add):not(.pm-drag-ghost)')];
           const toIndex = tiles.indexOf(d.placeholder);
           const doc = deps.getDoc();
@@ -255,7 +298,7 @@ export function createPageManager(deps) {
         if (REDUCED_MOTION) { settle(); return; }
         tile.style.transition = 'transform .18s cubic-bezier(.2,.8,.2,1)';
         tile.style.transform =
-          `translate(${slotRect.left - d.rect.left}px, ${slotRect.top - d.rect.top}px)`;
+          `translate(${slotLeft - d.rect.left}px, ${slotTop - d.rect.top}px)`;
         tile.addEventListener('transitionend', settle, { once: true });
         setTimeout(settle, 260); // safety: transitionend can be swallowed
       } else if (start && pressTimer !== null && e.type === 'pointerup') {

--- a/tests/mobile/page-manager.spec.js
+++ b/tests/mobile/page-manager.spec.js
@@ -139,6 +139,50 @@ test.describe('page manager — mobile', () => {
     expect(state.undo).toBe(0);
   });
 
+  test('drag near the grid edge AUTO-SCROLLS a big document (30+ page reality)', async ({ page }) => {
+    await page.goto('/editor-v2.html');
+    // 16 pages: fixture + 7 merges — enough to overflow the sheet's grid.
+    // (Serialized: loadFiles guards against concurrent picks by design.)
+    await page.setInputFiles('#file-input', FIXTURE);
+    await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+    for (let i = 0; i < 7; i += 1) {
+      await page.setInputFiles('#file-input', FIXTURE);
+      await expect(page.locator('.pv-page')).toHaveCount(2 * (i + 2));
+    }
+    await page.tap('#btn-pages');
+    await expect(page.locator('.pm-tile:not(.pm-add)')).toHaveCount(16);
+
+    const scrollable = await page.evaluate(() => {
+      const g = document.getElementById('pm-grid');
+      return g.scrollHeight > g.clientHeight;
+    });
+    expect(scrollable).toBe(true);
+
+    // Arm a drag on the first tile, then HOLD the pointer in the bottom edge
+    // zone — the grid must keep scrolling while the finger rests there.
+    const first = await page.locator('.pm-tile >> nth=0').elementHandle();
+    const a = await first.boundingBox();
+    const gr = await page.locator('#pm-grid').boundingBox();
+    await first.dispatchEvent('pointerdown', {
+      pointerId: 9, pointerType: 'touch', clientX: a.x + 40, clientY: a.y + 40, bubbles: true, isPrimary: true,
+    });
+    await page.waitForTimeout(380); // long-press arms
+    await first.dispatchEvent('pointermove', {
+      pointerId: 9, pointerType: 'touch',
+      clientX: gr.x + gr.width / 2, clientY: gr.y + gr.height - 12, bubbles: true,
+    });
+    await page.waitForTimeout(500); // the drag LOOP scrolls even with no new moves
+    const scrolled = await page.evaluate(() => document.getElementById('pm-grid').scrollTop);
+    expect(scrolled).toBeGreaterThan(50);
+
+    await first.dispatchEvent('pointerup', {
+      pointerId: 9, pointerType: 'touch',
+      clientX: gr.x + gr.width / 2, clientY: gr.y + gr.height - 12, bubbles: true,
+    });
+    // Drop somewhere valid — the doc must still have 16 coherent pages.
+    await expect.poll(async () => page.evaluate(() => window.v2.getDoc().pages.length)).toBe(16);
+  });
+
   test('extract downloads the selected pages as a PDF', async ({ page }) => {
     await openSheet(page);
     await page.tap('.pm-tile >> nth=0');


### PR DESCRIPTION
Big-doc drag auto-scroll + flicker-free insertion decisions + a real grid-sizing bug. 118/118 + 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSTkjTsoHVmrYm84C7MhLW