### PR TITLE
feat(v2): carried-signature ghost + ketuk→pilih copy sweep

### DIFF
--- a/backlog.md
+++ b/backlog.md
@@ -13,14 +13,15 @@ Running list of UI/UX findings + small fixes to pick up later. Append new items 
 
 ## Open
 
+- **[high — investigate FIRST, no fix yet: root cause unknown]** Production `client_error` events firing on the editor surface — [js/lib/errors.js](js/lib/errors.js), GA4 property 528550405, Sentry
+  - Signal (GA4, Jun 25–Jul 3, ID-only): **18 client_errors in 9 days (~2/day), all on `/`** (the editor). Breakdown: 8 desktop Win/Chrome · 7 desktop Mac/Chrome · 2 mobile Android/Chrome · 1 Mac `/index.html`. So overwhelmingly **desktop Chrome**, NOT a mobile-specific crash.
+  - **Why there's no fix here yet — we're blind on the message:** the error hook sends `kind/message/source/line/col/stack` (errors.js:37,50) but (a) Sentry needs OAuth (couldn't read it in the session that logged this), and (b) **GA4 has ZERO custom dimensions registered**, so the message/stack params are discarded at the reporting layer — only the event count survives. Can't propose a code change without the message.
+  - **Fastest path to root cause (do one):** (1) read the Sentry notification/issue directly (founder has it), OR (2) check the Vercel Analytics custom-event dashboard — `track()` bridges there and may show `message` as a column, OR (3) reproduce on desktop Chrome on `/` with DevTools console open.
+  - **Enabler fix (do regardless — makes ALL future errors self-diagnosing without Sentry):** register the client_error params as **GA4 custom dimensions** (`message`, `source`, `line`, `kind` at minimum) in GA4 Admin → Custom definitions. 5-min admin task, no code change. This is the long-outstanding "instrument GA4 custom dimensions" TODO from `docs/product-definition.md` §11. Once registered, this same query returns the actual error text and the fix becomes obvious.
+  - Pre-ads relevance: worth closing before the ads spend so the mobile ad cohort isn't hitting a silent break — though current data says the errors are desktop, not the mobile flow the ads target.
+
 - **[med, WAIT until ~Jul 5-6, decide with data]** Kelola Halaman hides its powers — users can be clueless about what the sheet can do (reorder/split/rotate/delete). Founder idea: explicit verb buttons (Tambah, Split, ...) or a mini tutorial — BUT deliberately wait ~2 days from Jul 3 launch and check analytics whether editor_action reorder/split/gabungkan_used happen organically before adding UI. [js/v2/page-manager.js]
 
-
-- **[founder desktop pass Jul 3 — v2 signature (tandatangan) punch list]** Two findings from the same session:
-  1. **[high]** Placement state needs a "carried object" telegraph. After the user draws a TTD and the flow enters the "tap a spot to place it" state, nothing signals what to do. Desktop: the signature should **stick transparently to the cursor** (ghost preview following the pointer) until they click to drop it. Mobile (no cursor): the **"Ketuk halaman untuk menempatkan tanda tangan" hint should PERSIST for the whole placement state** (not flash once) so the user always knows they're mid-placement. This is the INTENT/BEFORE telegraph from the "chef's kiss" item applied to signatures — treat as high because without it the placement state is a dead end users get stuck in. [js/v2/signature-modal.js + js/v2/app.js placement state]
-  2. **[low]** Signature/TTD toolbar (format/action bar for the signature tool) should be center-aligned too — same fix as the text format bar item 1. [js/v2 signature bar layout]
-
-- **[low]** Global copy sweep: change every user-facing instance of **"ketuk" → "pilih"** — founder feels "pilih" reads more natural. Covers hint strings like "Ketuk halaman untuk menempatkan tanda tangan" → "Pilih halaman..." and the "Ketuk halaman untuk tanda tangan" example in the telegraph item above. Grep all v2 + shared user-facing strings for "etuk" (catches Ketuk/ketuk); do NOT touch code identifiers, only display copy. [js/v2/*, index.html, any Indonesian UI strings]
 
 - **[decided Jul 2]** Watermark + page-number + Kunci PDF UI: NOT built in v2 (3-month analytics: <0.5% each — 7/3/3 visitors). Engine + export support stays tested, so reintroduction = one button. Revisit only if users ask.
 - **[decided Jul 2]** Desktop sidebar: NOT rebuilt in v2. One assemble surface (Kelola Halaman) on all devices; the desktop ergonomics pass may dock the SAME sheet as a side panel on wide screens — one component, two positions, never two implementations.
@@ -108,6 +109,8 @@ Running list of UI/UX findings + small fixes to pick up later. Append new items 
 ---
 
 ## Done
+
+- **Signature punch list + copy sweep (founder findings Jul 3-4)** — SHIPPED (Jul 4): carried-signature ghost on desktop (the drawn TTD rides the cursor at placement size × zoom, translucent, until click drops it; touch keeps the persistent sig-bar hint); sig-bar centering landed with #105; ketuk→pilih sweep across all display copy ("Pilih tempat untuk menempatkan tanda tangan", "Pilih halaman · tahan lalu geser...", zero "ketuk" remaining). Also fixed same-day: Kelola drag ghost hanging mid-air (window-owned drag lifetime, capture-failure regression test) + home-confirm dialog joining the .sheet system.
 
 - **Desktop text-tool punch list (founder findings Jul 3)** — SHIPPED (Jul 4): (1+2) format bar + sig bar now FLOAT over the canvas (frosted, zero document jump — verified 0px) and center on desktop; (3) select-then-edit interaction model: first click selects (drag-enabled), click on already-selected (or double-click) edits — root cause was a phantom double-click (pointerdown+pointerup both registered as taps 50ms apart), the double-tap timing machinery is GONE, replaced by release-without-drag-on-selected; (4) full color picker (native color input in swatch costume, live preview while dragging). 4 new desktop specs.
 

--- a/index.html
+++ b/index.html
@@ -889,7 +889,7 @@
     <div class="sheet pm-sheet-body">
       <div class="pm-head">
         <h2>Kelola Halaman</h2>
-        <span class="pm-hint">Ketuk untuk memilih · tahan lalu geser untuk mengurutkan</span>
+        <span class="pm-hint">Pilih halaman · tahan lalu geser untuk mengurutkan</span>
         <button class="btn-ghost" id="pm-close" aria-label="Tutup"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="width:14px;height:14px"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg></button>
       </div>
       <div id="pm-grid" class="pm-grid"></div>
@@ -901,7 +901,7 @@
         <button data-act="clear" class="btn-ghost">Batal</button>
       </div>
       <div id="pm-pickbar" class="pm-pickbar">
-        <span class="note">Ketuk halaman yang mau diunduh</span>
+        <span class="note">Pilih halaman yang mau diunduh</span>
         <button class="btn-ghost" id="pm-pick-cancel">Batal</button>
         <button class="btn-primary" id="pm-pick-ok">Pakai (0)</button>
       </div>

--- a/js/v2/app.js
+++ b/js/v2/app.js
@@ -245,6 +245,10 @@ function syncFormatBar() {
 // ---- tools ----------------------------------------------------------------------
 function setTool(next) {
   tool = next;
+  if (next !== 'signature') {
+    const g = document.getElementById('sig-ghost');
+    if (g) g.style.display = 'none';
+  }
   for (const btn of document.querySelectorAll('#toolbar .tool[data-tool]')) {
     const active = btn.dataset.tool === next;
     btn.classList.toggle('active', active);
@@ -260,18 +264,49 @@ for (const btn of document.querySelectorAll('#toolbar .tool[data-tool]')) {
     const t = btn.dataset.tool;
     if (t === 'signature' && !storedSignature) { signatureModal.open(); return; }
     setTool(t);
-    if (t === 'text') toast('Ketuk halaman untuk menulis');
+    if (t === 'text') toast('Pilih tempat untuk menulis');
     if (t === 'whiteout') toast('Seret di halaman untuk menutup teks');
-    if (t === 'signature') toast('Ketuk halaman untuk menempatkan tanda tangan');
+    if (t === 'signature') toast('Pilih tempat untuk menempatkan tanda tangan');
   });
 }
+
+// ---- carried-signature ghost (desktop telegraph, founder Jul 3) -------------------
+// After drawing a TTD, the "place it" state must be visible: on fine pointers
+// the signature itself rides the cursor, translucent, until the click drops
+// it. Touch has no cursor — there the persistent sig-bar hint does this job.
+const sigGhost = document.createElement('img');
+sigGhost.id = 'sig-ghost';
+sigGhost.alt = '';
+sigGhost.style.cssText =
+  'position:fixed;z-index:70;pointer-events:none;opacity:.55;display:none;' +
+  'filter:drop-shadow(0 4px 10px rgba(63,49,35,.25))';
+document.body.appendChild(sigGhost);
+const FINE_POINTER = window.matchMedia('(pointer: fine)').matches;
+
+document.addEventListener('pointermove', (e) => {
+  if (FINE_POINTER && tool === 'signature' && storedSignature) {
+    const w = (storedSignature.subtype === 'paraf' ? 80 : 150) * zoom;
+    const h = w * (storedSignature.height / storedSignature.width);
+    if (sigGhost.dataset.sig !== storedSignature.dataUrl.slice(-40)) {
+      sigGhost.src = storedSignature.dataUrl;
+      sigGhost.dataset.sig = storedSignature.dataUrl.slice(-40);
+    }
+    sigGhost.style.width = w + 'px';
+    sigGhost.style.height = h + 'px';
+    sigGhost.style.left = (e.clientX - w / 2) + 'px';
+    sigGhost.style.top = (e.clientY - h / 2) + 'px';
+    sigGhost.style.display = '';
+  } else if (sigGhost.style.display !== 'none') {
+    sigGhost.style.display = 'none';
+  }
+});
 
 // Hapus works BOTH ways (founder ask): with a selection it deletes now; with
 // nothing selected it arms delete-mode — the next tapped object is removed.
 document.getElementById('btn-delete-anno').addEventListener('click', () => {
   if (doc.selection.annotationId) { deleteSelected(); return; }
   setTool('delete');
-  toast('Ketuk objek yang mau dihapus');
+  toast('Pilih objek yang mau dihapus');
 });
 
 // ---- Tip-Ex color matching -------------------------------------------------------
@@ -498,8 +533,8 @@ const signatureModal = createSignatureModal({
     }
     setTool('signature');
     toast(sig.subtype === 'paraf'
-      ? 'Ketuk halaman untuk menempatkan paraf'
-      : 'Ketuk halaman untuk menempatkan tanda tangan');
+      ? 'Pilih tempat untuk menempatkan paraf'
+      : 'Pilih tempat untuk menempatkan tanda tangan');
   },
 });
 
@@ -529,7 +564,7 @@ function syncSigBar() {
   redrawBtn.style.display = (armed || found) ? '' : 'none';
   document.getElementById('sig-bar-label').textContent = found
     ? (found.anno.subtype === 'paraf' ? 'Paraf terpilih' : 'Tanda tangan terpilih')
-    : (armed ? 'Ketuk halaman untuk menempatkan' : '');
+    : (armed ? 'Pilih tempat untuk menempatkan' : '');
 }
 document.getElementById('btn-redraw-sig').addEventListener('click', () => signatureModal.open());
 
@@ -686,10 +721,10 @@ function applyIntent(intent) {
     // opens to make one; otherwise arm placement.
     if (!storedSignature) { signatureModal.open(); return; }
     setTool('signature');
-    toast('Ketuk halaman untuk menempatkan tanda tangan');
+    toast('Pilih tempat untuk menempatkan tanda tangan');
   } else if (intent === 'teks') {
     setTool('text');
-    toast('Ketuk halaman untuk menulis');
+    toast('Pilih tempat untuk menulis');
   } else if (intent === 'tipex') {
     setTool('whiteout');
     toast('Seret di halaman untuk menutup teks');

--- a/tests/editor-v2-desktop.spec.js
+++ b/tests/editor-v2-desktop.spec.js
@@ -142,3 +142,32 @@ test('Kelola drag settles even when pointer capture fails', async ({ page }) => 
   await expect(page.locator('.pm-drag-ghost')).toHaveCount(0);
   await expect(page.locator('.pm-placeholder')).toHaveCount(0);
 });
+
+// Founder telegraph (Jul 3): after drawing a TTD, the signature rides the
+// cursor translucently until the click drops it — the placement state is
+// never a dead end on desktop.
+test('carried-signature ghost follows the cursor, drops on click', async ({ page }) => {
+  await page.goto('/');
+  await page.setInputFiles('#file-input', FIXTURE);
+  await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+  await page.click('[data-tool="signature"]');
+  await expect(page.locator('#sig-modal')).toBeVisible();
+  const box = await page.locator('#sig-canvas').boundingBox();
+  await page.mouse.move(box.x + 40, box.y + 60);
+  await page.mouse.down();
+  await page.mouse.move(box.x + 180, box.y + 90, { steps: 6 });
+  await page.mouse.up();
+  await page.click('#sig-use');
+
+  // Armed: the ghost appears at the cursor over the page.
+  const pg = await page.locator('.pv-page').first().boundingBox();
+  await page.mouse.move(pg.x + 200, pg.y + 260);
+  await expect(page.locator('#sig-ghost')).toBeVisible();
+
+  // Click drops it: annotation lands, tool returns home, ghost gone.
+  await page.mouse.down();
+  await page.mouse.up();
+  expect(await page.evaluate(() => window.v2.getDoc().pages[0].annotations.length)).toBe(1);
+  await page.mouse.move(pg.x + 300, pg.y + 300);
+  await expect(page.locator('#sig-ghost')).toBeHidden();
+});


### PR DESCRIPTION
Founder telegraph (HIGH): after drawing a TTD on desktop, the signature
now rides the cursor — translucent, at placement size × zoom — until the
click drops it. The placement state is never a dead end. Touch keeps the
persistent sig-bar hint (no cursor to ride). Ghost hides the moment the
tool changes; fine-pointer devices only.

Copy sweep: every user-facing 'ketuk' is now 'pilih' (founder: reads
more natural) — 'Pilih tempat untuk menempatkan tanda tangan', 'Pilih
halaman · tahan lalu geser untuk mengurutkan', 'Pilih objek yang mau
dihapus'. Zero 'ketuk' remaining in display copy.

Full sweep: 157 Playwright + lint green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GSTkjTsoHVmrYm84C7MhLW
