### PR TITLE
feat(v2): growth loop — celebrate the download, then invite (share / QRIS)

### DIFF
--- a/editor-v2.html
+++ b/editor-v2.html
@@ -392,6 +392,44 @@
       .pv-anno-watermark, .pv-anno-pageNumber { cursor: default; }
     }
 
+    /* ---- support card (celebrate → invite; never modal, never nagging) ---- */
+    #support-card {
+      position: fixed; left: 50%; transform: translate(-50%, 12px); bottom: 14px; z-index: 110;
+      width: min(92vw, 360px); background: var(--surface); border-radius: 16px;
+      padding: 14px 16px 10px; box-shadow: 0 8px 30px rgba(15,18,26,.22);
+      border: 1px solid var(--line);
+      /* visibility (not just opacity): screen readers and hit-testing must
+         treat the dismissed card as GONE, not as an invisible dialog. */
+      opacity: 0; visibility: hidden; pointer-events: none;
+      transition: opacity .3s ease, transform .3s ease, visibility 0s linear .3s;
+    }
+    #support-card.show {
+      opacity: 1; visibility: visible; pointer-events: auto;
+      transform: translate(-50%, 0); transition-delay: 0s;
+    }
+    @media (prefers-reduced-motion: reduce) { #support-card { transition: none; } }
+    #sc-close {
+      position: absolute; top: 6px; right: 6px; width: 34px; height: 34px;
+      color: var(--muted); font-size: 14px; border-radius: 8px;
+    }
+    .sc-head { font-weight: 700; font-size: 15px; color: var(--ink); margin-bottom: 4px; }
+    .sc-sub { font-size: 12.5px; color: var(--muted); line-height: 1.5; margin-bottom: 10px; }
+    .sc-actions { display: flex; gap: 8px; }
+    .sc-actions button {
+      flex: 1; min-height: 42px; border-radius: 10px; font-size: 13.5px; font-weight: 600;
+      border: 1.5px solid var(--line); background: var(--bg); color: var(--ink);
+    }
+    #sc-share { border-color: var(--accent); color: var(--accent); background: rgba(79,142,247,.07); }
+    .sc-qr { display: none; text-align: center; padding-top: 12px; }
+    #support-card.qr-open .sc-qr { display: block; }
+    #support-card.qr-open .sc-actions #sc-donate { border-color: var(--accent); color: var(--accent); }
+    .sc-qr img { width: min(70vw, 220px); border-radius: 10px; border: 1px solid var(--line); }
+    .sc-qr p { font-size: 11.5px; color: var(--muted); margin-top: 6px; }
+    #sc-never {
+      display: block; margin: 8px auto 0; color: var(--muted); font-size: 11px;
+      text-decoration: underline; min-height: 32px; padding: 0 8px;
+    }
+
     #toast {
       position: fixed; left: 50%; transform: translateX(-50%); bottom: 130px; z-index: 40;
       background: rgba(26,29,33,.9); color: #fff; font-size: 13px;
@@ -471,6 +509,21 @@
     <button id="z-out" aria-label="Perkecil">−</button>
   </div>
   <div id="toast" role="status" aria-live="polite"></div>
+
+  <div id="support-card" role="dialog" aria-label="Dukung PDFLokal">
+    <button id="sc-close" aria-label="Tutup">✕</button>
+    <div class="sc-head">Berkas kamu jadi! 🎉</div>
+    <p class="sc-sub">PDFLokal gratis &amp; tanpa server — file kamu nggak pernah ke mana-mana. Suka? Bantu kami:</p>
+    <div class="sc-actions">
+      <button id="sc-share">🔗 Bagikan</button>
+      <button id="sc-donate">☕ Traktir Kopi</button>
+    </div>
+    <div class="sc-qr">
+      <img src="images/qris.png" alt="QRIS — scan untuk traktir kopi" loading="lazy">
+      <p>Scan pakai e-wallet atau m-banking kamu 🙏</p>
+    </div>
+    <button id="sc-never">jangan tampilkan lagi</button>
+  </div>
 
   <dialog id="pm-sheet" aria-label="Kelola halaman">
     <div class="sheet pm-sheet-body">

--- a/js/v2/app.js
+++ b/js/v2/app.js
@@ -31,6 +31,7 @@ import { createPageManager } from './page-manager.js';
 import { createSignatureModal } from './signature-modal.js';
 import { createDownloadSheet } from './download-sheet.js';
 import { track } from '../lib/analytics.js';
+import { createCelebration } from './celebrate.js';
 
 window.pdfjsLib.GlobalWorkerOptions.workerSrc = '/js/vendor/pdf.worker.min.js';
 
@@ -53,6 +54,7 @@ const pill = document.getElementById('v2-pill');
 const toastEl = document.getElementById('toast');
 
 // ---- small helpers -----------------------------------------------------------
+let celebration; // assigned below (needs toast, which needs the DOM refs above)
 let toastTimer = null;
 function toast(msg) {
   toastEl.textContent = msg;
@@ -67,7 +69,11 @@ function download(blob, filename) {
   a.download = filename;
   a.click();
   setTimeout(() => URL.revokeObjectURL(a.href), 4000);
+  // The chokepoint every export path funnels through — celebrate here, AFTER
+  // the save was triggered. (Wave 5: reward the "I got my file" moment.)
+  celebration.onDownloadSuccess();
 }
+celebration = createCelebration({ toast });
 
 // ---- zoom ---------------------------------------------------------------------
 // transform:scale + a sizer that carries the scaled layout size. NOT CSS zoom:

--- a/js/v2/celebrate.js
+++ b/js/v2/celebrate.js
@@ -1,0 +1,113 @@
+/*
+ * PDFLokal — v2/celebrate.js  (the download moment: reward, then invite)
+ * ============================================================================
+ * The download is the emotional peak — the user GOT their file. Two beats,
+ * in the founder's order (backlog Wave 5):
+ *   1. CELEBRATE — a small confetti burst. Never blocks or delays the save;
+ *     honors prefers-reduced-motion; pure canvas, zero deps, self-hosted.
+ *   2. INVITE — one dismissible card: share PDFLokal (Web Share / copy-link)
+ *     or tip via QRIS — revealed INLINE (never navigate away from the flow;
+ *     the QR is the same asset dukung.html uses). Frequency: once per
+ *     session, with a permanent "jangan tampilkan lagi" opt-out. The file is
+ *     already downloaded — nothing is ever held hostage.
+ */
+
+const OPTOUT_KEY = 'pdflokal-support-optout';
+const SHARE_URL = 'https://www.pdflokal.id';
+const SHARE_TEXT = 'Edit, gabung, dan tanda tangan PDF langsung di HP — gratis, privat, tanpa upload.';
+
+// Private-browsing-safe storage (localStorage throws in some private modes).
+function safeGet(key) {
+  try { return localStorage.getItem(key); } catch { return null; }
+}
+function safeSet(key, val) {
+  try { localStorage.setItem(key, val); } catch { /* private mode — session-only */ }
+}
+
+// ---- beat 1: confetti -----------------------------------------------------------
+function confetti() {
+  if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return;
+  const c = document.createElement('canvas');
+  c.style.cssText = 'position:fixed;inset:0;width:100%;height:100%;pointer-events:none;z-index:120';
+  c.width = window.innerWidth;
+  c.height = window.innerHeight;
+  document.body.appendChild(c);
+  const ctx = c.getContext('2d');
+  const COLORS = ['#4f8ef7', '#f7b84f', '#1d8a44', '#d33131', '#8e4ff7'];
+  const parts = Array.from({ length: 36 }, (_, i) => ({
+    x: c.width / 2 + (i % 2 ? 1 : -1) * (i * 3),
+    y: c.height * 0.35,
+    vx: (Math.cos(i * 1.7) * (2 + (i % 5))),
+    vy: -6 - (i % 7),
+    s: 5 + (i % 4) * 2,
+    r: i * 0.9,
+    color: COLORS[i % COLORS.length],
+  }));
+  const t0 = performance.now();
+  (function frame(t) {
+    const dt = (t - t0) / 900; // ~0.9s of joy, then gone
+    ctx.clearRect(0, 0, c.width, c.height);
+    if (dt >= 1) { c.remove(); return; }
+    for (const p of parts) {
+      p.x += p.vx;
+      p.y += p.vy;
+      p.vy += 0.35; // gravity
+      p.r += 0.15;
+      ctx.save();
+      ctx.globalAlpha = 1 - dt;
+      ctx.translate(p.x, p.y);
+      ctx.rotate(p.r);
+      ctx.fillStyle = p.color;
+      ctx.fillRect(-p.s / 2, -p.s / 2, p.s, p.s * 0.6);
+      ctx.restore();
+    }
+    requestAnimationFrame(frame);
+  }(t0));
+}
+
+// ---- beat 2: the support card ------------------------------------------------------
+// deps = { toast }
+export function createCelebration(deps) {
+  let shownThisSession = false;
+  const card = document.getElementById('support-card');
+
+  function hide() { card.classList.remove('show'); }
+
+  card.querySelector('#sc-close').addEventListener('click', hide);
+  card.querySelector('#sc-never').addEventListener('click', () => {
+    safeSet(OPTOUT_KEY, '1');
+    hide();
+    deps.toast('Oke, nggak akan muncul lagi 👍');
+  });
+
+  card.querySelector('#sc-share').addEventListener('click', async () => {
+    try {
+      if (navigator.share) {
+        await navigator.share({ title: 'PDFLokal', text: SHARE_TEXT, url: SHARE_URL });
+        hide();
+      } else {
+        await navigator.clipboard.writeText(`${SHARE_TEXT} ${SHARE_URL}`);
+        deps.toast('Link disalin — tinggal tempel ✓');
+        hide();
+      }
+    } catch { /* user cancelled the share sheet — keep the card, no nagging toast */ }
+  });
+
+  card.querySelector('#sc-donate').addEventListener('click', () => {
+    // Reveal the QR INLINE — never leave the editor (founder-locked).
+    card.classList.add('qr-open');
+  });
+
+  return {
+    // The one hook: called by the app's shared download chokepoint.
+    onDownloadSuccess() {
+      confetti(); // instant, independent of the card logic
+      if (shownThisSession || safeGet(OPTOUT_KEY) === '1') return;
+      shownThisSession = true;
+      setTimeout(() => {
+        card.classList.remove('qr-open');
+        card.classList.add('show');
+      }, 1100); // after the confetti settles and the sheet has closed
+    },
+  };
+}

--- a/tests/mobile/growth-loop.spec.js
+++ b/tests/mobile/growth-loop.spec.js
@@ -1,0 +1,78 @@
+/*
+ * Wave 5 growth loop: celebrate the download, then invite (share / QRIS tip).
+ * Never nags: once per session, permanent opt-out, file never held hostage.
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(__dirname, '..', 'fixtures', 'sample-2pages.pdf');
+
+async function downloadOnce(page) {
+  await page.tap('#btn-download');
+  const dl = page.waitForEvent('download');
+  await page.tap('#ds-cta');
+  await dl;
+}
+
+async function openDoc(page) {
+  await page.goto('/editor-v2.html');
+  await page.setInputFiles('#file-input', FIXTURE);
+  await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+}
+
+test.describe('growth loop — mobile', () => {
+  test('download celebrates (confetti) and then invites — once per session', async ({ page }) => {
+    await openDoc(page);
+    await downloadOnce(page);
+    // Confetti canvas exists briefly (fixed, pointer-events none), then self-removes.
+    await expect(page.locator('canvas[style*="pointer-events"]').last()).toBeAttached();
+    // The card arrives after the sheet closes.
+    await expect(page.locator('#support-card')).toBeVisible({ timeout: 4000 });
+    await expect(page.locator('.sc-head')).toContainText('Berkas kamu jadi');
+
+    // Dismiss, download again: same session → no second ask.
+    await page.tap('#sc-close');
+    await expect(page.locator('#support-card')).toBeHidden();
+    await downloadOnce(page);
+    await page.waitForTimeout(1600);
+    await expect(page.locator('#support-card')).toBeHidden();
+  });
+
+  test('Traktir Kopi reveals the QRIS inline — no navigation away', async ({ page }) => {
+    await openDoc(page);
+    await downloadOnce(page);
+    await expect(page.locator('#support-card')).toBeVisible({ timeout: 4000 });
+    await page.tap('#sc-donate');
+    await expect(page.locator('.sc-qr img[src*="qris"]')).toBeVisible();
+    expect(page.url()).toContain('editor-v2'); // still in the editor
+  });
+
+  test('"jangan tampilkan lagi" is permanent (survives reload)', async ({ page }) => {
+    await openDoc(page);
+    await downloadOnce(page);
+    await expect(page.locator('#support-card')).toBeVisible({ timeout: 4000 });
+    await page.tap('#sc-never');
+    await expect(page.locator('#support-card')).toBeHidden();
+
+    await openDoc(page); // fresh page load, same storage
+    await downloadOnce(page);
+    await page.waitForTimeout(1600);
+    await expect(page.locator('#support-card')).toBeHidden();
+  });
+
+  test('Bagikan uses the native share sheet when available', async ({ page }) => {
+    await openDoc(page);
+    await page.evaluate(() => {
+      window.__shared = null;
+      navigator.share = (data) => { window.__shared = data; return Promise.resolve(); };
+    });
+    await downloadOnce(page);
+    await expect(page.locator('#support-card')).toBeVisible({ timeout: 4000 });
+    await page.tap('#sc-share');
+    const shared = await page.evaluate(() => window.__shared);
+    expect(shared.url).toContain('pdflokal.id');
+    await expect(page.locator('#support-card')).toBeHidden(); // shared → card done
+  });
+});


### PR DESCRIPTION
Wave 5 (founder ask): the download is the emotional peak; reward it, THEN
gently ask. Two beats at the shared download chokepoint:

1. Confetti burst — pure canvas, ~0.9s, zero deps, prefers-reduced-motion
   honored, never blocks or delays the save.
2. Support card — 'Berkas kamu jadi! 🎉 … Bagikan / Traktir Kopi'. Share =
   Web Share API with copy-link fallback; Traktir = the SAME QRIS asset
   dukung.html uses, revealed INLINE (never navigate away — founder-locked).
   Once per session, permanent 'jangan tampilkan lagi' opt-out
   (private-browsing-safe storage), dismissible, arrives AFTER the file is
   saved — nothing is ever held hostage.

Card hidden state uses visibility (not just opacity) so screen readers and
hit-testing treat the dismissed card as gone.

4 touch tests (once-per-session, inline QR, permanent opt-out, native
share). 144/144 + 21/21 green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
