### PR TITLE
fix(v2): compress + re-pick pages left the CTA reaching for missing bytes

### DIFF
--- a/js/v2/download-sheet.js
+++ b/js/v2/download-sheet.js
@@ -69,6 +69,12 @@ export function createDownloadSheet(deps) {
     } finally {
       if (seq === state.seq) { state.building = false; render(); }
     }
+    // Rebuilding invalidated any compressed bytes. If Compress is STILL the
+    // selected size, re-run it now — otherwise the CTA would reach for bytes
+    // that no longer exist (founder-caught: compress → re-pick pages → stuck).
+    if (seq === state.seq && state.base && state.format === 'pdf' && state.size === 'kompres') {
+      buildCompressed();
+    }
   }
 
   async function buildCompressed() {
@@ -218,8 +224,13 @@ export function createDownloadSheet(deps) {
     render();
     const seq = state.seq;
     try {
+      // Belt-and-braces: if Compress is selected but its bytes are missing and
+      // nothing is computing them (any invalidation path), start it here.
+      if (state.format === 'pdf' && state.size === 'kompres' && !state.compressed && !state.compressing) {
+        buildCompressed();
+      }
       // Any in-flight build: the tap means "when it's ready".
-      while ((state.building || (state.format === 'pdf' && state.size === 'kompres' && state.compressing)) && seq === state.seq) {
+      while ((state.building || (state.format === 'pdf' && state.size === 'kompres' && (state.compressing || !state.compressed))) && seq === state.seq) {
         await new Promise((r) => setTimeout(r, 120));
       }
       if (seq !== state.seq) return;

--- a/tests/mobile/download-sheet.spec.js
+++ b/tests/mobile/download-sheet.spec.js
@@ -82,6 +82,25 @@ test.describe('unduh sheet — mobile', () => {
     expect(download.suggestedFilename()).toMatch(/hal-1\.jpg$/);
   });
 
+  test('compress then RE-PICK pages: compression re-runs, download still works', async ({ page }) => {
+    await openSheet(page);
+    // 1. Compress first…
+    await page.tap('#ds-size [data-v="kompres"]');
+    await expect(page.locator('#ds-size [data-v="kompres"]')).toContainText(/hemat|optimal/, { timeout: 20000 });
+    // 2. …then change the page selection (this invalidates the built bytes).
+    await page.tap('#ds-pages [data-v="some"]');
+    await page.tap('.pm-tile >> nth=0');
+    await page.tap('#pm-pick-ok');
+    await expect(page.locator('#ds-cta-main')).toContainText('(1 hal.)');
+    // 3. Compression must have re-run for the new subset…
+    await expect(page.locator('#ds-size [data-v="kompres"]')).toContainText(/hemat|optimal/, { timeout: 20000 });
+    // 4. …and the download must not be stuck.
+    const dl = page.waitForEvent('download');
+    await page.tap('#ds-cta');
+    const download = await dl;
+    expect(download.suggestedFilename()).toMatch(/\.pdf$/);
+  });
+
   test('cancelling the picker keeps Semua', async ({ page }) => {
     await openSheet(page);
     await page.tap('#ds-pages [data-v="some"]');


### PR DESCRIPTION
Founder-caught: select Compress, then change the page selection — the
rebuild correctly invalidated the compressed bytes but nothing re-ran the
compression, so the download failed. Two layers:
1. buildBase() re-triggers buildCompressed() when Compress is still the
   selected size after any rebuild.
2. doExport() self-heals: missing compressed bytes with nothing computing
   them → start compression and wait (covers all invalidation paths).
Compress failure still falls back to Asli (no infinite wait).

Regression test: compress → pick 1 page → savings recompute → download OK.
132/132 green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
