### PR TITLE
feat(v2): support card asks once per calendar day, not once per session

### DIFF
--- a/js/v2/celebrate.js
+++ b/js/v2/celebrate.js
@@ -11,6 +11,7 @@
  */
 
 const OPTOUT_KEY = 'pdflokal-support-optout';
+const LAST_SHOWN_KEY = 'pdflokal-support-last';
 const SHARE_URL = 'https://www.pdflokal.id';
 // Written the way a friend would actually send it, not like a brochure.
 const SHARE_TEXT = 'Eh coba deh pdflokal.id, bisa edit + tanda tangan PDF langsung di HP. Gratis, dan filenya nggak diupload ke mana-mana.';
@@ -131,8 +132,14 @@ export function createCelebration(deps) {
     // The one hook: called by the app's shared download chokepoint.
     onDownloadSuccess() {
       burst(); // instant, independent of the card logic
+      // Once per CALENDAR DAY (founder call, Jul 3): heavy users get a gentle
+      // daily reminder that free has a sponsor, never a toll booth per file.
+      // shownThisSession stays as the fallback where localStorage is unwritable
+      // (private mode) so it degrades to once-per-session, not every download.
       if (shownThisSession || safeGet(OPTOUT_KEY) === '1') return;
+      if (safeGet(LAST_SHOWN_KEY) === new Date().toDateString()) return;
       shownThisSession = true;
+      safeSet(LAST_SHOWN_KEY, new Date().toDateString());
       setTimeout(() => {
         card.classList.remove('qr-open');
         card.classList.add('show');

--- a/tests/mobile/growth-loop.spec.js
+++ b/tests/mobile/growth-loop.spec.js
@@ -23,21 +23,33 @@ async function openDoc(page) {
 }
 
 test.describe('growth loop — mobile', () => {
-  test('download celebrates (confetti) and then invites — once per session', async ({ page }) => {
+  test('download celebrates (burst) and then invites — once per day', async ({ page }) => {
     await openDoc(page);
     await downloadOnce(page);
-    // Confetti canvas exists briefly (fixed, pointer-events none), then self-removes.
+    // Burst wrap exists briefly (fixed, pointer-events none), then self-removes.
     await expect(page.locator('.v2-burst')).toBeAttached();
     // The card arrives after the sheet closes.
     await expect(page.locator('#support-card')).toBeVisible({ timeout: 4000 });
     await expect(page.locator('.sc-head')).toContainText('filemu udah jadi');
 
-    // Dismiss, download again: same session → no second ask.
+    // Dismiss, download again: same day → no second ask.
     await page.tap('#sc-close');
     await expect(page.locator('#support-card')).toBeHidden();
     await downloadOnce(page);
     await page.waitForTimeout(1600);
     await expect(page.locator('#support-card')).toBeHidden();
+
+    // Even across a reload (fresh session, same calendar day) → still quiet.
+    await openDoc(page);
+    await downloadOnce(page);
+    await page.waitForTimeout(1600);
+    await expect(page.locator('#support-card')).toBeHidden();
+
+    // A NEW day → the card asks again (stub the day key to yesterday).
+    await page.evaluate(() => localStorage.setItem('pdflokal-support-last', 'yesterday'));
+    await openDoc(page);
+    await downloadOnce(page);
+    await expect(page.locator('#support-card')).toBeVisible({ timeout: 4000 });
   });
 
   test('Traktir Kopi reveals the QRIS inline — no navigation away', async ({ page }) => {
@@ -56,6 +68,8 @@ test.describe('growth loop — mobile', () => {
     await page.tap('#sc-never');
     await expect(page.locator('#support-card')).toBeHidden();
 
+    // Clear the once-a-day key so ONLY the opt-out can be keeping it hidden.
+    await page.evaluate(() => localStorage.removeItem('pdflokal-support-last'));
     await openDoc(page); // fresh page load, same storage
     await downloadOnce(page);
     await page.waitForTimeout(1600);


### PR DESCRIPTION
Founder call: heavy users should get a gentle daily reminder that free
has a sponsor — never a toll booth per file. Falls back to once-per-
session where localStorage is unwritable (private mode). Permanent
opt-out unchanged.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GSTkjTsoHVmrYm84C7MhLW
