### PR TITLE
feat(v2): the physical-document language — stamps, stempel-press, held-paper drag

### DIFF
--- a/editor-v2.html
+++ b/editor-v2.html
@@ -95,11 +95,13 @@
     }
     .icon-btn:disabled { opacity: .3; cursor: default; }
     .icon-btn svg { width: 20px; height: 20px; }
+    /* Stempel-press: primary actions sink like a stamp being pressed. */
     #btn-download {
       background: var(--accent); color: #fff; font-weight: 600; font-size: 13.5px;
-      padding: 0 14px; border-radius: 8px;
+      padding: 0 14px; border-radius: 8px; box-shadow: 0 2px 0 var(--accent-down);
     }
-    #btn-download:disabled { opacity: .4; }
+    #btn-download:active:not(:disabled) { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    #btn-download:disabled { opacity: .4; box-shadow: none; }
 
     /* ---- toolbar: tools are verbs; ≥44px targets; nothing hover-only ---- */
     #toolbar {
@@ -258,10 +260,11 @@
       min-height: 44px;
     }
     .pm-tile.sel { border-color: var(--accent); }
-    /* The lifted page (FLIP drag): reads as a physical sheet in your hand. */
+    /* The lifted page (FLIP drag): reads as a physical sheet in your hand —
+       warm desk shadow + the slight tilt of held paper (rotation set in JS). */
     .pm-drag-ghost {
-      box-shadow: 0 10px 28px rgba(0,0,0,.28), 0 2px 8px rgba(0,0,0,.18);
-      opacity: .95; cursor: grabbing;
+      box-shadow: 0 14px 30px rgba(63,49,35,.32), 0 3px 10px rgba(63,49,35,.2);
+      opacity: .97; cursor: grabbing;
     }
     .pm-placeholder {
       border-style: dashed; border-color: var(--accent);
@@ -374,9 +377,11 @@
       background: var(--accent); color: #fff; font: inherit; font-weight: 700; font-size: 15px;
       display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 1px;
       margin-top: 4px; font-variant-numeric: tabular-nums;
+      box-shadow: 0 3px 0 var(--accent-down); /* the deepest press: it commits the file */
     }
+    .ds-cta:active:not(:disabled) { transform: translateY(2px); box-shadow: 0 1px 0 var(--accent-down); }
     .ds-cta small { font-weight: 500; font-size: 11px; opacity: .85; }
-    .ds-cta:disabled { opacity: .6; }
+    .ds-cta:disabled { opacity: .6; box-shadow: none; }
 
     /* pick-mode bar inside Kelola Halaman */
     .pm-pickbar {

--- a/js/render/page-view.js
+++ b/js/render/page-view.js
@@ -32,7 +32,7 @@ export function renderPageView(page, opts = {}) {
   const h = rotated ? page.width : page.height;
   view.style.cssText =
     `position:relative;flex:0 0 auto;width:${w}px;height:${h}px;` +
-    'background:#fff;box-shadow:0 2px 14px rgba(0,0,0,.14);border-radius:2px';
+    'background:#fff;box-shadow:0 2px 12px rgba(63,49,35,.16);border-radius:2px';
 
   // Intentional placeholder text (e.g. "Hal 42") so a flung-past page reads as
   // "loading", not "broken". Stored on the view so clearPageRaster can reuse it.

--- a/js/v2/app.js
+++ b/js/v2/app.js
@@ -647,7 +647,7 @@ async function loadFilesInner(files) {
     zoom = Math.min(1, (scrollEl.clientWidth - 16) / doc.pages[0].width);
   }
   rebuildStage(); // applies zoom + sizer at the end
-  if (!firstLoad) toast(`${usable.length} file ditambahkan`);
+  if (!firstLoad) toast(`Dijepit jadi satu, sekarang ${doc.pages.length} halaman`);
   // If the Halaman sheet triggered this add, refresh its grid in place.
   if (document.getElementById('pm-sheet').open) pageManager.render();
 }

--- a/js/v2/celebrate.js
+++ b/js/v2/celebrate.js
@@ -2,12 +2,14 @@
  * PDFLokal — v2/celebrate.js  (the download moment: reward, then invite)
  * ============================================================================
  * The download is the emotional peak. Two beats, in the founder's order:
- *   1. CELEBRATE: a modern micro-burst (soft ring pulse + floating dots with
- *      spring easing, Web Animations API). Quick, quiet, gone in ~0.7s.
- *      Founder killed the 1990s rectangle confetti, rightly.
+ *   1. CELEBRATE: the BERES stamp (stempel language — "cap = pernyataan
+ *      status", see memory/design-language-2026-07.md). Thunk, gone in ~1.5s.
  *   2. INVITE: one dismissible card (share PDFLokal or tip via QRIS inline).
- *      Swipe-down dismisses it like any sheet. Once per session, permanent
- *      opt-out. The file is already saved; nothing is ever held hostage.
+ *      Swipe-down dismisses it like any sheet. Once per calendar day,
+ *      permanent opt-out. The file is already saved; never held hostage.
+ * This module also owns the other stamp moments: TAMPILAN BARU (once per
+ * device) and TETAP JALAN (offline mid-session). SUDAH OPTIMAL lives in
+ * download-sheet.js, BARU in the future changelog.
  */
 
 const OPTOUT_KEY = 'pdflokal-support-optout';
@@ -24,49 +26,43 @@ function safeSet(key, val) {
   try { localStorage.setItem(key, val); } catch { /* private mode, session-only */ }
 }
 
-// ---- beat 1: the burst ------------------------------------------------------------
-// One expanding ring + a dozen soft dots that spring up and drift out, all
-// GPU-composited transforms/opacity via WAAPI. Reads as "success", not "party".
-function burst() {
-  if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) return;
-  const wrap = document.createElement('div');
-  wrap.className = 'v2-burst';
-  wrap.style.cssText =
-    'position:fixed;left:50%;bottom:96px;width:0;height:0;pointer-events:none;z-index:120';
-  document.body.appendChild(wrap);
+// ---- the stamp language -----------------------------------------------------------
+// "Cap = pernyataan status": a stamp asserts the document's status, exactly like
+// a real stempel, and is never decoration. Exactly five moments earn one (see
+// memory/design-language-2026-07.md). Distressed texture is a CSS feTurbulence
+// mask — zero assets, cheap on 1-juta phones.
+const STAMP_MASK = 'url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\' width=\'120\' height=\'120\'><filter id=\'n\'><feTurbulence baseFrequency=\'.75\'/></filter><rect width=\'120\' height=\'120\' filter=\'url(%23n)\' opacity=\'.9\'/></svg>")';
 
-  const ring = document.createElement('div');
-  ring.style.cssText =
-    'position:absolute;left:-28px;top:-28px;width:56px;height:56px;border-radius:50%;' +
-    'border:2.5px solid rgba(220,38,38,.5)';
-  wrap.appendChild(ring);
-  ring.animate(
-    [{ transform: 'scale(.3)', opacity: 1 }, { transform: 'scale(1.9)', opacity: 0 }],
-    { duration: 520, easing: 'cubic-bezier(.2,.8,.2,1)' },
-  );
-
-  const COLORS = ['#dc2626', '#f87171', '#1d8a44', '#f7b84f'];
-  for (let i = 0; i < 12; i += 1) {
-    const dot = document.createElement('div');
-    const s = 5 + (i % 3) * 3;
-    dot.style.cssText =
-      `position:absolute;left:${-s / 2}px;top:${-s / 2}px;width:${s}px;height:${s}px;` +
-      `border-radius:50%;background:${COLORS[i % COLORS.length]};opacity:0`;
-    wrap.appendChild(dot);
-    const ang = (Math.PI * (i + 0.5)) / 12 + Math.PI; // upward fan
-    const dist = 60 + (i % 4) * 22;
-    const dx = Math.cos(ang) * dist * ((i % 2) ? 1 : -1) * 0.6;
-    const dy = -Math.abs(Math.sin(ang)) * dist - 30;
-    dot.animate(
+// opts.anchor: 'center' | 'bottom'. opts.host: element to append into — pass the
+// open <dialog> when stamping over one (fixed children of a top-layer dialog
+// paint above it; a body-appended stamp would be hidden underneath).
+export function showStamp(text, { anchor = 'center', duration = 1500, host = document.body } = {}) {
+  const el = document.createElement('div');
+  el.className = 'v2-stamp';
+  el.textContent = text;
+  const pos = anchor === 'bottom' ? 'bottom:110px' : 'top:34%';
+  el.style.cssText =
+    `position:fixed;left:50%;${pos};z-index:130;pointer-events:none;` +
+    'padding:8px 18px;border:3.5px solid #dc2626;border-radius:8px;color:#dc2626;' +
+    'font-weight:700;font-size:21px;letter-spacing:.08em;text-transform:uppercase;' +
+    'background:rgba(250,248,244,.72);white-space:nowrap;' +
+    `-webkit-mask-image:${STAMP_MASK};mask-image:${STAMP_MASK};` +
+    'transform:translateX(-50%) rotate(-6deg);';
+  host.appendChild(el);
+  if (!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+    el.animate(
       [
-        { transform: 'translate(0,0) scale(.4)', opacity: 0 },
-        { transform: `translate(${dx * 0.5}px,${dy * 0.6}px) scale(1)`, opacity: 1, offset: 0.35 },
-        { transform: `translate(${dx}px,${dy}px) scale(.5)`, opacity: 0 },
+        { transform: 'translateX(-50%) rotate(-14deg) scale(2.1)', opacity: 0 },
+        { transform: 'translateX(-50%) rotate(-6deg) scale(.96)', opacity: 1, offset: 0.55 },
+        { transform: 'translateX(-50%) rotate(-6deg) scale(1)', opacity: 1 },
       ],
-      { duration: 620 + (i % 5) * 40, delay: i * 14, easing: 'cubic-bezier(.16,.84,.3,1)' },
+      { duration: 420, easing: 'cubic-bezier(.34,1.45,.44,1)' },
     );
+    el.animate([{ opacity: 1 }, { opacity: 0 }], {
+      duration: 280, delay: duration - 280, fill: 'forwards',
+    });
   }
-  setTimeout(() => wrap.remove(), 950);
+  setTimeout(() => el.remove(), duration);
 }
 
 // ---- beat 2: the support card --------------------------------------------------------
@@ -74,6 +70,23 @@ function burst() {
 export function createCelebration(deps) {
   let shownThisSession = false;
   const card = document.getElementById('support-card');
+
+  // TAMPILAN BARU: once per device, the revamp announces itself. A stamp, not
+  // a tour — one thunk and it's gone.
+  if (safeGet('pdflokal-seen-revamp') !== '1') {
+    safeSet('pdflokal-seen-revamp', '1');
+    setTimeout(() => showStamp('Tampilan baru'), 900);
+  }
+
+  // TETAP JALAN: connection dies, PDFLokal doesn't (no server in the loop).
+  // The moat made visible — once per session, only while a page is open.
+  let offlineShown = false;
+  window.addEventListener('offline', () => {
+    if (offlineShown) return;
+    offlineShown = true;
+    showStamp('Tetap jalan', { duration: 1800 });
+    deps.toast('Internet putus. Tenang, semuanya jalan di HP-mu, bukan di server.');
+  });
 
   function hide() {
     card.classList.remove('show');
@@ -131,7 +144,7 @@ export function createCelebration(deps) {
   return {
     // The one hook: called by the app's shared download chokepoint.
     onDownloadSuccess() {
-      burst(); // instant, independent of the card logic
+      showStamp('Beres ✓'); // stamped on the document (center); the card owns the bottom
       // Once per CALENDAR DAY (founder call, Jul 3): heavy users get a gentle
       // daily reminder that free has a sponsor, never a toll booth per file.
       // shownThisSession stays as the fallback where localStorage is unwritable

--- a/js/v2/download-sheet.js
+++ b/js/v2/download-sheet.js
@@ -16,6 +16,7 @@
 
 import { buildPdfBytes } from '../core/export.js';
 import { track } from '../lib/analytics.js';
+import { showStamp } from './celebrate.js';
 
 const COMPRESS_QUALITY = 0.72; // the ONE preset (founder call: no levels until data asks)
 const COMPRESS_MAXDIM = 1600;
@@ -95,6 +96,12 @@ export function createDownloadSheet(deps) {
       });
       if (seq !== state.seq) return;
       state.compressed = { bytes: out.bytes, size: out.size, unchanged: out.unchanged };
+      // SUDAH OPTIMAL: the honesty guard gets a face. The file was already as
+      // small as it honestly gets — we say so with a stamp instead of faking
+      // savings. Stamped INTO the dialog (top layer covers body-fixed elements).
+      if (out.unchanged && modal.open) {
+        showStamp('Sudah optimal', { duration: 1300, host: modal });
+      }
     } catch (err) {
       console.error(err);
       if (seq === state.seq) { state.size = 'asli'; deps.toast('Kompres gagal, kami pakai ukuran asli ya'); }
@@ -254,8 +261,8 @@ export function createDownloadSheet(deps) {
       if (state.format === 'pdf') {
         const src = state.size === 'kompres' ? state.compressed : state.base;
         if (!src) throw new Error('build missing');
+        // No success toast: the BERES stamp (download chokepoint) is the one voice.
         deps.download(new Blob([src.bytes], { type: 'application/pdf' }), `${baseName}-pdflokal.pdf`);
-        deps.toast(`Selesai! PDF-mu udah diunduh (${fmtMB(src.size)})`);
       } else {
         if (!state.base) throw new Error('build missing');
         const { renderPdfToImages, zipFiles } = await import('../core/export-images.js');
@@ -265,7 +272,6 @@ export function createDownloadSheet(deps) {
         if (files.length === 1) {
           const mime = state.imgfmt === 'png' ? 'image/png' : 'image/jpeg';
           deps.download(new Blob([files[0].bytes], { type: mime }), files[0].name);
-          deps.toast('Selesai! Gambarmu udah diunduh');
         } else {
           const zip = zipFiles(files);
           deps.download(new Blob([zip], { type: 'application/zip' }), `${baseName}-gambar.zip`);

--- a/js/v2/page-manager.js
+++ b/js/v2/page-manager.js
@@ -272,7 +272,7 @@ export function createPageManager(deps) {
     function dragLoop() {
       if (!drag) return;
       tile.style.transform =
-        `translate(${drag.lastX - start.x}px, ${drag.lastY - start.y}px) scale(1.04)`;
+        `translate(${drag.lastX - start.x}px, ${drag.lastY - start.y}px) scale(1.045) rotate(1.5deg)`;
 
       // Auto-scroll: proportional to how deep the finger is in the edge zone.
       const gr = grid.getBoundingClientRect();

--- a/tests/mobile/growth-loop.spec.js
+++ b/tests/mobile/growth-loop.spec.js
@@ -23,11 +23,11 @@ async function openDoc(page) {
 }
 
 test.describe('growth loop — mobile', () => {
-  test('download celebrates (burst) and then invites — once per day', async ({ page }) => {
+  test('download celebrates (BERES stamp) and then invites — once per day', async ({ page }) => {
     await openDoc(page);
     await downloadOnce(page);
-    // Burst wrap exists briefly (fixed, pointer-events none), then self-removes.
-    await expect(page.locator('.v2-burst')).toBeAttached();
+    // The stamp exists briefly (fixed, pointer-events none), then self-removes.
+    await expect(page.locator('.v2-stamp', { hasText: 'Beres' })).toBeAttached();
     // The card arrives after the sheet closes.
     await expect(page.locator('#support-card')).toBeVisible({ timeout: 4000 });
     await expect(page.locator('.sc-head')).toContainText('filemu udah jadi');

--- a/tests/mobile/stamps.spec.js
+++ b/tests/mobile/stamps.spec.js
@@ -1,0 +1,52 @@
+/*
+ * The stamp language: "cap = pernyataan status" — a stamp asserts document
+ * status, never decorates (memory/design-language-2026-07.md). Five moments:
+ * BERES (growth-loop.spec) · TAMPILAN BARU · TETAP JALAN · SUDAH OPTIMAL ·
+ * BARU (changelog, future). These specs cover the three new ones.
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(__dirname, '..', 'fixtures', 'sample-2pages.pdf');
+
+test.describe('stamp moments — mobile', () => {
+  test('TAMPILAN BARU shows once per device, then never again', async ({ page }) => {
+    await page.goto('/editor-v2.html');
+    await expect(page.locator('.v2-stamp', { hasText: 'Tampilan baru' }))
+      .toBeAttached({ timeout: 3000 });
+    // Same device (storage persists): a reload stays quiet.
+    await page.reload();
+    await page.waitForTimeout(1800);
+    await expect(page.locator('.v2-stamp')).toHaveCount(0);
+  });
+
+  test('TETAP JALAN when the connection drops mid-session — once', async ({ page }) => {
+    await page.goto('/editor-v2.html');
+    await page.setInputFiles('#file-input', FIXTURE);
+    await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+    await page.waitForTimeout(2600); // let the welcome stamp come and go
+    await page.evaluate(() => window.dispatchEvent(new Event('offline')));
+    await expect(page.locator('.v2-stamp', { hasText: 'Tetap jalan' })).toBeAttached();
+    await expect(page.locator('#toast')).toContainText('jalan di HP-mu');
+    // Second drop in the same session: no repeat theater.
+    await page.waitForTimeout(2200);
+    await page.evaluate(() => window.dispatchEvent(new Event('offline')));
+    await page.waitForTimeout(600);
+    await expect(page.locator('.v2-stamp')).toHaveCount(0);
+  });
+
+  test('SUDAH OPTIMAL when compress finds nothing to save — stamped over the sheet', async ({ page }) => {
+    await page.goto('/editor-v2.html');
+    await page.setInputFiles('#file-input', FIXTURE);
+    await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+    await page.tap('#btn-download');
+    // The tiny text-only fixture cannot shrink: the honesty guard returns the
+    // original bytes and the segment says so; the stamp gives it a face.
+    await page.tap('text=Compress');
+    await expect(page.locator('#dl-sheet .v2-stamp', { hasText: 'Sudah optimal' }))
+      .toBeAttached({ timeout: 8000 });
+    await expect(page.locator('#dl-sheet')).toContainText('file sudah optimal');
+  });
+});


### PR DESCRIPTION
Design language ratified with founder (memory/design-language-2026-07.md):
- Stamp language, 'cap = pernyataan status': BERES on the document at
  download (replaces dot burst + redundant success toasts), TAMPILAN BARU
  once per device, TETAP JALAN when connection drops mid-session (once),
  SUDAH OPTIMAL over the sheet when the compress honesty guard fires.
  Distressed texture = CSS feTurbulence mask, zero assets.
- Stempel-press: Unduh + sheet CTA sink on tap (deepest press = commits
  the file).
- Held paper: drag ghost gets warm desk shadow + 1.5deg tilt; page slots
  get warm shadows.
- Paperclip microcopy: adding files toasts 'Dijepit jadi satu'.

3 new stamp tests. Full sweep green: 146 Playwright + lint.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GSTkjTsoHVmrYm84C7MhLW
