### PR TITLE
feat(v2): swap-prep — analytics parity, Android back button, desktop ergonomics

### DIFF
--- a/editor-v2.html
+++ b/editor-v2.html
@@ -5,6 +5,19 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <meta name="robots" content="noindex, nofollow">
   <title>PDFLokal — Editor v2 (beta)</title>
+
+  <!-- Google tag (gtag.js) — same allowlist discipline as index.html -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17538923405"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    if (location.hostname === 'pdflokal.id' || location.hostname === 'www.pdflokal.id') {
+      gtag('config', 'AW-17538923405');
+      gtag('config', 'G-0XJY0WLCZ1');
+    }
+  </script>
+  <script defer src="/_vercel/insights/script.js"></script>
   <!--
     Editor v2 — the clean rebuild on js/core + js/render (decision: Jul 2 2026,
     decisions.md "clean rebuild & swap"). Lives BESIDE the live app: unlinked,
@@ -362,6 +375,23 @@
     .pm-pickbar .note { flex: 1; font-size: 12px; color: var(--muted); }
     .pm-pickbar .btn-primary { flex: 0 0 auto; }
 
+    /* ---- desktop ergonomics (≥900px): same components, roomier arrangement ---- */
+    @media (min-width: 900px) {
+      dialog.bottomsheet { align-items: center; padding: 16px; }
+      .ds-body { border-radius: 16px; }
+      .tool { min-width: 66px; }
+      .tool:hover { background: rgba(79,142,247,.07); }
+      .icon-btn:hover:not(:disabled) { color: var(--ink); }
+      #btn-file:hover:not(:disabled) { color: var(--ink); }
+      #file-menu button:hover { background: var(--bg); }
+      .ds-seg button:hover:not(.on) { border-color: rgba(79,142,247,.4); }
+      .pm-tile:hover:not(.pm-placeholder) { border-color: rgba(79,142,247,.45); }
+      .pm-bulk button:hover, .pm-pickbar button:hover { border-color: var(--accent); color: var(--accent); }
+      #v2-stage { padding-bottom: 40px; }
+      .pv-anno { cursor: grab; }
+      .pv-anno-watermark, .pv-anno-pageNumber { cursor: default; }
+    }
+
     #toast {
       position: fixed; left: 50%; transform: translateX(-50%); bottom: 130px; z-index: 40;
       background: rgba(26,29,33,.9); color: #fff; font-size: 13px;
@@ -540,6 +570,31 @@
   <script src="js/vendor/fontkit.umd.min.js"></script>
   <script src="js/vendor/signature_pad.umd.min.js"></script>
   <script src="js/vendor/fflate.min.js"></script>
+  <script>window.APP_VERSION = 'v2-beta';</script>
+  <script src="js/vendor/sentry.min.js"></script>
+  <script>
+    // Same config as index.html (tunnel beats ad blockers; prod-only) with ONE
+    // v2 adaptation: pages are <img> now, not <canvas> — the replay block list
+    // must cover .pv-bg (page images) and signature images or replays would
+    // record user documents. Privacy first, always.
+    if (window.Sentry) Sentry.init({
+      dsn: 'https://0913dcff45e0045c49dfe1b14f34c65f@o4511472486580224.ingest.us.sentry.io/4511472494313472',
+      tunnel: '/api/sentry-tunnel',
+      enabled: location.hostname === 'pdflokal.id' || location.hostname === 'www.pdflokal.id',
+      release: window.APP_VERSION,
+      sampleRate: 1.0,
+      replaysSessionSampleRate: 0.10,
+      replaysOnErrorSampleRate: 1.0,
+      integrations: [
+        Sentry.replayIntegration({
+          maskAllText: true,
+          maskAllInputs: true,
+          blockAllMedia: true,
+          block: ['canvas', '.pv-bg', '.pv-anno img', '.pm-thumb', '#sig-preview'],
+        }),
+      ],
+    });
+  </script>
   <script type="module" src="js/v2/app.js"></script>
 </body>
 </html>

--- a/js/v2/app.js
+++ b/js/v2/app.js
@@ -30,6 +30,7 @@ import { createFormatBar } from './format-bar.js';
 import { createPageManager } from './page-manager.js';
 import { createSignatureModal } from './signature-modal.js';
 import { createDownloadSheet } from './download-sheet.js';
+import { track } from '../lib/analytics.js';
 
 window.pdfjsLib.GlobalWorkerOptions.workerSrc = '/js/vendor/pdf.worker.min.js';
 
@@ -321,7 +322,7 @@ const interaction = createInteraction({
   onChange: (kind) => {
     // Tip-Ex stroke finished (color was already matched at stroke START):
     // return home to Pilih (founder: whiteout should NOT stay sticky).
-    if (kind === 'draw') setTool('select');
+    if (kind === 'draw') { track('editor_action', { action: 'whiteout' }); setTool('select'); }
     refreshChrome();
   },
   onDeleteTap: (annoId, pageId) => {
@@ -342,6 +343,7 @@ const interaction = createInteraction({
         image: storedSignature.dataUrl, subtype: storedSignature.subtype,
         x: Math.max(0, x - w / 2), y: Math.max(0, y - h / 2), width: w, height: h,
       }));
+      track('editor_action', { action: storedSignature.subtype === 'paraf' ? 'paraf' : 'signature' });
       selectAnnotation(doc, created.id); // selected → "Semua Hal." is one tap away
       syncPage(pageId);
       setTool('select'); // tools are verbs; back home
@@ -433,6 +435,7 @@ function openTextEditor({ pageId, x, y, anno }) {
       if (text && text !== anno.text) {
         record(history, doc);
         updateAnnotation(doc, anno.id, { text });
+        track('editor_action', { action: 'text_inline' });
       } else if (!text) {
         record(history, doc);
         removeAnnotation(doc, anno.id);
@@ -448,6 +451,7 @@ function openTextEditor({ pageId, x, y, anno }) {
       // Keep the fresh text SELECTED: the user sees it's an object, and a
       // format-bar dropdown change right after the blur-commit still lands.
       selectAnnotation(doc, created.id);
+      track('editor_action', { action: 'text' });
     }
     syncPage(pageId);
     setTool('select');
@@ -629,6 +633,7 @@ async function loadFilesInner(files) {
     const bytes = new Uint8Array(await f.arrayBuffer());
     if (isPdf(f)) await importPdf(doc, { name: f.name, bytes });
     else await importImage(doc, { name: f.name, bytes, mimeType: f.type });
+    track('file_loaded', { tool: 'editor-v2', fileType: isPdf(f) ? 'pdf' : 'image' });
   }
   if (!rasterizer) rasterizer = createPageRasterizer(doc);
   emptyEl.style.display = 'none';
@@ -713,6 +718,49 @@ function doDownload() {
   downloadSheet.open();
 }
 document.getElementById('btn-download').addEventListener('click', doDownload);
+
+// ---- Android back button: closes the open sheet, never leaves the app -----------------
+// Every dialog open pushes one history entry; the hardware/gesture back pops it
+// and we close the dialog. UI-initiated closes (✕, backdrop, Escape, success)
+// consume their entry with history.back() — guarded so our own back() doesn't
+// cascade into closing the next dialog underneath (nested pm-over-download case).
+(function wireDialogHistory() {
+  // NOTE: window.history everywhere — plain `history` is SHADOWED in this
+  // module by the undo history (const history = createHistory()).
+  const dialogs = ['pm-sheet', 'sig-modal', 'dl-sheet'].map((id) => document.getElementById(id));
+  const stack = []; // open dialogs in STACKING order (array order lies for nesting)
+  let expectPop = false;
+
+  for (const dlg of dialogs) {
+    const nativeShow = dlg.showModal.bind(dlg);
+    dlg.showModal = () => {
+      nativeShow();
+      window.history.pushState({ v2dlg: dlg.id }, '');
+      stack.push(dlg);
+    };
+    dlg.addEventListener('close', () => {
+      const i = stack.lastIndexOf(dlg);
+      if (i !== -1) stack.splice(i, 1);
+      // Closed by UI code → its history entry is stale; consume it silently.
+      if (window.history.state?.v2dlg === dlg.id) {
+        expectPop = true;
+        window.history.back();
+      }
+    });
+  }
+
+  window.addEventListener('popstate', () => {
+    if (expectPop) { expectPop = false; return; }
+    // Hardware back: close every dialog stacked ABOVE the entry we landed on.
+    // Rapid double-back COALESCES two traversals into one popstate — closing
+    // only the top layer would strand the lower sheet open with no history
+    // entry left (the next back would exit the app with a sheet showing).
+    const cur = window.history.state?.v2dlg || null;
+    const keepIdx = cur ? stack.findIndex((d) => d.id === cur) : -1;
+    const toClose = stack.slice(keepIdx + 1).reverse();
+    for (const d of toClose) if (d.open) d.close();
+  });
+}());
 
 // ---- test hooks (same pattern the old suite relies on) ----------------------------------
 window.v2 = {

--- a/js/v2/download-sheet.js
+++ b/js/v2/download-sheet.js
@@ -15,6 +15,7 @@
  */
 
 import { buildPdfBytes } from '../core/export.js';
+import { track } from '../lib/analytics.js';
 
 const COMPRESS_QUALITY = 0.72; // the ONE preset (founder call: no levels until data asks)
 const COMPRESS_MAXDIM = 1600;
@@ -258,6 +259,13 @@ export function createDownloadSheet(deps) {
           deps.toast(`${n} gambar dibungkus ZIP ✓`);
         }
       }
+      // Richer than the old event: the CHOICES are the product signal now.
+      track('download', {
+        tool: 'editor-v2',
+        format: state.format === 'pdf' ? 'pdf' : state.imgfmt,
+        size: state.size,
+        pages: state.picked ? 'some' : 'all',
+      });
       modal.close();
     } catch (err) {
       console.error(err);

--- a/js/v2/page-manager.js
+++ b/js/v2/page-manager.js
@@ -19,6 +19,7 @@
 
 import { removePage, reorderPage, rotatePage } from '../core/operations.js';
 import { record } from '../core/history.js';
+import { track } from '../lib/analytics.js';
 
 const LONG_PRESS_MS = 280;
 const DRAG_SLOP = 8; // px of movement that cancels a pending long-press
@@ -46,6 +47,8 @@ export function createPageManager(deps) {
     selected.clear();
     render();
     sheet.showModal();
+    // Same event name as the old modal — dashboard continuity across the swap.
+    track('gabungkan_used', { pageCount: deps.getDoc().pages.length });
   }
   function close() { sheet.close(); }
   sheet.addEventListener('click', (e) => { if (e.target === sheet) close(); });
@@ -333,6 +336,7 @@ export function createPageManager(deps) {
           if (toIndex !== -1 && toIndex !== fromIndex) {
             record(deps.history, doc);
             reorderPage(doc, page.id, toIndex);
+            track('editor_action', { action: 'reorder' });
             deps.onDocChanged();
           }
           render(); // rebuild clears all inline drag styles
@@ -372,6 +376,7 @@ export function createPageManager(deps) {
         p.raster = null;             // raster is now the wrong orientation
         thumbs.delete(p.id);         // thumb too
       }
+      track('editor_action', { action: 'rotate' });
       render();
       deps.onDocChanged();
     } else if (act === 'delete') {
@@ -379,10 +384,12 @@ export function createPageManager(deps) {
       record(deps.history, doc);
       for (const p of pages) removePage(doc, p.id);
       selected.clear();
+      track('editor_action', { action: 'delete_page' });
       render();
       deps.onDocChanged();
       deps.toast(`${pages.length} halaman dihapus`);
     } else if (act === 'extract') {
+      track('editor_action', { action: 'split' }); // old name kept: extract IS split
       deps.onExtract(pages);
     } else if (act === 'clear') {
       selected.clear();

--- a/tests/mobile/back-button.spec.js
+++ b/tests/mobile/back-button.spec.js
@@ -1,0 +1,72 @@
+/*
+ * Android back button: closes the open sheet, never leaves the editor.
+ * (Every dialog open pushes a history entry; back pops it → dialog closes;
+ * UI-initiated closes consume their own entry without side effects.)
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(__dirname, '..', 'fixtures', 'sample-2pages.pdf');
+
+async function openDoc(page) {
+  await page.goto('/editor-v2.html');
+  await page.setInputFiles('#file-input', FIXTURE);
+  await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+}
+
+test.describe('back button — mobile', () => {
+  test('back closes Kelola Halaman instead of leaving the page', async ({ page }) => {
+    await openDoc(page);
+    await page.tap('#btn-pages');
+    await expect(page.locator('#pm-sheet')).toBeVisible();
+    await page.goBack();
+    await expect(page.locator('#pm-sheet')).toBeHidden();
+    expect(page.url()).toContain('editor-v2'); // still here
+    await expect(page.locator('.pv-page').first()).toBeVisible();
+  });
+
+  test('nested sheets: back peels one layer at a time', async ({ page }) => {
+    await openDoc(page);
+    await page.tap('#btn-download');
+    await expect(page.locator('#dl-sheet')).toBeVisible();
+    await page.tap('#ds-pages [data-v="some"]'); // Kelola Halaman on top
+    await expect(page.locator('#pm-sheet')).toBeVisible();
+
+    await page.goBack();
+    await expect(page.locator('#pm-sheet')).toBeHidden();
+    await expect(page.locator('#dl-sheet')).toBeVisible(); // still one layer left
+    await page.waitForTimeout(250); // let traversal #1 fully settle (see rapid test below)
+
+    await page.goBack();
+    await expect(page.locator('#dl-sheet')).toBeHidden();
+    expect(page.url()).toContain('editor-v2');
+  });
+
+  test('RAPID double-back (coalesced traversal) still closes everything, stays on page', async ({ page }) => {
+    await openDoc(page);
+    await page.tap('#btn-download');
+    await page.tap('#ds-pages [data-v="some"]');
+    await expect(page.locator('#pm-sheet')).toBeVisible();
+
+    // Two backs as fast as the harness can fire them — the browser may
+    // coalesce them into a single popstate. Outcome must be the same.
+    await Promise.all([page.goBack(), page.goBack()]).catch(() => {});
+    await expect(page.locator('#pm-sheet')).toBeHidden();
+    await expect(page.locator('#dl-sheet')).toBeHidden();
+    expect(page.url()).toContain('editor-v2');
+    await expect(page.locator('.pv-page').first()).toBeVisible();
+  });
+
+  test('UI close (✕) leaves history clean: back after it does not reopen or exit oddly', async ({ page }) => {
+    await openDoc(page);
+    await page.tap('#btn-download');
+    await expect(page.locator('#dl-sheet')).toBeVisible();
+    await page.tap('#ds-close');
+    await expect(page.locator('#dl-sheet')).toBeHidden();
+    // The dialog's history entry was consumed — nothing dialog-ish left to pop.
+    // (history.back() is async — poll.)
+    await expect.poll(async () => page.evaluate(() => window.history.state?.v2dlg || null)).toBe(null);
+  });
+});

--- a/tests/mobile/bigdoc-stress.spec.js
+++ b/tests/mobile/bigdoc-stress.spec.js
@@ -1,0 +1,174 @@
+/*
+ * Big-doc stress — the "1 juta phones" survival property (Editor v2).
+ * ============================================================================
+ * Proves the streaming render engine (js/render/viewport.js, wired in
+ * js/v2/app.js) keeps memory BOUNDED on a large document: pages within ~2
+ * screens rasterize to <img>, pages beyond ~4 screens are RELEASED. Scroll a
+ * 120-page doc top→middle→bottom and the count of live rasters must NOT grow
+ * with document size — it tracks the viewport window, not the page count.
+ *
+ * Runs under the mobile-chrome project (Pixel 7: touch, DPR ~2.6). Fixture is
+ * tests/fixtures/bigdoc-120.pdf (see generate-bigdoc.mjs — 120 distinct pages).
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(__dirname, '..', 'fixtures', 'bigdoc-120.pdf');
+
+const PAGE_COUNT = 120;
+const LOAD_SCREENS = 2; // viewport.js loadScreens — rasterize window (each side)
+const KEEP_SCREENS = 4; // viewport.js keepScreens — release beyond this (each side)
+const HEAP_CEIL = 900 * 1024 * 1024; // generous: catch unbounded growth, not tuning
+
+// Read the streaming-relevant geometry straight from the engine's own frame of
+// reference (getBoundingClientRect on #v2-scroll + the page views).
+async function geometry(page) {
+  return page.evaluate(() => {
+    const scroll = document.getElementById('v2-scroll');
+    const pages = document.querySelectorAll('.pv-page');
+    const r0 = pages[0].getBoundingClientRect();
+    const r1 = pages[1].getBoundingClientRect();
+    return {
+      viewportH: scroll.clientHeight,
+      scrollH: scroll.scrollHeight,
+      pageH: r0.height,
+      stride: r1.top - r0.top, // visual px between consecutive page tops (incl. gap)
+      slotCount: pages.length,
+    };
+  });
+}
+
+async function rasterCount(page) {
+  return page.locator('.pv-page .pv-bg').count();
+}
+
+async function scrollTo(page, top) {
+  await page.evaluate((t) => { document.getElementById('v2-scroll').scrollTop = t; }, top);
+}
+
+// Let the fling gate lapse (settleMs=130) and give PDF.js a moment to catch up.
+async function settle(page, ms = 900) {
+  await page.waitForTimeout(ms);
+}
+
+async function heap(page) {
+  return page.evaluate(() => (performance.memory ? performance.memory.usedJSHeapSize : null));
+}
+
+test.describe('editor v2 — big-doc streaming (memory stays bounded)', () => {
+  test('120-page doc: streaming keeps live rasters bounded, heap flat, edits work', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    // ---- (a) slots exist quickly, scrollbar reflects the full document --------
+    await page.goto('/editor-v2.html');
+    const t0 = Date.now();
+    await page.setInputFiles('#file-input', FIXTURE);
+    await expect(page.locator('.pv-page')).toHaveCount(PAGE_COUNT, { timeout: 10_000 });
+    const slotMs = Date.now() - t0;
+    expect(slotMs).toBeLessThan(10_000);
+
+    const g = await geometry(page);
+    expect(g.slotCount).toBe(PAGE_COUNT);
+    // Document height ≈ 120 × page stride (metadata-only layout, no raster needed).
+    const expectedH = g.stride * PAGE_COUNT;
+    expect(g.scrollH).toBeGreaterThan(expectedH * 0.9);
+    expect(g.scrollH).toBeLessThan(expectedH * 1.2);
+
+    // The honest engine bound: nothing beyond the keep window (KEEP_SCREENS each
+    // side + the viewport itself) may hold a raster. Computed from real geometry
+    // so it adapts to the emulator's viewport/zoom instead of a magic number.
+    const keepWindowScreens = 2 * KEEP_SCREENS + 1;
+    const keepBound = Math.ceil((keepWindowScreens * g.viewportH) / g.stride) + 2;
+    const loadWindowScreens = 2 * LOAD_SCREENS + 1;
+    const loadBound = Math.ceil((loadWindowScreens * g.viewportH) / g.stride) + 2;
+
+    const heapLoad = await heap(page);
+
+    // Wait for the initial (top) window to rasterize so we have a real baseline.
+    await settle(page);
+    const topCount = await rasterCount(page);
+    expect(topCount).toBeGreaterThan(0); // first screens actually rendered
+    expect(topCount).toBeLessThanOrEqual(keepBound);
+    expect(topCount).toBeLessThan(25);
+
+    // ---- (b) STREAMING BOUND: jump to the middle, count live rasters ----------
+    await scrollTo(page, g.scrollH / 2);
+    await settle(page);
+    const midCount = await rasterCount(page);
+    expect(midCount).toBeGreaterThan(0);       // caught up after the fling settled
+    expect(midCount).toBeLessThanOrEqual(keepBound);
+    expect(midCount).toBeLessThan(25);
+    const heapMid = await heap(page);
+
+    // Jump to the bottom — the release path is the actual memory guarantee.
+    await scrollTo(page, g.scrollH);
+    await settle(page);
+    const bottomCount = await rasterCount(page);
+    expect(bottomCount).toBeGreaterThan(0);
+    expect(bottomCount).toBeLessThanOrEqual(keepBound);
+    expect(bottomCount).toBeLessThan(25);
+    const heapBottom = await heap(page);
+
+    // Direct proof RELEASE happened: page 1, ~120 screens above the bottom of the
+    // doc, must have dropped its raster. If eviction were broken every page the
+    // user ever scrolled past would still be an <img> and this would fail.
+    await expect(page.locator('.pv-page').nth(0).locator('.pv-bg')).toHaveCount(0);
+    // …and a page near the bottom DID rasterize (catch-up works both directions).
+    const bottomHasRaster = await page.evaluate(() => {
+      const pages = document.querySelectorAll('.pv-page');
+      for (let i = pages.length - 1; i >= pages.length - 10; i -= 1) {
+        if (pages[i].querySelector('.pv-bg')) return true;
+      }
+      return false;
+    });
+    expect(bottomHasRaster).toBe(true);
+
+    // ---- (c) heap sanity: bounded, not growing with pages scrolled -----------
+    if (heapLoad !== null) {
+      for (const h of [heapLoad, heapMid, heapBottom]) expect(h).toBeLessThan(HEAP_CEIL);
+      // Scrolling the whole doc must not balloon the heap: the release window
+      // caps live raster memory. Allow generous slack for GC lag / lib caches.
+      expect(heapBottom).toBeLessThan(heapLoad + 250 * 1024 * 1024);
+    }
+
+    // ---- (d) interactions still work deep in the doc (page ~100) --------------
+    const p100 = page.locator('.pv-page').nth(99);
+    await p100.scrollIntoViewIfNeeded();
+    await settle(page);
+    await expect(p100.locator('.pv-bg')).toBeVisible({ timeout: 8_000 });
+
+    await page.tap('[data-tool="text"]');
+    await p100.tap({ position: { x: 120, y: 160 } });
+    await expect(page.locator('.v2-text-edit')).toBeVisible();
+    await page.keyboard.type('Halaman seratus');
+    await page.keyboard.press('Enter');
+
+    const annos100 = await page.evaluate(() => window.v2.getDoc().pages[99].annotations);
+    expect(annos100.some((a) => a.type === 'text' && a.text === 'Halaman seratus')).toBe(true);
+    // The edit landed on page 100 and nowhere else.
+    const strayText = await page.evaluate(() =>
+      window.v2.getDoc().pages
+        .filter((_, i) => i !== 99)
+        .some((p) => p.annotations.some((a) => a.type === 'text' && a.text === 'Halaman seratus')));
+    expect(strayText).toBe(false);
+
+    // ---- (e) the Unduh sheet builds the whole 120-page PDF and reports a size -
+    await page.tap('#btn-download');
+    await expect(page.locator('#dl-sheet')).toBeVisible();
+    // Base build of 120 pages completes and the CTA shows real bytes (KB/MB).
+    await expect(page.locator('#ds-cta-main')).toContainText(/\d+([.,]\d+)?\s*(KB|MB)/, { timeout: 30_000 });
+
+    // Report the observed numbers into the test log for the run summary.
+    console.log(JSON.stringify({
+      slotMs, geometry: g, keepBound, loadBound,
+      rasterCounts: { top: topCount, middle: midCount, bottom: bottomCount },
+      heapMB: heapLoad === null ? 'unavailable' : {
+        load: +(heapLoad / 1048576).toFixed(1),
+        middle: +(heapMid / 1048576).toFixed(1),
+        bottom: +(heapBottom / 1048576).toFixed(1),
+      },
+    }, null, 2));
+  });
+});


### PR DESCRIPTION
ANALYTICS (the swap must not blind the dashboard): v2 now emits the same
Vercel/GA4/Sentry-breadcrumb events as the live editor via lib/analytics.js —
editor_action (text, text_inline, signature, paraf, whiteout, rotate,
delete_page, reorder, split), file_loaded, gabungkan_used, and a RICHER
download event carrying the Unduh sheet choices (format/size/pages — the
product signal that drives decisions). Head gets gtag + Vercel insights +
Sentry init with a v2-critical privacy adaptation: pages are <img> now, so
the replay block list covers .pv-bg, annotation images, thumbs, sig preview.

ANDROID BACK BUTTON: every sheet open pushes a history entry; hardware back
closes sheets layer by layer instead of leaving the app. Handles the
coalesced rapid double-back (one popstate for two entries — closing only the
top would strand a sheet with no entry left). UI closes (tap-out, Escape, ✕,
success) consume their entries silently. Found en route: 'history' in app.js
is shadowed by the UNDO history — window.history everywhere in that block.

DESKTOP (>=900px): Unduh sheet centers as a modal, hover affordances on
tools/tiles/segments, grab cursors on annotations.

6 back-button tests (incl. coalesced-traversal), 137/137 + 21/21 green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
