### PR TITLE
polish(v2): founder notes — modern burst, swipe dismiss, 0.2s, SVG icons, human copy

### DIFF
--- a/editor-v2.html
+++ b/editor-v2.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <meta name="robots" content="noindex, nofollow">
-  <title>PDFLokal — Editor v2 (beta)</title>
+  <title>PDFLokal Editor</title>
 
   <!-- Google tag (gtag.js) — same allowlist discipline as index.html -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17538923405"></script>
@@ -445,8 +445,14 @@
     <div class="file-menu-wrap">
       <button id="btn-file" disabled aria-haspopup="menu" aria-expanded="false">File ▾</button>
       <div id="file-menu" role="menu" hidden>
-        <button role="menuitem" id="fm-add">➕ Tambah File (gabung)</button>
-        <button role="menuitem" id="fm-new">📄 Buka Baru <span class="fm-note">ganti semua</span></button>
+        <button role="menuitem" id="fm-add">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M15 2v5h5"/><line x1="12" y1="18" x2="12" y2="12"/><line x1="9" y1="15" x2="15" y2="15"/></svg>
+          Tambah File <span class="fm-note">gabung</span>
+        </button>
+        <button role="menuitem" id="fm-new">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M15 2v5h5"/></svg>
+          Buka Baru <span class="fm-note">ganti semua</span>
+        </button>
       </div>
     </div>
     <span class="spacer"></span>
@@ -480,7 +486,7 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
       Hapus
     </button>
-    <button class="tool" id="btn-pages" disabled aria-label="Kelola halaman — urutkan, putar, hapus, ekstrak">
+    <button class="tool" id="btn-pages" disabled aria-label="Kelola halaman: urutkan, putar, hapus, ekstrak">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
       Halaman
     </button>
@@ -490,16 +496,19 @@
   <div id="sig-bar" role="toolbar" aria-label="Aksi tanda tangan">
     <span id="sig-bar-label"></span>
     <button id="btn-all-pages">Terapkan ke Semua Hal.</button>
-    <button id="btn-redraw-sig">Gambar Ulang ✍️</button>
+    <button id="btn-redraw-sig">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:14px;height:14px;vertical-align:-2px"><path d="M17 3a2.8 2.8 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>
+      Gambar Ulang
+    </button>
   </div>
 
   <main id="v2-scroll">
     <div id="v2-sizer"><div id="v2-stage"></div></div>
     <div id="empty">
       <h1>Edit PDF langsung di HP-mu</h1>
-      <p>Gabung, tanda tangan, tulis, dan tutup teks — semua diproses di perangkatmu, nggak ada yang di-upload.</p>
+      <p>Gabung, tanda tangan, tulis, tutup teks. Semuanya diproses di HP-mu sendiri, nggak ada yang di-upload.</p>
       <button id="btn-open">Buka PDF</button>
-      <span class="privacy">🔒 100% privat — file kamu nggak pernah ninggalin perangkat</span>
+      <span class="privacy"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:13px;height:13px;vertical-align:-2px"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg> 100% privat, file kamu nggak pernah ninggalin perangkat</span>
     </div>
   </main>
 
@@ -511,16 +520,24 @@
   <div id="toast" role="status" aria-live="polite"></div>
 
   <div id="support-card" role="dialog" aria-label="Dukung PDFLokal">
-    <button id="sc-close" aria-label="Tutup">✕</button>
-    <div class="sc-head">Berkas kamu jadi! 🎉</div>
-    <p class="sc-sub">PDFLokal gratis &amp; tanpa server — file kamu nggak pernah ke mana-mana. Suka? Bantu kami:</p>
+    <button id="sc-close" aria-label="Tutup">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+    </button>
+    <div class="sc-head">Selesai, filemu udah jadi!</div>
+    <p class="sc-sub">PDFLokal gratis dan bakal terus gratis. Kalau kepakai, bantu kami sedikit ya:</p>
     <div class="sc-actions">
-      <button id="sc-share">🔗 Bagikan</button>
-      <button id="sc-donate">☕ Traktir Kopi</button>
+      <button id="sc-share">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.6" y1="13.5" x2="15.4" y2="17.5"/><line x1="15.4" y1="6.5" x2="8.6" y2="10.5"/></svg>
+        Bagikan ke teman
+      </button>
+      <button id="sc-donate">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 8h1a4 4 0 1 1 0 8h-1"/><path d="M3 8h14v9a4 4 0 0 1-4 4H7a4 4 0 0 1-4-4Z"/><line x1="6" y1="2" x2="6" y2="4"/><line x1="10" y1="2" x2="10" y2="4"/><line x1="14" y1="2" x2="14" y2="4"/></svg>
+        Traktir kopi
+      </button>
     </div>
     <div class="sc-qr">
-      <img src="images/qris.png" alt="QRIS — scan untuk traktir kopi" loading="lazy">
-      <p>Scan pakai e-wallet atau m-banking kamu 🙏</p>
+      <img src="images/qris.png" alt="QRIS untuk traktir kopi" loading="lazy">
+      <p>Scan pakai e-wallet atau m-banking kamu. Makasih banyak!</p>
     </div>
     <button id="sc-never">jangan tampilkan lagi</button>
   </div>
@@ -530,7 +547,7 @@
       <div class="pm-head">
         <h2>Kelola Halaman</h2>
         <span class="pm-hint">Ketuk untuk memilih · tahan lalu geser untuk mengurutkan</span>
-        <button class="btn-ghost" id="pm-close" aria-label="Tutup">✕</button>
+        <button class="btn-ghost" id="pm-close" aria-label="Tutup"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="width:14px;height:14px"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
       </div>
       <div id="pm-grid" class="pm-grid"></div>
       <div id="pm-bulk" class="pm-bulk">
@@ -554,7 +571,7 @@
       <div class="ds-title">
         <h2>Unduh</h2>
         <span class="ds-meta" id="ds-meta"></span>
-        <button class="btn-ghost" id="ds-close" aria-label="Tutup">✕</button>
+        <button class="btn-ghost" id="ds-close" aria-label="Tutup"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="width:14px;height:14px"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
       </div>
 
       <div class="ds-row">
@@ -603,7 +620,7 @@
       <div class="sig-pane-upload" style="display:none">
         <label class="sig-upload-drop">
           <input type="file" id="sig-file" accept="image/*" hidden>
-          <span>Pilih foto tanda tangan 📷</span>
+          <span><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="width:16px;height:16px;vertical-align:-3px"><path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"/><circle cx="12" cy="13" r="3"/></svg> Pilih foto tanda tanganmu</span>
         </label>
         <label class="sig-check"><input type="checkbox" id="sig-removebg" checked> Hapus latar putih</label>
         <div id="sig-preview" class="sig-preview"></div>

--- a/js/v2/app.js
+++ b/js/v2/app.js
@@ -386,15 +386,15 @@ const pageManager = createPageManager({
   onExtract: async (pages) => {
     // Export ONLY the selected pages: a shallow Doc sharing the same sources.
     try {
-      toast('Menyiapkan PDF…');
+      toast('Sebentar, lagi disiapkan');
       const { buildPdfBytes } = await import('../core/export.js');
       const subset = { sources: doc.sources, pages, selection: { pageId: null, annotationId: null } };
       const bytes = await buildPdfBytes(subset, { PDFLib: window.PDFLib, fontkit: window.fontkit });
       download(new Blob([bytes], { type: 'application/pdf' }), `${baseName}-halaman-${pages.length}.pdf`);
-      toast(`${pages.length} halaman diekstrak ✓`);
+      toast(`Selesai! ${pages.length} halaman diekstrak jadi PDF baru`);
     } catch (err) {
       console.error(err);
-      toast('Gagal mengekstrak — coba lagi ya');
+      toast('Waduh, gagal mengekstrak. Coba sekali lagi ya');
     }
   },
   toast,
@@ -535,7 +535,7 @@ document.getElementById('btn-all-pages').addEventListener('click', () => {
     }));
   }
   rebuildStage();
-  toast(`Diterapkan ke ${doc.pages.length - 1} halaman lain ✓`);
+  toast(`Oke, ditaruh di ${doc.pages.length - 1} halaman lainnya juga`);
 });
 
 // ---- delete / undo / redo ------------------------------------------------------------
@@ -614,7 +614,7 @@ const SIZE_BLOCK = 100 * 1024 * 1024;
 let loadingFiles = false; // re-entry guard: double-taps and rapid picks interleave imports
 
 async function loadFiles(files) {
-  if (loadingFiles) { toast('Sabar ya, file sebelumnya masih dimuat…'); return; }
+  if (loadingFiles) { toast('Sebentar ya, file sebelumnya masih dimuat'); return; }
   loadingFiles = true;
   try {
     await loadFilesInner(files);
@@ -631,7 +631,7 @@ async function loadFilesInner(files) {
   if (usable.length === 0) { toast('Pilih file PDF atau gambar ya'); return; }
   const oversize = usable.find((f) => f.size > SIZE_BLOCK);
   if (oversize) { toast(`"${oversize.name}" terlalu besar (maks 100MB)`); return; }
-  if (usable.some((f) => f.size > SIZE_WARN)) toast('File besar — proses bisa agak lama ya');
+  if (usable.some((f) => f.size > SIZE_WARN)) toast('Filenya lumayan besar, sabar sebentar ya');
   const firstLoad = doc.pages.length === 0;
   if (firstLoad) baseName = usable[0].name.replace(/\.[^.]+$/, '');
 

--- a/js/v2/celebrate.js
+++ b/js/v2/celebrate.js
@@ -1,83 +1,112 @@
 /*
  * PDFLokal — v2/celebrate.js  (the download moment: reward, then invite)
  * ============================================================================
- * The download is the emotional peak — the user GOT their file. Two beats,
- * in the founder's order (backlog Wave 5):
- *   1. CELEBRATE — a small confetti burst. Never blocks or delays the save;
- *     honors prefers-reduced-motion; pure canvas, zero deps, self-hosted.
- *   2. INVITE — one dismissible card: share PDFLokal (Web Share / copy-link)
- *     or tip via QRIS — revealed INLINE (never navigate away from the flow;
- *     the QR is the same asset dukung.html uses). Frequency: once per
- *     session, with a permanent "jangan tampilkan lagi" opt-out. The file is
- *     already downloaded — nothing is ever held hostage.
+ * The download is the emotional peak. Two beats, in the founder's order:
+ *   1. CELEBRATE: a modern micro-burst (soft ring pulse + floating dots with
+ *      spring easing, Web Animations API). Quick, quiet, gone in ~0.7s.
+ *      Founder killed the 1990s rectangle confetti, rightly.
+ *   2. INVITE: one dismissible card (share PDFLokal or tip via QRIS inline).
+ *      Swipe-down dismisses it like any sheet. Once per session, permanent
+ *      opt-out. The file is already saved; nothing is ever held hostage.
  */
 
 const OPTOUT_KEY = 'pdflokal-support-optout';
 const SHARE_URL = 'https://www.pdflokal.id';
-const SHARE_TEXT = 'Edit, gabung, dan tanda tangan PDF langsung di HP — gratis, privat, tanpa upload.';
+// Written the way a friend would actually send it, not like a brochure.
+const SHARE_TEXT = 'Eh coba deh pdflokal.id, bisa edit + tanda tangan PDF langsung di HP. Gratis, dan filenya nggak diupload ke mana-mana.';
 
 // Private-browsing-safe storage (localStorage throws in some private modes).
 function safeGet(key) {
   try { return localStorage.getItem(key); } catch { return null; }
 }
 function safeSet(key, val) {
-  try { localStorage.setItem(key, val); } catch { /* private mode — session-only */ }
+  try { localStorage.setItem(key, val); } catch { /* private mode, session-only */ }
 }
 
-// ---- beat 1: confetti -----------------------------------------------------------
-function confetti() {
+// ---- beat 1: the burst ------------------------------------------------------------
+// One expanding ring + a dozen soft dots that spring up and drift out, all
+// GPU-composited transforms/opacity via WAAPI. Reads as "success", not "party".
+function burst() {
   if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return;
-  const c = document.createElement('canvas');
-  c.style.cssText = 'position:fixed;inset:0;width:100%;height:100%;pointer-events:none;z-index:120';
-  c.width = window.innerWidth;
-  c.height = window.innerHeight;
-  document.body.appendChild(c);
-  const ctx = c.getContext('2d');
-  const COLORS = ['#4f8ef7', '#f7b84f', '#1d8a44', '#d33131', '#8e4ff7'];
-  const parts = Array.from({ length: 36 }, (_, i) => ({
-    x: c.width / 2 + (i % 2 ? 1 : -1) * (i * 3),
-    y: c.height * 0.35,
-    vx: (Math.cos(i * 1.7) * (2 + (i % 5))),
-    vy: -6 - (i % 7),
-    s: 5 + (i % 4) * 2,
-    r: i * 0.9,
-    color: COLORS[i % COLORS.length],
-  }));
-  const t0 = performance.now();
-  (function frame(t) {
-    const dt = (t - t0) / 900; // ~0.9s of joy, then gone
-    ctx.clearRect(0, 0, c.width, c.height);
-    if (dt >= 1) { c.remove(); return; }
-    for (const p of parts) {
-      p.x += p.vx;
-      p.y += p.vy;
-      p.vy += 0.35; // gravity
-      p.r += 0.15;
-      ctx.save();
-      ctx.globalAlpha = 1 - dt;
-      ctx.translate(p.x, p.y);
-      ctx.rotate(p.r);
-      ctx.fillStyle = p.color;
-      ctx.fillRect(-p.s / 2, -p.s / 2, p.s, p.s * 0.6);
-      ctx.restore();
-    }
-    requestAnimationFrame(frame);
-  }(t0));
+  const wrap = document.createElement('div');
+  wrap.className = 'v2-burst';
+  wrap.style.cssText =
+    'position:fixed;left:50%;bottom:96px;width:0;height:0;pointer-events:none;z-index:120';
+  document.body.appendChild(wrap);
+
+  const ring = document.createElement('div');
+  ring.style.cssText =
+    'position:absolute;left:-28px;top:-28px;width:56px;height:56px;border-radius:50%;' +
+    'border:2.5px solid rgba(79,142,247,.55)';
+  wrap.appendChild(ring);
+  ring.animate(
+    [{ transform: 'scale(.3)', opacity: 1 }, { transform: 'scale(1.9)', opacity: 0 }],
+    { duration: 520, easing: 'cubic-bezier(.2,.8,.2,1)' },
+  );
+
+  const COLORS = ['#4f8ef7', '#7db1ff', '#1d8a44', '#f7b84f'];
+  for (let i = 0; i < 12; i += 1) {
+    const dot = document.createElement('div');
+    const s = 5 + (i % 3) * 3;
+    dot.style.cssText =
+      `position:absolute;left:${-s / 2}px;top:${-s / 2}px;width:${s}px;height:${s}px;` +
+      `border-radius:50%;background:${COLORS[i % COLORS.length]};opacity:0`;
+    wrap.appendChild(dot);
+    const ang = (Math.PI * (i + 0.5)) / 12 + Math.PI; // upward fan
+    const dist = 60 + (i % 4) * 22;
+    const dx = Math.cos(ang) * dist * ((i % 2) ? 1 : -1) * 0.6;
+    const dy = -Math.abs(Math.sin(ang)) * dist - 30;
+    dot.animate(
+      [
+        { transform: 'translate(0,0) scale(.4)', opacity: 0 },
+        { transform: `translate(${dx * 0.5}px,${dy * 0.6}px) scale(1)`, opacity: 1, offset: 0.35 },
+        { transform: `translate(${dx}px,${dy}px) scale(.5)`, opacity: 0 },
+      ],
+      { duration: 620 + (i % 5) * 40, delay: i * 14, easing: 'cubic-bezier(.16,.84,.3,1)' },
+    );
+  }
+  setTimeout(() => wrap.remove(), 950);
 }
 
-// ---- beat 2: the support card ------------------------------------------------------
+// ---- beat 2: the support card --------------------------------------------------------
 // deps = { toast }
 export function createCelebration(deps) {
   let shownThisSession = false;
   const card = document.getElementById('support-card');
 
-  function hide() { card.classList.remove('show'); }
+  function hide() {
+    card.classList.remove('show');
+    card.style.transform = ''; // reset any swipe offset
+  }
+
+  // Swipe-down to dismiss: it looks like a sheet, so it must behave like one.
+  let swipe = null;
+  card.addEventListener('pointerdown', (e) => {
+    if (e.target.closest('button, a, img')) return; // taps on controls stay taps
+    swipe = { y: e.clientY, id: e.pointerId, moved: false };
+    card.setPointerCapture(e.pointerId);
+  });
+  card.addEventListener('pointermove', (e) => {
+    if (!swipe || e.pointerId !== swipe.id) return;
+    const dy = e.clientY - swipe.y;
+    if (dy > 6) swipe.moved = true;
+    if (swipe.moved) card.style.transform = `translate(-50%, ${Math.max(0, dy)}px)`;
+  });
+  const endSwipe = (e) => {
+    if (!swipe || e.pointerId !== swipe.id) return;
+    const dy = e.clientY - swipe.y;
+    swipe = null;
+    if (dy > 56) hide();
+    else card.style.transform = ''; // spring back (CSS transition)
+  };
+  card.addEventListener('pointerup', endSwipe);
+  card.addEventListener('pointercancel', endSwipe);
 
   card.querySelector('#sc-close').addEventListener('click', hide);
   card.querySelector('#sc-never').addEventListener('click', () => {
     safeSet(OPTOUT_KEY, '1');
     hide();
-    deps.toast('Oke, nggak akan muncul lagi 👍');
+    deps.toast('Oke, nggak bakal muncul lagi');
   });
 
   card.querySelector('#sc-share').addEventListener('click', async () => {
@@ -87,27 +116,27 @@ export function createCelebration(deps) {
         hide();
       } else {
         await navigator.clipboard.writeText(`${SHARE_TEXT} ${SHARE_URL}`);
-        deps.toast('Link disalin — tinggal tempel ✓');
+        deps.toast('Udah disalin, tinggal kirim ke temanmu');
         hide();
       }
-    } catch { /* user cancelled the share sheet — keep the card, no nagging toast */ }
+    } catch { /* user cancelled the share sheet; keep the card, no nagging */ }
   });
 
   card.querySelector('#sc-donate').addEventListener('click', () => {
-    // Reveal the QR INLINE — never leave the editor (founder-locked).
+    // Reveal the QR INLINE, never leave the editor (founder-locked).
     card.classList.add('qr-open');
   });
 
   return {
     // The one hook: called by the app's shared download chokepoint.
     onDownloadSuccess() {
-      confetti(); // instant, independent of the card logic
+      burst(); // instant, independent of the card logic
       if (shownThisSession || safeGet(OPTOUT_KEY) === '1') return;
       shownThisSession = true;
       setTimeout(() => {
         card.classList.remove('qr-open');
         card.classList.add('show');
-      }, 1100); // after the confetti settles and the sheet has closed
+      }, 200); // right on the heels of the burst (founder: 1.1s was too slow)
     },
   };
 }

--- a/js/v2/download-sheet.js
+++ b/js/v2/download-sheet.js
@@ -66,7 +66,7 @@ export function createDownloadSheet(deps) {
       state.base = { bytes, size: bytes.length };
     } catch (err) {
       console.error(err);
-      if (seq === state.seq) deps.toast('Gagal menyiapkan PDF — coba lagi ya');
+      if (seq === state.seq) deps.toast('Waduh, gagal menyiapkan PDF. Coba lagi ya');
     } finally {
       if (seq === state.seq) { state.building = false; render(); }
     }
@@ -97,7 +97,7 @@ export function createDownloadSheet(deps) {
       state.compressed = { bytes: out.bytes, size: out.size, unchanged: out.unchanged };
     } catch (err) {
       console.error(err);
-      if (seq === state.seq) { state.size = 'asli'; deps.toast('Gagal mengompres — pakai ukuran asli ya'); }
+      if (seq === state.seq) { state.size = 'asli'; deps.toast('Kompres gagal, kami pakai ukuran asli ya'); }
     } finally {
       // Clear the flag UNCONDITIONALLY (review H1): a run superseded by ++seq
       // must not leave `compressing` wedged true — that blocked every future
@@ -185,7 +185,7 @@ export function createDownloadSheet(deps) {
         sub.textContent = `hemat ${Math.round((1 - state.compressed.size / state.base.size) * 100)}% dari ${fmtMB(state.base.size)}`;
         sub.hidden = false;
       } else if (state.size === 'kompres' && state.compressed?.unchanged) {
-        sub.textContent = 'sudah optimal — nggak bisa lebih kecil tanpa merusak';
+        sub.textContent = 'udah paling kecil, nggak bisa dikompres lagi tanpa merusak';
         sub.hidden = false;
       } else {
         sub.hidden = true;
@@ -255,7 +255,7 @@ export function createDownloadSheet(deps) {
         const src = state.size === 'kompres' ? state.compressed : state.base;
         if (!src) throw new Error('build missing');
         deps.download(new Blob([src.bytes], { type: 'application/pdf' }), `${baseName}-pdflokal.pdf`);
-        deps.toast(`PDF berhasil dibuat ✓ (${fmtMB(src.size)})`);
+        deps.toast(`Selesai! PDF-mu udah diunduh (${fmtMB(src.size)})`);
       } else {
         if (!state.base) throw new Error('build missing');
         const { renderPdfToImages, zipFiles } = await import('../core/export-images.js');
@@ -265,11 +265,11 @@ export function createDownloadSheet(deps) {
         if (files.length === 1) {
           const mime = state.imgfmt === 'png' ? 'image/png' : 'image/jpeg';
           deps.download(new Blob([files[0].bytes], { type: mime }), files[0].name);
-          deps.toast('Gambar berhasil dibuat ✓');
+          deps.toast('Selesai! Gambarmu udah diunduh');
         } else {
           const zip = zipFiles(files);
           deps.download(new Blob([zip], { type: 'application/zip' }), `${baseName}-gambar.zip`);
-          deps.toast(`${n} gambar dibungkus ZIP ✓`);
+          deps.toast(`Selesai! ${n} gambar dibungkus jadi satu ZIP`);
         }
       }
       // Richer than the old event: the CHOICES are the product signal now.
@@ -282,7 +282,7 @@ export function createDownloadSheet(deps) {
       modal.close();
     } catch (err) {
       console.error(err);
-      deps.toast('Gagal membuat file — coba lagi ya');
+      deps.toast('Waduh, gagal membuat file. Coba sekali lagi ya');
     } finally {
       state.exporting = false;
       render();

--- a/js/v2/page-manager.js
+++ b/js/v2/page-manager.js
@@ -387,7 +387,7 @@ export function createPageManager(deps) {
       track('editor_action', { action: 'delete_page' });
       render();
       deps.onDocChanged();
-      deps.toast(`${pages.length} halaman dihapus`);
+      deps.toast(`${pages.length} halaman dihapus. Salah? Tinggal Undo`);
     } else if (act === 'extract') {
       track('editor_action', { action: 'split' }); // old name kept: extract IS split
       deps.onExtract(pages);

--- a/tests/mobile/growth-loop.spec.js
+++ b/tests/mobile/growth-loop.spec.js
@@ -27,10 +27,10 @@ test.describe('growth loop — mobile', () => {
     await openDoc(page);
     await downloadOnce(page);
     // Confetti canvas exists briefly (fixed, pointer-events none), then self-removes.
-    await expect(page.locator('canvas[style*="pointer-events"]').last()).toBeAttached();
+    await expect(page.locator('.v2-burst')).toBeAttached();
     // The card arrives after the sheet closes.
     await expect(page.locator('#support-card')).toBeVisible({ timeout: 4000 });
-    await expect(page.locator('.sc-head')).toContainText('Berkas kamu jadi');
+    await expect(page.locator('.sc-head')).toContainText('filemu udah jadi');
 
     // Dismiss, download again: same session → no second ask.
     await page.tap('#sc-close');


### PR DESCRIPTION
- Celebration rebuilt: soft ring pulse + a dozen floating dots with spring
  easing (Web Animations API), ~0.7s, reads as 'success' not 'party'. The
  1990s rectangle confetti is dead.
- Support card: swipe-down dismisses it (it looks like a sheet, so it must
  behave like one; taps on buttons stay taps), arrives in 0.2s not 1.1s.
- Icons: every emoji-as-icon replaced with consistent stroke SVGs (share,
  coffee, file, pen, camera, lock, close X) matching the toolbar set.
- Copy humanized across v2: talking TO a person ('Selesai, filemu udah
  jadi!', 'Waduh, gagal... coba sekali lagi ya', 'Salah? Tinggal Undo').
  Share text now reads like a friend's message, not a brochure. Zero
  em-dashes anywhere a user reads.

145/145 + 21/21 green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
