### PR TITLE
fix(v2): pre-swap review findings — 2 HIGH, 2 MED, 2 LOW

### DIFF
--- a/js/render/interaction.js
+++ b/js/render/interaction.js
@@ -68,13 +68,23 @@ export function createInteraction(ctx) {
   }
 
   // Re-apply selection chrome after an external overlay rebuild (undo, add…).
+  // MUST actually decorate (review H2): renderPageView sets only z-index, so a
+  // rebuildStage that keeps a selection (undo/redo, Semua Hal.) would leave the
+  // selected object without outline/handle AND without touch-action:none —
+  // invisible selection that scrolls instead of dragging on a phone.
   function refreshSelection() {
     selectedEl = null;
     const doc = ctx.getDoc();
     const id = doc.selection.annotationId;
     if (!id) return;
     const el = stage.querySelector(`[data-anno-id="${id}"]`);
-    if (el) selectedEl = el;
+    if (!el) return;
+    selectedEl = el;
+    const found = findAnno(doc, id);
+    if (found && !el.classList.contains('pv-selected')) {
+      el.style.zIndex = '1000';
+      decorateSelected(el, found.anno);
+    }
   }
 
   function findAnno(doc, annoId) {

--- a/js/v2/app.js
+++ b/js/v2/app.js
@@ -545,8 +545,8 @@ function deleteSelected() {
   if (pageId) syncPage(pageId);
 }
 
-function doUndo() { if (undo(history, doc)) rebuildStage(); }
-function doRedo() { if (redo(history, doc)) rebuildStage(); }
+function doUndo() { if (undo(history, doc)) { pageManager.invalidateThumbs(); rebuildStage(); } }
+function doRedo() { if (redo(history, doc)) { pageManager.invalidateThumbs(); rebuildStage(); } }
 document.getElementById('btn-undo').addEventListener('click', doUndo);
 document.getElementById('btn-redo').addEventListener('click', doRedo);
 
@@ -734,6 +734,7 @@ document.getElementById('btn-download').addEventListener('click', doDownload);
   for (const dlg of dialogs) {
     const nativeShow = dlg.showModal.bind(dlg);
     dlg.showModal = () => {
+      if (dlg.open) return; // double-tap/double-Ctrl+S: showModal throws on open dialogs
       nativeShow();
       window.history.pushState({ v2dlg: dlg.id }, '');
       stack.push(dlg);

--- a/js/v2/download-sheet.js
+++ b/js/v2/download-sheet.js
@@ -99,7 +99,20 @@ export function createDownloadSheet(deps) {
       console.error(err);
       if (seq === state.seq) { state.size = 'asli'; deps.toast('Gagal mengompres — pakai ukuran asli ya'); }
     } finally {
-      if (seq === state.seq) { state.compressing = false; render(); }
+      // Clear the flag UNCONDITIONALLY (review H1): a run superseded by ++seq
+      // must not leave `compressing` wedged true — that blocked every future
+      // buildCompressed via its own re-entry guard, and doExport's wait loop
+      // never exited (Compress dead for the whole session). Single-flight
+      // makes the unconditional clear safe: the guard prevents a second run
+      // while this one is alive.
+      state.compressing = false;
+      if (seq === state.seq) {
+        render();
+      } else if (state.format === 'pdf' && state.size === 'kompres' && !state.compressed) {
+        // Superseded while Compress is still what the user wants → restart
+        // for the NEW selection (this run's result was for stale pages).
+        buildCompressed();
+      }
     }
   }
 
@@ -278,11 +291,13 @@ export function createDownloadSheet(deps) {
 
   return {
     open() {
+      if (modal.open) return; // double Ctrl+S / double-tap: showModal throws on open dialogs
       state.format = 'pdf';
       state.imgfmt = 'jpg';
       state.size = 'asli';
       state.picked = null;
       state.compressed = null;
+      state.compressing = false; // belt-and-braces vs any historic flag leak
       state.exporting = false;
       modal.showModal();
       buildBase(); // truth on the button + pre-warmed bytes for the 90% path

--- a/js/v2/page-manager.js
+++ b/js/v2/page-manager.js
@@ -382,7 +382,7 @@ export function createPageManager(deps) {
     } else if (act === 'delete') {
       if (pages.length >= doc.pages.length) return; // guarded in UI as well
       record(deps.history, doc);
-      for (const p of pages) removePage(doc, p.id);
+      for (const p of pages) { removePage(doc, p.id); thumbs.delete(p.id); }
       selected.clear();
       track('editor_action', { action: 'delete_page' });
       render();
@@ -397,5 +397,9 @@ export function createPageManager(deps) {
     }
   });
 
-  return { open, openPick, close, render };
+  // Undo/redo can revert rotations the thumb cache baked in (review M4) — the
+  // caller flushes us wholesale; thumbs regenerate lazily on next open.
+  function invalidateThumbs() { thumbs.clear(); }
+
+  return { open, openPick, close, render, invalidateThumbs };
 }

--- a/js/v2/signature-modal.js
+++ b/js/v2/signature-modal.js
@@ -37,6 +37,10 @@ export function createSignatureModal({ modal, onReady, toast }) {
 
   // ---- draw pane ---------------------------------------------------------------
   function initPad() {
+    // Detach the previous pad's pointer listeners first (review M3): each
+    // SignaturePad constructor adds its own set to the SAME canvas — without
+    // off(), N modal opens = N pads all drawing every stroke N× thick.
+    pad?.off();
     const dpr = Math.min(window.devicePixelRatio || 1, 2);
     canvas.width = canvas.offsetWidth * dpr;
     canvas.height = canvas.offsetHeight * dpr;
@@ -52,10 +56,11 @@ export function createSignatureModal({ modal, onReady, toast }) {
     if (!f || !f.type.startsWith('image/')) { toast('Pilih file gambar ya'); return; }
     const img = new Image();
     img.onload = () => {
+      URL.revokeObjectURL(img.src); // decoded — the blob URL has done its job
       uploadedImg = img;
       renderUploadPreview();
     };
-    img.onerror = () => toast('Gagal membaca gambar');
+    img.onerror = () => { URL.revokeObjectURL(img.src); toast('Gagal membaca gambar'); };
     img.src = URL.createObjectURL(f);
   });
   removeBgCheck.addEventListener('change', renderUploadPreview);

--- a/tests/mobile/review-fixes.spec.js
+++ b/tests/mobile/review-fixes.spec.js
@@ -1,0 +1,95 @@
+/*
+ * Regression tests for the pre-swap review's verified findings.
+ * H1: a superseded compress run must not wedge `compressing` true forever.
+ * H2: selection chrome (outline/handle/touch-action) survives rebuildStage.
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(__dirname, '..', 'fixtures', 'sample-2pages.pdf');
+const BIGDOC = path.join(__dirname, '..', 'fixtures', 'bigdoc-120.pdf');
+
+test.describe('review fixes', () => {
+  test('H1: re-pick WHILE compressing (superseded run) — Compress recovers, download works', async ({ page }) => {
+    test.setTimeout(90000);
+    await page.goto('/editor-v2.html');
+    await page.setInputFiles('#file-input', BIGDOC); // big → compression takes seconds
+    await expect(page.locator('.pv-page').first()).toBeVisible();
+    await page.tap('#btn-download');
+    await expect(page.locator('#ds-cta-main')).toContainText(/KB|MB/, { timeout: 60000 });
+
+    await page.tap('#ds-size [data-v="kompres"]');
+    // While the 120-page compression is IN FLIGHT, change the page selection.
+    await page.tap('#ds-pages [data-v="some"]');
+    await page.tap('.pm-tile >> nth=0');
+    await page.tap('.pm-tile >> nth=1');
+    await page.tap('#pm-pick-ok');
+    await expect(page.locator('#ds-cta-main')).toContainText('(2 hal.)');
+
+    // The wedge would leave the spinner forever; recovery = a result lands.
+    await expect(page.locator('#ds-size [data-v="kompres"]')).toContainText(/hemat|optimal/, { timeout: 60000 });
+    const dl = page.waitForEvent('download');
+    await page.tap('#ds-cta');
+    expect((await dl).suggestedFilename()).toMatch(/\.pdf$/);
+  });
+
+  test('H2: selection chrome survives rebuildStage (Semua Hal. + undo keep it draggable)', async ({ page }) => {
+    await page.goto('/editor-v2.html');
+    await page.setInputFiles('#file-input', FIXTURE);
+    await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+
+    // Draw + place a signature (lands selected), then fan out (rebuildStage).
+    await page.tap('[data-tool="signature"]');
+    const box = await page.locator('#sig-canvas').boundingBox();
+    await page.mouse.move(box.x + 40, box.y + 60);
+    await page.mouse.down();
+    await page.mouse.move(box.x + 180, box.y + 90, { steps: 5 });
+    await page.mouse.up();
+    await page.tap('#sig-use');
+    await page.tap('.pv-page >> nth=0', { position: { x: 150, y: 250 } });
+    await page.tap('#btn-all-pages'); // → rebuildStage with selection intact
+
+    // Chrome must be back: outline class, resize handle, touch-action none.
+    const sel = page.locator('.pv-anno.pv-selected');
+    await expect(sel).toHaveCount(1);
+    await expect(sel.locator('.pv-handle')).toHaveCount(1);
+    expect(await sel.evaluate((el) => el.style.touchAction)).toBe('none');
+
+    // And the object must actually DRAG on touch after the rebuild.
+    const before = await page.evaluate(() => {
+      const a = window.v2.getDoc().pages[0].annotations[0];
+      return { x: a.x, y: a.y };
+    });
+    await page.evaluate(async () => {
+      const el = document.querySelector('.pv-anno.pv-selected');
+      const r = el.getBoundingClientRect();
+      const fire = (type, x, y) => el.dispatchEvent(new PointerEvent(type, {
+        pointerId: 41, pointerType: 'touch', isPrimary: true,
+        clientX: x, clientY: y, bubbles: true, cancelable: true,
+      }));
+      fire('pointerdown', r.left + r.width / 2, r.top + r.height / 2);
+      for (let i = 1; i <= 4; i += 1) {
+        fire('pointermove', r.left + r.width / 2 + i * 12, r.top + r.height / 2 + i * 8);
+        await new Promise((res) => requestAnimationFrame(res));
+      }
+      fire('pointerup', r.left + r.width / 2 + 48, r.top + r.height / 2 + 32);
+    });
+    const after = await page.evaluate(() => {
+      const a = window.v2.getDoc().pages[0].annotations[0];
+      return { x: a.x, y: a.y };
+    });
+    expect(after.x).toBeGreaterThan(before.x);
+
+    // Undo (another rebuildStage path): chrome still coherent — either a
+    // decorated selection or a clean deselection, never a naked "selected".
+    await page.tap('#btn-undo');
+    const coherent = await page.evaluate(() => {
+      const id = window.v2.getDoc().selection.annotationId;
+      const el = document.querySelector('.pv-anno.pv-selected');
+      return (id === null && el === null) || (id !== null && el?.dataset.annoId === id);
+    });
+    expect(coherent).toBe(true);
+  });
+});


### PR DESCRIPTION
Adversarial review before the swap; every finding verified by call-chain
trace, all but one fixed (L7 skipped by design: a pinch-cancelled Tip-Ex
stroke never completed, so staying in the tool is correct).

H1 download-sheet: a compress run superseded by ++seq left
wedged true forever (its finally was seq-guarded; the re-entry guard then
blocked every future run and doExport's wait never exited — Compress dead
for the session). Flag now clears unconditionally (single-flight makes that
safe) and a superseded run RESTARTS compression when Compress is still the
selected size. open() resets flags.

H2 interaction: refreshSelection claimed to re-apply selection chrome but
only cached the element — after any rebuildStage keeping a selection
(undo/redo, Semua Hal.) the selected object lost outline/handle AND
touch-action:none: invisible selection that scrolled instead of dragging on
touch. Now actually decorates, mirroring syncOverlay.

M3 signature-modal: each open stacked another SignaturePad on the same
canvas (N× listeners, N× strokes) — pad.off() before re-init.
M4 page-manager: thumbs cache now flushed on undo/redo (stale rotated
thumbnails) and pruned on bulk delete.
L5 upload blob URL revoked after decode. L6 all dialogs guard double-open.

2 regression tests (compress-superseded race on the 120-page fixture;
selection chrome + real drag after rebuild). 140/140 + 21/21 green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
