### PR TITLE
fix(v2): two mobile Sentry crashes — armDrag orphan tile + iOS caret guard

### DIFF
--- a/js/v2/app.js
+++ b/js/v2/app.js
@@ -508,9 +508,12 @@ function openTextEditor({ pageId, x, y, anno }) {
   overlay.appendChild(ed);
   ed.focus();
   // Place the caret at the end (mobile keyboards otherwise start at 0).
+  // Guarded (Sentry JAVASCRIPT-D): iOS WebKit can leave the selection
+  // rangeless after selectAllChildren — collapseToEnd() then throws
+  // InvalidStateError. Caret-at-start beats a dead text tool.
   const sel = window.getSelection();
   sel.selectAllChildren(ed);
-  sel.collapseToEnd();
+  if (sel.rangeCount > 0) sel.collapseToEnd();
 }
 
 // ---- signature modal (draw / upload / paraf) --------------------------------------------

--- a/js/v2/page-manager.js
+++ b/js/v2/page-manager.js
@@ -251,6 +251,11 @@ export function createPageManager(deps) {
 
     function armDrag(e) {
       if (pickResolve) return; // pick mode is selection-only — no reordering
+      // Defensive (Sentry JAVASCRIPT-E): render() only parks while a drag is
+      // ACTIVE — a rebuild during the long-press wait (thumbnail upgrade)
+      // detaches this tile, and insertBefore against an orphan throws.
+      // Stale tile → don't arm; the rebuilt tile carries fresh listeners.
+      if (tile.parentNode !== grid) { start = null; pressTimer = null; return; }
       const rect = tile.getBoundingClientRect();
       const placeholder = document.createElement('div');
       placeholder.className = 'pm-tile pm-placeholder';

--- a/tests/mobile/editor-v2.spec.js
+++ b/tests/mobile/editor-v2.spec.js
@@ -135,4 +135,31 @@ test.describe('editor v2 — mobile', () => {
     expect(last.w).toBe(1);
     expect(last.h).toBe(1);
   });
+
+  test('text tool survives a rangeless selection (iOS WebKit caret guard)', async ({ page }) => {
+    // Sentry JAVASCRIPT-D (Chrome iOS, Jul 6): after selectAllChildren, iOS
+    // WebKit can leave the selection with zero ranges; collapseToEnd() on a
+    // rangeless selection throws InvalidStateError and kills tap-to-type.
+    // Simulate the rangeless selection: caret-at-start is an acceptable
+    // fallback, a dead text tool is not.
+    const errors = [];
+    page.on('pageerror', (e) => errors.push(e.message));
+    await openWithFixture(page);
+    await page.evaluate(() => {
+      window.getSelection = () => ({
+        rangeCount: 0,
+        selectAllChildren() {},
+        collapseToEnd() { throw new DOMException('The object is in an invalid state.', 'InvalidStateError'); },
+      });
+    });
+    await page.tap('[data-tool="text"]');
+    await page.tap('.pv-page >> nth=0', { position: { x: 150, y: 200 } });
+    await expect(page.locator('.v2-text-edit')).toBeVisible();
+    await page.keyboard.type('tetap hidup');
+    await page.keyboard.press('Enter');
+
+    expect(errors.filter((m) => m.includes('invalid state'))).toEqual([]);
+    const annos = await page.evaluate(() => window.v2.getDoc().pages[0].annotations);
+    expect(annos[0]?.text).toBe('tetap hidup');
+  });
 });

--- a/tests/mobile/page-manager.spec.js
+++ b/tests/mobile/page-manager.spec.js
@@ -225,4 +225,31 @@ test.describe('page manager — mobile', () => {
     const download = await dl;
     expect(download.suggestedFilename()).toMatch(/halaman-1\.pdf$/);
   });
+
+  test('grid re-render during the long-press wait does not crash armDrag', async ({ page }) => {
+    // Sentry JAVASCRIPT-E (Android Chrome, Jul 7): render() only parks while a
+    // drag is ACTIVE — during the 280ms long-press wait dragActive is still
+    // false, so a thumbnail upgrade can rebuild the grid and detach the
+    // pressed tile. The timer then fires armDrag on the orphan and
+    // grid.insertBefore(placeholder, tile) throws NotFoundError. A stale tile
+    // must simply not arm (the rebuilt tile carries fresh listeners).
+    const errors = [];
+    page.on('pageerror', (e) => errors.push(e.message));
+    await openSheet(page);
+    const first = await page.locator('.pm-tile >> nth=0').elementHandle();
+    const a = await first.boundingBox();
+    await first.dispatchEvent('pointerdown', {
+      pointerId: 11, pointerType: 'touch', clientX: a.x + 40, clientY: a.y + 40, bubbles: true, isPrimary: true,
+    });
+    // The killer: a re-render inside the wait window (thumbnail upgrade in the wild).
+    await page.evaluate(() => window.v2.pageManager.render());
+    await page.waitForTimeout(380); // long-press timer fires on the detached tile
+
+    expect(errors.filter((m) => m.includes('NotFoundError') || m.includes('insertBefore'))).toEqual([]);
+    await expect(page.locator('.pm-drag-ghost')).toHaveCount(0);
+    await expect(page.locator('.pm-placeholder')).toHaveCount(0);
+    // The sheet is still alive: tapping a (rebuilt) tile selects it.
+    await page.tap('.pm-tile >> nth=0');
+    await expect(page.locator('#pm-bulk')).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Sentry issues

- **JAVASCRIPT-E** (Jul 7, Android Chrome): `NotFoundError: insertBefore` in `armDrag` — `render()` only parks while a drag is ACTIVE, so a grid rebuild during the 280ms long-press wait detached the pressed tile; the timer then fired `armDrag` on the orphan. Same family as fee8a76e (#109), which guarded `dragLoop` but not the arm itself. Fix: refuse to arm on a tile no longer in the grid.
- **JAVASCRIPT-D** (Jul 6, Chrome iOS): `InvalidStateError` in `openTextEditor` — iOS WebKit can leave the selection rangeless after `selectAllChildren`; `collapseToEnd()` then threw and killed tap-to-type. Fix: guard with `sel.rangeCount` — caret-at-start beats a dead text tool.

## Tests

Both regression tests reproduce the exact Sentry errors against pre-fix code and pass now:
- `page-manager.spec.js`: re-render inside the long-press wait window → no crash, sheet stays alive
- `editor-v2.spec.js`: rangeless `getSelection` stub → text still commits

## Sweep

Lint + 163 Playwright green. The 3 golden-master failures are **pre-existing on main** (suite still waits for `ueState` at `/` — missed in the v2 cutover repointing; flagged in backlog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)