### PR TITLE
fix(v2): drag always settles + home-confirm joins the sheet system

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,15 +133,10 @@
     }
     .brand { font-weight: 700; font-size: 15px; letter-spacing: -.01em; }
     .brand-red { color: var(--accent); }
-    /* home confirm: a small centered card, not a full-screen overlay */
-    #home-confirm {
-      margin: auto; border: none; border-radius: 16px; padding: 20px 20px 16px;
-      max-width: min(88vw, 340px); box-shadow: 0 12px 40px rgba(33,29,26,.3);
-      font: inherit; color: var(--ink);
-    }
-    #home-confirm::backdrop { background: rgba(33,29,26,.45); }
-    #home-confirm b { font-size: 15.5px; letter-spacing: -.01em; }
-    #home-confirm p { font-size: 13px; color: var(--muted); margin: 5px 0 14px; }
+    /* home confirm: rides the standard dialog/.sheet system (the global
+       dialog rule IS the dark overlay — a bespoke dialog fights it and loses) */
+    .hc-sheet { max-width: 340px; }
+    .hc-sheet p { font-size: 13px; color: var(--muted); margin: -6px 0 2px; }
     .hc-row { display: flex; gap: 8px; }
     .hc-row button {
       flex: 1; min-height: 44px; border-radius: 10px; font-weight: 700; font-size: 13.5px;
@@ -857,11 +852,13 @@
   <div id="toast" role="status" aria-live="polite"></div>
 
   <dialog id="home-confirm" aria-label="Kembali ke beranda">
-    <b>Kembali ke beranda?</b>
-    <p>Editanmu bakal hilang kalau belum kamu unduh.</p>
-    <div class="hc-row">
-      <button id="hc-cancel">Batal</button>
-      <button id="hc-go">Ke Beranda</button>
+    <div class="sheet hc-sheet">
+      <h2>Kembali ke beranda?</h2>
+      <p>Editanmu bakal hilang kalau belum kamu unduh.</p>
+      <div class="hc-row">
+        <button id="hc-cancel">Batal</button>
+        <button id="hc-go">Ke Beranda</button>
+      </div>
     </div>
   </dialog>
 

--- a/js/v2/page-manager.js
+++ b/js/v2/page-manager.js
@@ -262,6 +262,21 @@ export function createPageManager(deps) {
       recacheSlots();
       // The pointer may be gone by the time the long-press timer fires.
       try { tile.setPointerCapture(e.pointerId ?? start.id); } catch { /* keep dragging uncaptured */ }
+      // WHY window listeners: the lifted tile has pointerEvents:none, so if
+      // pointer capture fails or is lost mid-drag, its own pointerup never
+      // fires and the ghost hangs in the air with its placeholder (founder-
+      // caught, Jul 4, desktop). The window hears the release no matter where
+      // it lands — even outside the dialog. Removed in end().
+      drag.winMove = (ev) => {
+        if (!drag) return;
+        ev.preventDefault();
+        drag.lastX = ev.clientX;
+        drag.lastY = ev.clientY;
+      };
+      drag.winEnd = (ev) => end(ev);
+      window.addEventListener('pointermove', drag.winMove);
+      window.addEventListener('pointerup', drag.winEnd);
+      window.addEventListener('pointercancel', drag.winEnd);
       if (navigator.vibrate) navigator.vibrate(10);
       requestAnimationFrame(dragLoop);
     }
@@ -320,6 +335,9 @@ export function createPageManager(deps) {
       if (drag) {
         const d = drag;
         drag = null; // stops the loop
+        window.removeEventListener('pointermove', d.winMove);
+        window.removeEventListener('pointerup', d.winEnd);
+        window.removeEventListener('pointercancel', d.winEnd);
         // Settle target from LAYOUT coords (a mid-glide placeholder's gBCR lies).
         const gr = grid.getBoundingClientRect();
         const slotLeft = gr.left + d.placeholder.offsetLeft - grid.scrollLeft;

--- a/tests/editor-v2-desktop.spec.js
+++ b/tests/editor-v2-desktop.spec.js
@@ -114,3 +114,31 @@ test.describe('select-then-edit model — desktop', () => {
     await expect(page.locator('.pv-anno-text')).toHaveCSS('color', 'rgb(139, 92, 246)');
   });
 });
+
+// Founder-caught (Jul 4, desktop): if pointer capture fails mid-drag, the
+// lifted tile (pointerEvents:none) never hears pointerup — the ghost hung in
+// the air with its placeholder until later reorders. Window-level listeners
+// now own the drag lifetime; this test forces the capture failure.
+test('Kelola drag settles even when pointer capture fails', async ({ page }) => {
+  await page.goto('/');
+  await page.setInputFiles('#file-input', FIXTURE);
+  await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+  await page.click('#btn-pages');
+  await expect(page.locator('#pm-sheet')).toBeVisible();
+  await page.evaluate(() => {
+    Element.prototype.setPointerCapture = () => { throw new Error('capture denied'); };
+  });
+
+  const tile = await page.locator('.pm-tile:not(.pm-add)').first().elementHandle();
+  const box = await tile.boundingBox();
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  // Past DRAG_SLOP arms the mouse drag, then wander and release elsewhere.
+  await page.mouse.move(box.x + box.width / 2 + 40, box.y + 20, { steps: 4 });
+  await page.mouse.move(box.x + box.width + 120, box.y + box.height / 2, { steps: 6 });
+  await page.mouse.up();
+
+  await page.waitForTimeout(500); // glide + settle window
+  await expect(page.locator('.pm-drag-ghost')).toHaveCount(0);
+  await expect(page.locator('.pm-placeholder')).toHaveCount(0);
+});


### PR DESCRIPTION
Kelola Halaman ghost hung mid-air (founder screenshots, desktop): the
lifted tile has pointerEvents:none, so when pointer capture failed or
was lost, its own pointerup never fired — no settle, no render, ghost +
placeholder stuck until a later reorder repainted. Window-level
pointermove/up/cancel listeners now own the drag lifetime (removed at
end); release lands anywhere — outside the dialog included — and it
settles. Regression test forces setPointerCapture to throw.

home-confirm rendered as a naked dark strip: the global dialog rule IS
a full-screen overlay expecting a .sheet child; the bespoke dialog CSS
fought it and lost. Now rides .sheet like every other dialog.

Full sweep: 156 Playwright + lint green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GSTkjTsoHVmrYm84C7MhLW
