### PR TITLE
fix(landing): desktop goes tool-first — single column, no marketing hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,17 +392,15 @@
     .ld-foot { padding: 30px 0 40px; display: flex; gap: 18px; align-items: baseline; flex-wrap: wrap; }
     .ld-foot a { font-size: 13px; color: var(--muted); text-decoration: none; min-height: 44px; display: inline-flex; align-items: center; }
     .ld-foot span { margin-left: auto; font-size: 12px; color: var(--muted); }
-    /* desktop composition (founder, Jul 4: the 620px column drowned in margin) */
+    /* desktop composition (founder, Jul 4 rd2: single tool-first column —
+       "tooly, not marketingy". Wider than mobile so it doesn't drown in
+       margin, but the flow stays headline -> dropzone -> cards, top down. */
     @media (min-width: 900px) {
-      .ld { max-width: 1020px; padding: 0 40px 8px; }
-      .ld-hero {
-        display: grid; grid-template-columns: 1.05fr 1fr; gap: 48px;
-        align-items: center; padding: 22px 0 0;
-      }
-      .ld h1 { font-size: 44px; margin-top: 18px; }
+      .ld { max-width: 840px; padding: 0 32px 8px; }
+      .ld h1 { font-size: 40px; margin-top: 26px; }
       .ld-sub { font-size: 16px; }
-      .dropzone { padding: 44px 24px 38px; }
-      .ld-grid { grid-template-columns: repeat(auto-fill, minmax(215px, 1fr)); }
+      .dropzone { padding: 42px 24px 36px; }
+      .ld-grid { grid-template-columns: repeat(4, 1fr); } /* top-4 = one clean row */
       .ld-card:hover { border-color: rgba(220,38,38,.45); }
       .dropzone:hover { border-color: var(--accent); background: rgba(220,38,38,.04); }
       .ld-faq, .ld-janji { max-width: 720px; }


### PR DESCRIPTION
Founder: the 2-col hero read 'marketingy instead of tooly'. Back to the
old layout's spirit: headline, dropzone, cards, top down, one column —
just wider (840px) so it doesn't drown in margin. Top-4 cards are one
clean 4-across row.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GSTkjTsoHVmrYm84C7MhLW
