### PR TITLE
fix(v2): Kelola drag no longer stolen by native scroll on mobile

### DIFF
--- a/js/v2/page-manager.js
+++ b/js/v2/page-manager.js
@@ -283,9 +283,17 @@ export function createPageManager(deps) {
         drag.lastY = ev.clientY;
       };
       drag.winEnd = (ev) => end(ev);
+      // WHY touchmove too: tiles carry touch-action: pan-y, and
+      // pointermove.preventDefault() does NOT revoke the browser's pan claim —
+      // vertical finger movement after the lift made Chrome fire pointercancel
+      // (drag dies, grid scrolls; founder, Jul 5, mobile prod). Consuming
+      // touchmove non-passively while armed is the only mid-gesture veto;
+      // touch-action changes after touchstart are ignored. Removed in end().
+      drag.winTouchMove = (ev) => { if (ev.cancelable) ev.preventDefault(); };
       window.addEventListener('pointermove', drag.winMove);
       window.addEventListener('pointerup', drag.winEnd);
       window.addEventListener('pointercancel', drag.winEnd);
+      window.addEventListener('touchmove', drag.winTouchMove, { passive: false });
       if (navigator.vibrate) navigator.vibrate(10);
       requestAnimationFrame(dragLoop);
     }
@@ -351,6 +359,7 @@ export function createPageManager(deps) {
         window.removeEventListener('pointermove', d.winMove);
         window.removeEventListener('pointerup', d.winEnd);
         window.removeEventListener('pointercancel', d.winEnd);
+        window.removeEventListener('touchmove', d.winTouchMove);
         // Settle target from LAYOUT coords (a mid-glide placeholder's gBCR lies).
         const gr = grid.getBoundingClientRect();
         const slotLeft = gr.left + d.placeholder.offsetLeft - grid.scrollLeft;

--- a/tests/mobile/page-manager.spec.js
+++ b/tests/mobile/page-manager.spec.js
@@ -115,6 +115,40 @@ test.describe('page manager — mobile', () => {
     expect(travelled).toBe('aku ikut'); // its annotation came along — no re-keying
   });
 
+  test('armed drag consumes touchmove so native scroll cannot steal it', async ({ page }) => {
+    // Mobile prod bug (founder, Jul 5): tiles have touch-action: pan-y, and
+    // pointermove.preventDefault() does NOT revoke the browser's pan claim —
+    // any vertical finger movement after the long-press lift made Chrome fire
+    // pointercancel (drag dies, grid scrolls). The fix consumes touchmove at
+    // the window with a non-passive listener while — and only while — a drag
+    // is armed. This asserts that contract at all three stages.
+    await openSheet(page);
+    const probe = () => page.evaluate(() => {
+      const ev = new TouchEvent('touchmove', { bubbles: true, cancelable: true });
+      window.dispatchEvent(ev);
+      return ev.defaultPrevented;
+    });
+
+    expect(await probe()).toBe(false); // before: scrolling the sheet stays native
+
+    const first = await page.locator('.pm-tile >> nth=0').elementHandle();
+    const a = await first.boundingBox();
+    await first.dispatchEvent('pointerdown', {
+      pointerId: 9, pointerType: 'touch', clientX: a.x + 40, clientY: a.y + 40, bubbles: true, isPrimary: true,
+    });
+    await page.waitForTimeout(380); // long-press arms
+    await expect(page.locator('.pm-drag-ghost')).toHaveCount(1);
+
+    expect(await probe()).toBe(true); // during: the pan is ours, not the browser's
+
+    await first.dispatchEvent('pointerup', {
+      pointerId: 9, pointerType: 'touch', clientX: a.x + 40, clientY: a.y + 40, bubbles: true,
+    });
+    await expect(page.locator('.pm-drag-ghost')).toHaveCount(0);
+
+    expect(await probe()).toBe(false); // after: listener removed, scroll native again
+  });
+
   test('File menu: Tambah appends, Buka Baru replaces (no refresh)', async ({ page }) => {
     await openSheet(page);
     await page.tap('#pm-close');


### PR DESCRIPTION
Tiles carry touch-action: pan-y, and pointermove.preventDefault() does not
revoke the browser's pan claim — vertical movement after the long-press
lift made Chrome fire pointercancel: drag died, grid scrolled. While a
drag is armed, touchmove is now consumed at the window (non-passive),
released in end(). Regression test asserts the contract before/during/
after a drag; fails on pre-fix code.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GSTkjTsoHVmrYm84C7MhLW
