### PR TITLE
feat(growth): Play Store demand-validation vote at the download moment

### DIFF
--- a/edit-pdf.html
+++ b/edit-pdf.html
@@ -766,6 +766,59 @@
       display: block; margin: 8px auto 0; color: var(--muted); font-size: 11px;
       text-decoration: underline; min-height: 32px; padding: 0 8px;
     }
+    /* ---- Play Store vote (TEMPORARY drive) — centered + scrim, more presence
+       than the quiet cards; still non-modal (scrim tap dismisses, file saved) ---- */
+    #vote-card {
+      position: fixed; inset: 0; z-index: 120; display: flex;
+      align-items: center; justify-content: center; padding: 20px;
+      background: rgba(20,16,12,.42);
+      opacity: 0; visibility: hidden; pointer-events: none;
+      transition: opacity .28s ease, visibility 0s linear .28s;
+    }
+    #vote-card.show { opacity: 1; visibility: visible; pointer-events: auto; transition-delay: 0s; }
+    .vc-inner {
+      position: relative; width: min(92vw, 340px); background: var(--surface);
+      border-radius: 18px; padding: 22px 20px 16px; text-align: center;
+      box-shadow: 0 18px 50px rgba(15,18,26,.34); border: 1px solid var(--line);
+      transform: translateY(10px) scale(.98);
+      transition: transform .28s cubic-bezier(.34,1.4,.44,1);
+    }
+    #vote-card.show .vc-inner { transform: none; }
+    @media (prefers-reduced-motion: reduce) { #vote-card, .vc-inner { transition: none; } }
+    #vc-close {
+      position: absolute; top: 8px; right: 8px; width: 32px; height: 32px;
+      display: inline-flex; align-items: center; justify-content: center;
+      color: var(--muted); border-radius: 8px;
+    }
+    #vc-close svg { width: 16px; height: 16px; }
+    .vc-eyebrow {
+      display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: .06em;
+      text-transform: uppercase; color: var(--accent); background: rgba(220,38,38,.08);
+      padding: 4px 11px; border-radius: 999px; margin-bottom: 12px;
+    }
+    .vc-head { font-size: 18px; font-weight: 700; color: var(--ink); line-height: 1.3; margin-bottom: 8px; }
+    .vc-sub { font-size: 12.8px; color: var(--muted); line-height: 1.5; margin-bottom: 16px; }
+    .vc-actions { display: flex; gap: 9px; }
+    .vc-actions button {
+      flex: 1; min-height: 46px; border-radius: 11px; font: inherit; font-size: 14px; font-weight: 700;
+      border: 1.5px solid var(--line); background: var(--bg); color: var(--ink);
+    }
+    #vc-yes { border-color: var(--accent); background: var(--accent); color: #fff; box-shadow: 0 2px 0 var(--accent-down); }
+    #vc-yes:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    /* two-step machine: s1 (vote) by default, s2 (tester opt-in) after .step2 */
+    .vc-s2 { display: none; }
+    #vote-card.step2 .vc-s1 { display: none; }
+    #vote-card.step2 .vc-s2 { display: block; }
+    #vc-tester {
+      display: block; width: 100%; min-height: 46px; line-height: 46px; border-radius: 11px;
+      background: var(--accent); color: #fff; font-weight: 700; font-size: 14px; text-decoration: none;
+      box-shadow: 0 2px 0 var(--accent-down);
+    }
+    #vc-tester:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    #vc-later {
+      display: block; margin: 10px auto 0; color: var(--muted); font-size: 12px;
+      text-decoration: underline; min-height: 32px; padding: 0 8px;
+    }
 
     #toast {
       position: fixed; left: 50%; transform: translateX(-50%); bottom: 130px; z-index: 40;
@@ -1106,6 +1159,35 @@
       <a id="ic-guide" class="ic-guide" target="_blank" rel="noopener" hidden>Lihat panduan resmi →</a>
     </div>
     <button id="ic-never">jangan tampilkan lagi</button>
+  </div>
+
+  <!-- TEMPORARY: Play Store demand-validation vote. Shown at the download moment
+       IN PLACE OF the share/tip card during the drive (js/v2/playstore-vote.js;
+       toggled by PLAYSTORE_CAMPAIGN in celebrate.js). Two steps: binary vote →
+       tester opt-in for "Ya" voters only. Centered + scrim (founder call: more
+       attention than the quiet bottom card). -->
+  <div id="vote-card" aria-hidden="true">
+    <div class="vc-inner" role="dialog" aria-label="Mau PDFLokal di Play Store?">
+      <button id="vc-close" aria-label="Tutup">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+      <div class="vc-step vc-s1">
+        <span class="vc-eyebrow">Kabar PDFLokal</span>
+        <div class="vc-head">Mau PDFLokal ada di Play Store?</div>
+        <p class="vc-sub">Biar bisa kamu install sekali tap — jalan tanpa internet, layar penuh buat ngedit, dan tetap 100% di HP-mu.</p>
+        <div class="vc-actions">
+          <button id="vc-no">Nggak perlu</button>
+          <button id="vc-yes">Ya, mau</button>
+        </div>
+      </div>
+      <div class="vc-step vc-s2">
+        <span class="vc-eyebrow">Bantu wujudkan</span>
+        <div class="vc-head">Mau bantu jadi tester?</div>
+        <p class="vc-sub">Google minta 15 orang nyoba dulu selama 2 minggu biar PDFLokal lolos. Gampang — cukup install &amp; sesekali dibuka.</p>
+        <a id="vc-tester" href="#" target="_blank" rel="noopener">Jadi tester &rarr;</a>
+        <button id="vc-later">Nanti aja</button>
+      </div>
+    </div>
   </div>
 
   <dialog id="pm-sheet" aria-label="Kelola halaman">

--- a/gabung-pdf.html
+++ b/gabung-pdf.html
@@ -766,6 +766,59 @@
       display: block; margin: 8px auto 0; color: var(--muted); font-size: 11px;
       text-decoration: underline; min-height: 32px; padding: 0 8px;
     }
+    /* ---- Play Store vote (TEMPORARY drive) — centered + scrim, more presence
+       than the quiet cards; still non-modal (scrim tap dismisses, file saved) ---- */
+    #vote-card {
+      position: fixed; inset: 0; z-index: 120; display: flex;
+      align-items: center; justify-content: center; padding: 20px;
+      background: rgba(20,16,12,.42);
+      opacity: 0; visibility: hidden; pointer-events: none;
+      transition: opacity .28s ease, visibility 0s linear .28s;
+    }
+    #vote-card.show { opacity: 1; visibility: visible; pointer-events: auto; transition-delay: 0s; }
+    .vc-inner {
+      position: relative; width: min(92vw, 340px); background: var(--surface);
+      border-radius: 18px; padding: 22px 20px 16px; text-align: center;
+      box-shadow: 0 18px 50px rgba(15,18,26,.34); border: 1px solid var(--line);
+      transform: translateY(10px) scale(.98);
+      transition: transform .28s cubic-bezier(.34,1.4,.44,1);
+    }
+    #vote-card.show .vc-inner { transform: none; }
+    @media (prefers-reduced-motion: reduce) { #vote-card, .vc-inner { transition: none; } }
+    #vc-close {
+      position: absolute; top: 8px; right: 8px; width: 32px; height: 32px;
+      display: inline-flex; align-items: center; justify-content: center;
+      color: var(--muted); border-radius: 8px;
+    }
+    #vc-close svg { width: 16px; height: 16px; }
+    .vc-eyebrow {
+      display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: .06em;
+      text-transform: uppercase; color: var(--accent); background: rgba(220,38,38,.08);
+      padding: 4px 11px; border-radius: 999px; margin-bottom: 12px;
+    }
+    .vc-head { font-size: 18px; font-weight: 700; color: var(--ink); line-height: 1.3; margin-bottom: 8px; }
+    .vc-sub { font-size: 12.8px; color: var(--muted); line-height: 1.5; margin-bottom: 16px; }
+    .vc-actions { display: flex; gap: 9px; }
+    .vc-actions button {
+      flex: 1; min-height: 46px; border-radius: 11px; font: inherit; font-size: 14px; font-weight: 700;
+      border: 1.5px solid var(--line); background: var(--bg); color: var(--ink);
+    }
+    #vc-yes { border-color: var(--accent); background: var(--accent); color: #fff; box-shadow: 0 2px 0 var(--accent-down); }
+    #vc-yes:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    /* two-step machine: s1 (vote) by default, s2 (tester opt-in) after .step2 */
+    .vc-s2 { display: none; }
+    #vote-card.step2 .vc-s1 { display: none; }
+    #vote-card.step2 .vc-s2 { display: block; }
+    #vc-tester {
+      display: block; width: 100%; min-height: 46px; line-height: 46px; border-radius: 11px;
+      background: var(--accent); color: #fff; font-weight: 700; font-size: 14px; text-decoration: none;
+      box-shadow: 0 2px 0 var(--accent-down);
+    }
+    #vc-tester:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    #vc-later {
+      display: block; margin: 10px auto 0; color: var(--muted); font-size: 12px;
+      text-decoration: underline; min-height: 32px; padding: 0 8px;
+    }
 
     #toast {
       position: fixed; left: 50%; transform: translateX(-50%); bottom: 130px; z-index: 40;
@@ -1113,6 +1166,35 @@
       <a id="ic-guide" class="ic-guide" target="_blank" rel="noopener" hidden>Lihat panduan resmi →</a>
     </div>
     <button id="ic-never">jangan tampilkan lagi</button>
+  </div>
+
+  <!-- TEMPORARY: Play Store demand-validation vote. Shown at the download moment
+       IN PLACE OF the share/tip card during the drive (js/v2/playstore-vote.js;
+       toggled by PLAYSTORE_CAMPAIGN in celebrate.js). Two steps: binary vote →
+       tester opt-in for "Ya" voters only. Centered + scrim (founder call: more
+       attention than the quiet bottom card). -->
+  <div id="vote-card" aria-hidden="true">
+    <div class="vc-inner" role="dialog" aria-label="Mau PDFLokal di Play Store?">
+      <button id="vc-close" aria-label="Tutup">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+      <div class="vc-step vc-s1">
+        <span class="vc-eyebrow">Kabar PDFLokal</span>
+        <div class="vc-head">Mau PDFLokal ada di Play Store?</div>
+        <p class="vc-sub">Biar bisa kamu install sekali tap — jalan tanpa internet, layar penuh buat ngedit, dan tetap 100% di HP-mu.</p>
+        <div class="vc-actions">
+          <button id="vc-no">Nggak perlu</button>
+          <button id="vc-yes">Ya, mau</button>
+        </div>
+      </div>
+      <div class="vc-step vc-s2">
+        <span class="vc-eyebrow">Bantu wujudkan</span>
+        <div class="vc-head">Mau bantu jadi tester?</div>
+        <p class="vc-sub">Google minta 15 orang nyoba dulu selama 2 minggu biar PDFLokal lolos. Gampang — cukup install &amp; sesekali dibuka.</p>
+        <a id="vc-tester" href="#" target="_blank" rel="noopener">Jadi tester &rarr;</a>
+        <button id="vc-later">Nanti aja</button>
+      </div>
+    </div>
   </div>
 
   <dialog id="pm-sheet" aria-label="Kelola halaman">

--- a/hapus-halaman-pdf.html
+++ b/hapus-halaman-pdf.html
@@ -766,6 +766,59 @@
       display: block; margin: 8px auto 0; color: var(--muted); font-size: 11px;
       text-decoration: underline; min-height: 32px; padding: 0 8px;
     }
+    /* ---- Play Store vote (TEMPORARY drive) — centered + scrim, more presence
+       than the quiet cards; still non-modal (scrim tap dismisses, file saved) ---- */
+    #vote-card {
+      position: fixed; inset: 0; z-index: 120; display: flex;
+      align-items: center; justify-content: center; padding: 20px;
+      background: rgba(20,16,12,.42);
+      opacity: 0; visibility: hidden; pointer-events: none;
+      transition: opacity .28s ease, visibility 0s linear .28s;
+    }
+    #vote-card.show { opacity: 1; visibility: visible; pointer-events: auto; transition-delay: 0s; }
+    .vc-inner {
+      position: relative; width: min(92vw, 340px); background: var(--surface);
+      border-radius: 18px; padding: 22px 20px 16px; text-align: center;
+      box-shadow: 0 18px 50px rgba(15,18,26,.34); border: 1px solid var(--line);
+      transform: translateY(10px) scale(.98);
+      transition: transform .28s cubic-bezier(.34,1.4,.44,1);
+    }
+    #vote-card.show .vc-inner { transform: none; }
+    @media (prefers-reduced-motion: reduce) { #vote-card, .vc-inner { transition: none; } }
+    #vc-close {
+      position: absolute; top: 8px; right: 8px; width: 32px; height: 32px;
+      display: inline-flex; align-items: center; justify-content: center;
+      color: var(--muted); border-radius: 8px;
+    }
+    #vc-close svg { width: 16px; height: 16px; }
+    .vc-eyebrow {
+      display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: .06em;
+      text-transform: uppercase; color: var(--accent); background: rgba(220,38,38,.08);
+      padding: 4px 11px; border-radius: 999px; margin-bottom: 12px;
+    }
+    .vc-head { font-size: 18px; font-weight: 700; color: var(--ink); line-height: 1.3; margin-bottom: 8px; }
+    .vc-sub { font-size: 12.8px; color: var(--muted); line-height: 1.5; margin-bottom: 16px; }
+    .vc-actions { display: flex; gap: 9px; }
+    .vc-actions button {
+      flex: 1; min-height: 46px; border-radius: 11px; font: inherit; font-size: 14px; font-weight: 700;
+      border: 1.5px solid var(--line); background: var(--bg); color: var(--ink);
+    }
+    #vc-yes { border-color: var(--accent); background: var(--accent); color: #fff; box-shadow: 0 2px 0 var(--accent-down); }
+    #vc-yes:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    /* two-step machine: s1 (vote) by default, s2 (tester opt-in) after .step2 */
+    .vc-s2 { display: none; }
+    #vote-card.step2 .vc-s1 { display: none; }
+    #vote-card.step2 .vc-s2 { display: block; }
+    #vc-tester {
+      display: block; width: 100%; min-height: 46px; line-height: 46px; border-radius: 11px;
+      background: var(--accent); color: #fff; font-weight: 700; font-size: 14px; text-decoration: none;
+      box-shadow: 0 2px 0 var(--accent-down);
+    }
+    #vc-tester:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    #vc-later {
+      display: block; margin: 10px auto 0; color: var(--muted); font-size: 12px;
+      text-decoration: underline; min-height: 32px; padding: 0 8px;
+    }
 
     #toast {
       position: fixed; left: 50%; transform: translateX(-50%); bottom: 130px; z-index: 40;
@@ -1111,6 +1164,35 @@
       <a id="ic-guide" class="ic-guide" target="_blank" rel="noopener" hidden>Lihat panduan resmi →</a>
     </div>
     <button id="ic-never">jangan tampilkan lagi</button>
+  </div>
+
+  <!-- TEMPORARY: Play Store demand-validation vote. Shown at the download moment
+       IN PLACE OF the share/tip card during the drive (js/v2/playstore-vote.js;
+       toggled by PLAYSTORE_CAMPAIGN in celebrate.js). Two steps: binary vote →
+       tester opt-in for "Ya" voters only. Centered + scrim (founder call: more
+       attention than the quiet bottom card). -->
+  <div id="vote-card" aria-hidden="true">
+    <div class="vc-inner" role="dialog" aria-label="Mau PDFLokal di Play Store?">
+      <button id="vc-close" aria-label="Tutup">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+      <div class="vc-step vc-s1">
+        <span class="vc-eyebrow">Kabar PDFLokal</span>
+        <div class="vc-head">Mau PDFLokal ada di Play Store?</div>
+        <p class="vc-sub">Biar bisa kamu install sekali tap — jalan tanpa internet, layar penuh buat ngedit, dan tetap 100% di HP-mu.</p>
+        <div class="vc-actions">
+          <button id="vc-no">Nggak perlu</button>
+          <button id="vc-yes">Ya, mau</button>
+        </div>
+      </div>
+      <div class="vc-step vc-s2">
+        <span class="vc-eyebrow">Bantu wujudkan</span>
+        <div class="vc-head">Mau bantu jadi tester?</div>
+        <p class="vc-sub">Google minta 15 orang nyoba dulu selama 2 minggu biar PDFLokal lolos. Gampang — cukup install &amp; sesekali dibuka.</p>
+        <a id="vc-tester" href="#" target="_blank" rel="noopener">Jadi tester &rarr;</a>
+        <button id="vc-later">Nanti aja</button>
+      </div>
+    </div>
   </div>
 
   <dialog id="pm-sheet" aria-label="Kelola halaman">

--- a/index.html
+++ b/index.html
@@ -766,6 +766,59 @@
       display: block; margin: 8px auto 0; color: var(--muted); font-size: 11px;
       text-decoration: underline; min-height: 32px; padding: 0 8px;
     }
+    /* ---- Play Store vote (TEMPORARY drive) — centered + scrim, more presence
+       than the quiet cards; still non-modal (scrim tap dismisses, file saved) ---- */
+    #vote-card {
+      position: fixed; inset: 0; z-index: 120; display: flex;
+      align-items: center; justify-content: center; padding: 20px;
+      background: rgba(20,16,12,.42);
+      opacity: 0; visibility: hidden; pointer-events: none;
+      transition: opacity .28s ease, visibility 0s linear .28s;
+    }
+    #vote-card.show { opacity: 1; visibility: visible; pointer-events: auto; transition-delay: 0s; }
+    .vc-inner {
+      position: relative; width: min(92vw, 340px); background: var(--surface);
+      border-radius: 18px; padding: 22px 20px 16px; text-align: center;
+      box-shadow: 0 18px 50px rgba(15,18,26,.34); border: 1px solid var(--line);
+      transform: translateY(10px) scale(.98);
+      transition: transform .28s cubic-bezier(.34,1.4,.44,1);
+    }
+    #vote-card.show .vc-inner { transform: none; }
+    @media (prefers-reduced-motion: reduce) { #vote-card, .vc-inner { transition: none; } }
+    #vc-close {
+      position: absolute; top: 8px; right: 8px; width: 32px; height: 32px;
+      display: inline-flex; align-items: center; justify-content: center;
+      color: var(--muted); border-radius: 8px;
+    }
+    #vc-close svg { width: 16px; height: 16px; }
+    .vc-eyebrow {
+      display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: .06em;
+      text-transform: uppercase; color: var(--accent); background: rgba(220,38,38,.08);
+      padding: 4px 11px; border-radius: 999px; margin-bottom: 12px;
+    }
+    .vc-head { font-size: 18px; font-weight: 700; color: var(--ink); line-height: 1.3; margin-bottom: 8px; }
+    .vc-sub { font-size: 12.8px; color: var(--muted); line-height: 1.5; margin-bottom: 16px; }
+    .vc-actions { display: flex; gap: 9px; }
+    .vc-actions button {
+      flex: 1; min-height: 46px; border-radius: 11px; font: inherit; font-size: 14px; font-weight: 700;
+      border: 1.5px solid var(--line); background: var(--bg); color: var(--ink);
+    }
+    #vc-yes { border-color: var(--accent); background: var(--accent); color: #fff; box-shadow: 0 2px 0 var(--accent-down); }
+    #vc-yes:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    /* two-step machine: s1 (vote) by default, s2 (tester opt-in) after .step2 */
+    .vc-s2 { display: none; }
+    #vote-card.step2 .vc-s1 { display: none; }
+    #vote-card.step2 .vc-s2 { display: block; }
+    #vc-tester {
+      display: block; width: 100%; min-height: 46px; line-height: 46px; border-radius: 11px;
+      background: var(--accent); color: #fff; font-weight: 700; font-size: 14px; text-decoration: none;
+      box-shadow: 0 2px 0 var(--accent-down);
+    }
+    #vc-tester:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    #vc-later {
+      display: block; margin: 10px auto 0; color: var(--muted); font-size: 12px;
+      text-decoration: underline; min-height: 32px; padding: 0 8px;
+    }
 
     #toast {
       position: fixed; left: 50%; transform: translateX(-50%); bottom: 130px; z-index: 40;
@@ -1069,6 +1122,35 @@
       <a id="ic-guide" class="ic-guide" target="_blank" rel="noopener" hidden>Lihat panduan resmi →</a>
     </div>
     <button id="ic-never">jangan tampilkan lagi</button>
+  </div>
+
+  <!-- TEMPORARY: Play Store demand-validation vote. Shown at the download moment
+       IN PLACE OF the share/tip card during the drive (js/v2/playstore-vote.js;
+       toggled by PLAYSTORE_CAMPAIGN in celebrate.js). Two steps: binary vote →
+       tester opt-in for "Ya" voters only. Centered + scrim (founder call: more
+       attention than the quiet bottom card). -->
+  <div id="vote-card" aria-hidden="true">
+    <div class="vc-inner" role="dialog" aria-label="Mau PDFLokal di Play Store?">
+      <button id="vc-close" aria-label="Tutup">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+      <div class="vc-step vc-s1">
+        <span class="vc-eyebrow">Kabar PDFLokal</span>
+        <div class="vc-head">Mau PDFLokal ada di Play Store?</div>
+        <p class="vc-sub">Biar bisa kamu install sekali tap — jalan tanpa internet, layar penuh buat ngedit, dan tetap 100% di HP-mu.</p>
+        <div class="vc-actions">
+          <button id="vc-no">Nggak perlu</button>
+          <button id="vc-yes">Ya, mau</button>
+        </div>
+      </div>
+      <div class="vc-step vc-s2">
+        <span class="vc-eyebrow">Bantu wujudkan</span>
+        <div class="vc-head">Mau bantu jadi tester?</div>
+        <p class="vc-sub">Google minta 15 orang nyoba dulu selama 2 minggu biar PDFLokal lolos. Gampang — cukup install &amp; sesekali dibuka.</p>
+        <a id="vc-tester" href="#" target="_blank" rel="noopener">Jadi tester &rarr;</a>
+        <button id="vc-later">Nanti aja</button>
+      </div>
+    </div>
   </div>
 
   <dialog id="pm-sheet" aria-label="Kelola halaman">

--- a/jpg-ke-pdf.html
+++ b/jpg-ke-pdf.html
@@ -766,6 +766,59 @@
       display: block; margin: 8px auto 0; color: var(--muted); font-size: 11px;
       text-decoration: underline; min-height: 32px; padding: 0 8px;
     }
+    /* ---- Play Store vote (TEMPORARY drive) — centered + scrim, more presence
+       than the quiet cards; still non-modal (scrim tap dismisses, file saved) ---- */
+    #vote-card {
+      position: fixed; inset: 0; z-index: 120; display: flex;
+      align-items: center; justify-content: center; padding: 20px;
+      background: rgba(20,16,12,.42);
+      opacity: 0; visibility: hidden; pointer-events: none;
+      transition: opacity .28s ease, visibility 0s linear .28s;
+    }
+    #vote-card.show { opacity: 1; visibility: visible; pointer-events: auto; transition-delay: 0s; }
+    .vc-inner {
+      position: relative; width: min(92vw, 340px); background: var(--surface);
+      border-radius: 18px; padding: 22px 20px 16px; text-align: center;
+      box-shadow: 0 18px 50px rgba(15,18,26,.34); border: 1px solid var(--line);
+      transform: translateY(10px) scale(.98);
+      transition: transform .28s cubic-bezier(.34,1.4,.44,1);
+    }
+    #vote-card.show .vc-inner { transform: none; }
+    @media (prefers-reduced-motion: reduce) { #vote-card, .vc-inner { transition: none; } }
+    #vc-close {
+      position: absolute; top: 8px; right: 8px; width: 32px; height: 32px;
+      display: inline-flex; align-items: center; justify-content: center;
+      color: var(--muted); border-radius: 8px;
+    }
+    #vc-close svg { width: 16px; height: 16px; }
+    .vc-eyebrow {
+      display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: .06em;
+      text-transform: uppercase; color: var(--accent); background: rgba(220,38,38,.08);
+      padding: 4px 11px; border-radius: 999px; margin-bottom: 12px;
+    }
+    .vc-head { font-size: 18px; font-weight: 700; color: var(--ink); line-height: 1.3; margin-bottom: 8px; }
+    .vc-sub { font-size: 12.8px; color: var(--muted); line-height: 1.5; margin-bottom: 16px; }
+    .vc-actions { display: flex; gap: 9px; }
+    .vc-actions button {
+      flex: 1; min-height: 46px; border-radius: 11px; font: inherit; font-size: 14px; font-weight: 700;
+      border: 1.5px solid var(--line); background: var(--bg); color: var(--ink);
+    }
+    #vc-yes { border-color: var(--accent); background: var(--accent); color: #fff; box-shadow: 0 2px 0 var(--accent-down); }
+    #vc-yes:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    /* two-step machine: s1 (vote) by default, s2 (tester opt-in) after .step2 */
+    .vc-s2 { display: none; }
+    #vote-card.step2 .vc-s1 { display: none; }
+    #vote-card.step2 .vc-s2 { display: block; }
+    #vc-tester {
+      display: block; width: 100%; min-height: 46px; line-height: 46px; border-radius: 11px;
+      background: var(--accent); color: #fff; font-weight: 700; font-size: 14px; text-decoration: none;
+      box-shadow: 0 2px 0 var(--accent-down);
+    }
+    #vc-tester:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    #vc-later {
+      display: block; margin: 10px auto 0; color: var(--muted); font-size: 12px;
+      text-decoration: underline; min-height: 32px; padding: 0 8px;
+    }
 
     #toast {
       position: fixed; left: 50%; transform: translateX(-50%); bottom: 130px; z-index: 40;
@@ -1114,6 +1167,35 @@
       <a id="ic-guide" class="ic-guide" target="_blank" rel="noopener" hidden>Lihat panduan resmi →</a>
     </div>
     <button id="ic-never">jangan tampilkan lagi</button>
+  </div>
+
+  <!-- TEMPORARY: Play Store demand-validation vote. Shown at the download moment
+       IN PLACE OF the share/tip card during the drive (js/v2/playstore-vote.js;
+       toggled by PLAYSTORE_CAMPAIGN in celebrate.js). Two steps: binary vote →
+       tester opt-in for "Ya" voters only. Centered + scrim (founder call: more
+       attention than the quiet bottom card). -->
+  <div id="vote-card" aria-hidden="true">
+    <div class="vc-inner" role="dialog" aria-label="Mau PDFLokal di Play Store?">
+      <button id="vc-close" aria-label="Tutup">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+      <div class="vc-step vc-s1">
+        <span class="vc-eyebrow">Kabar PDFLokal</span>
+        <div class="vc-head">Mau PDFLokal ada di Play Store?</div>
+        <p class="vc-sub">Biar bisa kamu install sekali tap — jalan tanpa internet, layar penuh buat ngedit, dan tetap 100% di HP-mu.</p>
+        <div class="vc-actions">
+          <button id="vc-no">Nggak perlu</button>
+          <button id="vc-yes">Ya, mau</button>
+        </div>
+      </div>
+      <div class="vc-step vc-s2">
+        <span class="vc-eyebrow">Bantu wujudkan</span>
+        <div class="vc-head">Mau bantu jadi tester?</div>
+        <p class="vc-sub">Google minta 15 orang nyoba dulu selama 2 minggu biar PDFLokal lolos. Gampang — cukup install &amp; sesekali dibuka.</p>
+        <a id="vc-tester" href="#" target="_blank" rel="noopener">Jadi tester &rarr;</a>
+        <button id="vc-later">Nanti aja</button>
+      </div>
+    </div>
   </div>
 
   <dialog id="pm-sheet" aria-label="Kelola halaman">

--- a/js/v2/celebrate.js
+++ b/js/v2/celebrate.js
@@ -13,6 +13,14 @@
  * BARU in the future changelog.
  */
 
+import { createPlaystoreVote } from './playstore-vote.js';
+
+// TEMPORARY (founder call 2026-07-19): during the Play Store demand-validation
+// drive, the download moment shows the binary VOTE card instead of share/tip —
+// the peak-enthusiasm slot is spent, on purpose, on the go/no-go signal. Flip
+// this to false to end the drive; the share/tip card returns, nothing else.
+const PLAYSTORE_CAMPAIGN = true;
+
 const OPTOUT_KEY = 'pdflokal-support-optout';
 const LAST_SHOWN_KEY = 'pdflokal-support-last';
 const SHARE_URL = 'https://www.pdflokal.id';
@@ -95,6 +103,9 @@ export function showStamp(text, {
 export function createCelebration(deps) {
   let shownThisSession = false;
   const card = document.getElementById('support-card');
+  // The temporary Play Store vote — owns its own gating; celebrate.js only asks
+  // it to try, and skips the share/tip card when it takes the moment.
+  const vote = createPlaystoreVote({ toast: deps.toast });
 
   // TETAP JALAN: connection dies, PDFLokal doesn't (no server in the loop).
   // The moat made visible — once per session, only while a page is open.
@@ -168,6 +179,10 @@ export function createCelebration(deps) {
       // Big, and ~1.2s late on purpose: Android Chrome's download dialog +
       // notification own the first second; we celebrate once the stage clears.
       showStamp('Beres ✓', { big: true, delay: 1200, duration: 3000 });
+      // During the drive, the vote takes this slot from share/tip. If it shows,
+      // we stop here; if it declines (already voted / dismissed today), the
+      // share/tip card runs as usual — so voters still get the normal invite.
+      if (PLAYSTORE_CAMPAIGN && vote.maybeShow()) return;
       // The share/tip invite, once per CALENDAR DAY (founder call, Jul 3) — a gentle
       // reminder that free has a sponsor, never a toll booth per file. (Install lives
       // on the homepage now, off this moment — see install-prompt.js.) shownThisSession

--- a/js/v2/playstore-vote.js
+++ b/js/v2/playstore-vote.js
@@ -1,0 +1,96 @@
+/*
+ * PDFLokal — v2/playstore-vote.js  (TEMPORARY demand-validation campaign)
+ * ===========================================================================
+ * A binary "do you want PDFLokal on Play Store?" vote, shown at the download
+ * moment IN PLACE OF the share/tip card. Founder call (2026-07-19): the peak-
+ * enthusiasm slot is spent — deliberately and temporarily — on this go/no-go
+ * signal, because the tester count is worth more than a marginal share for the
+ * two weeks of the drive.
+ *
+ * Two steps: (1) the vote → GA4 event; (2) only "Ya" voters see the tester
+ * opt-in → a Google Form. The yes→optin DROP-OFF is the real signal, not the
+ * raw yes count: a free "yes" click skews positive (selection bias + zero
+ * cost), so the number that matters is how many yes-voters actually leave an
+ * email.
+ *
+ * Persistence: NONE of ours. The vote is a GA4 event (reuses the analytics
+ * rail — no backend, no DB, no CSP change). The only thing stored is the
+ * tester's Gmail + WhatsApp, in the Google Form, reached by the committed few.
+ *
+ * TO END THE CAMPAIGN: set PLAYSTORE_CAMPAIGN = false in celebrate.js. This
+ * module goes dormant; the share/tip card returns. Nothing else to revert.
+ */
+
+import { track } from '../lib/analytics.js';
+
+// The live tester sign-up form (Gmail + WhatsApp). Placeholder until it ships;
+// swap this ONE string for the real forms.gle/… link.
+const FORM_URL = 'https://forms.gle/cWaqHGvDXi1Dapie6';
+
+const VOTED_KEY = 'pdflokal-ps-voted'; // set once they vote (yes|no) → never re-ask
+const LAST_KEY = 'pdflokal-ps-last';   // dismiss-without-vote → once/day, no nagging
+
+function safeGet(k) { try { return localStorage.getItem(k); } catch { return null; } }
+function safeSet(k, v) { try { localStorage.setItem(k, v); } catch { /* private mode */ } }
+
+// deps = { toast }
+export function createPlaystoreVote(deps) {
+  const card = document.getElementById('vote-card');
+  // Defensive no-op: SEO/landing pages are generated FROM index.html; if this
+  // markup ever fails to propagate, degrade silently rather than crash the app.
+  // (JAVASCRIPT-J: a null getElementById once took the whole growth channel
+  // down on every SEO page for ~4h.)
+  if (!card) return { maybeShow() { return false; } };
+
+  function hide() {
+    card.classList.remove('show');
+    card.setAttribute('aria-hidden', 'true');
+  }
+  function show() {
+    card.classList.add('show');
+    card.setAttribute('aria-hidden', 'false');
+  }
+
+  // Scrim tap (outside the inner card) dismisses — the file is already saved,
+  // it is never held hostage. Close button too.
+  card.addEventListener('click', (e) => { if (e.target === card) hide(); });
+  card.querySelector('#vc-close').addEventListener('click', hide);
+
+  card.querySelector('#vc-no').addEventListener('click', () => {
+    track('vote_playstore', { choice: 'no' });
+    safeSet(VOTED_KEY, '1');
+    deps.toast('Oke, makasih masukannya!');
+    hide();
+  });
+
+  card.querySelector('#vc-yes').addEventListener('click', () => {
+    track('vote_playstore', { choice: 'yes' });
+    safeSet(VOTED_KEY, '1');
+    card.classList.add('step2'); // reveal the tester opt-in in place
+  });
+
+  const tester = card.querySelector('#vc-tester');
+  tester.href = FORM_URL;
+  tester.addEventListener('click', () => {
+    // The one metric that matters: yes → actually-signs-up conversion.
+    track('tester_optin');
+    setTimeout(hide, 120); // let the new tab open first
+  });
+
+  card.querySelector('#vc-later').addEventListener('click', () => {
+    deps.toast('Sip, makasih ya!');
+    hide();
+  });
+
+  return {
+    // Returns true if it showed → celebrate.js then SKIPS the share/tip card.
+    maybeShow() {
+      if (safeGet(VOTED_KEY) === '1') return false;                 // already voted → done forever
+      if (safeGet(LAST_KEY) === new Date().toDateString()) return false; // dismissed already today
+      safeSet(LAST_KEY, new Date().toDateString());
+      card.classList.remove('step2'); // always open on the vote, never mid-flow
+      setTimeout(show, 200); // on the heels of the BERES burst
+      return true;
+    },
+  };
+}

--- a/kompres-pdf-100kb.html
+++ b/kompres-pdf-100kb.html
@@ -766,6 +766,59 @@
       display: block; margin: 8px auto 0; color: var(--muted); font-size: 11px;
       text-decoration: underline; min-height: 32px; padding: 0 8px;
     }
+    /* ---- Play Store vote (TEMPORARY drive) — centered + scrim, more presence
+       than the quiet cards; still non-modal (scrim tap dismisses, file saved) ---- */
+    #vote-card {
+      position: fixed; inset: 0; z-index: 120; display: flex;
+      align-items: center; justify-content: center; padding: 20px;
+      background: rgba(20,16,12,.42);
+      opacity: 0; visibility: hidden; pointer-events: none;
+      transition: opacity .28s ease, visibility 0s linear .28s;
+    }
+    #vote-card.show { opacity: 1; visibility: visible; pointer-events: auto; transition-delay: 0s; }
+    .vc-inner {
+      position: relative; width: min(92vw, 340px); background: var(--surface);
+      border-radius: 18px; padding: 22px 20px 16px; text-align: center;
+      box-shadow: 0 18px 50px rgba(15,18,26,.34); border: 1px solid var(--line);
+      transform: translateY(10px) scale(.98);
+      transition: transform .28s cubic-bezier(.34,1.4,.44,1);
+    }
+    #vote-card.show .vc-inner { transform: none; }
+    @media (prefers-reduced-motion: reduce) { #vote-card, .vc-inner { transition: none; } }
+    #vc-close {
+      position: absolute; top: 8px; right: 8px; width: 32px; height: 32px;
+      display: inline-flex; align-items: center; justify-content: center;
+      color: var(--muted); border-radius: 8px;
+    }
+    #vc-close svg { width: 16px; height: 16px; }
+    .vc-eyebrow {
+      display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: .06em;
+      text-transform: uppercase; color: var(--accent); background: rgba(220,38,38,.08);
+      padding: 4px 11px; border-radius: 999px; margin-bottom: 12px;
+    }
+    .vc-head { font-size: 18px; font-weight: 700; color: var(--ink); line-height: 1.3; margin-bottom: 8px; }
+    .vc-sub { font-size: 12.8px; color: var(--muted); line-height: 1.5; margin-bottom: 16px; }
+    .vc-actions { display: flex; gap: 9px; }
+    .vc-actions button {
+      flex: 1; min-height: 46px; border-radius: 11px; font: inherit; font-size: 14px; font-weight: 700;
+      border: 1.5px solid var(--line); background: var(--bg); color: var(--ink);
+    }
+    #vc-yes { border-color: var(--accent); background: var(--accent); color: #fff; box-shadow: 0 2px 0 var(--accent-down); }
+    #vc-yes:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    /* two-step machine: s1 (vote) by default, s2 (tester opt-in) after .step2 */
+    .vc-s2 { display: none; }
+    #vote-card.step2 .vc-s1 { display: none; }
+    #vote-card.step2 .vc-s2 { display: block; }
+    #vc-tester {
+      display: block; width: 100%; min-height: 46px; line-height: 46px; border-radius: 11px;
+      background: var(--accent); color: #fff; font-weight: 700; font-size: 14px; text-decoration: none;
+      box-shadow: 0 2px 0 var(--accent-down);
+    }
+    #vc-tester:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    #vc-later {
+      display: block; margin: 10px auto 0; color: var(--muted); font-size: 12px;
+      text-decoration: underline; min-height: 32px; padding: 0 8px;
+    }
 
     #toast {
       position: fixed; left: 50%; transform: translateX(-50%); bottom: 130px; z-index: 40;
@@ -1101,6 +1154,35 @@
       <a id="ic-guide" class="ic-guide" target="_blank" rel="noopener" hidden>Lihat panduan resmi →</a>
     </div>
     <button id="ic-never">jangan tampilkan lagi</button>
+  </div>
+
+  <!-- TEMPORARY: Play Store demand-validation vote. Shown at the download moment
+       IN PLACE OF the share/tip card during the drive (js/v2/playstore-vote.js;
+       toggled by PLAYSTORE_CAMPAIGN in celebrate.js). Two steps: binary vote →
+       tester opt-in for "Ya" voters only. Centered + scrim (founder call: more
+       attention than the quiet bottom card). -->
+  <div id="vote-card" aria-hidden="true">
+    <div class="vc-inner" role="dialog" aria-label="Mau PDFLokal di Play Store?">
+      <button id="vc-close" aria-label="Tutup">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+      <div class="vc-step vc-s1">
+        <span class="vc-eyebrow">Kabar PDFLokal</span>
+        <div class="vc-head">Mau PDFLokal ada di Play Store?</div>
+        <p class="vc-sub">Biar bisa kamu install sekali tap — jalan tanpa internet, layar penuh buat ngedit, dan tetap 100% di HP-mu.</p>
+        <div class="vc-actions">
+          <button id="vc-no">Nggak perlu</button>
+          <button id="vc-yes">Ya, mau</button>
+        </div>
+      </div>
+      <div class="vc-step vc-s2">
+        <span class="vc-eyebrow">Bantu wujudkan</span>
+        <div class="vc-head">Mau bantu jadi tester?</div>
+        <p class="vc-sub">Google minta 15 orang nyoba dulu selama 2 minggu biar PDFLokal lolos. Gampang — cukup install &amp; sesekali dibuka.</p>
+        <a id="vc-tester" href="#" target="_blank" rel="noopener">Jadi tester &rarr;</a>
+        <button id="vc-later">Nanti aja</button>
+      </div>
+    </div>
   </div>
 
   <dialog id="pm-sheet" aria-label="Kelola halaman">

--- a/kompres-pdf-1mb.html
+++ b/kompres-pdf-1mb.html
@@ -766,6 +766,59 @@
       display: block; margin: 8px auto 0; color: var(--muted); font-size: 11px;
       text-decoration: underline; min-height: 32px; padding: 0 8px;
     }
+    /* ---- Play Store vote (TEMPORARY drive) — centered + scrim, more presence
+       than the quiet cards; still non-modal (scrim tap dismisses, file saved) ---- */
+    #vote-card {
+      position: fixed; inset: 0; z-index: 120; display: flex;
+      align-items: center; justify-content: center; padding: 20px;
+      background: rgba(20,16,12,.42);
+      opacity: 0; visibility: hidden; pointer-events: none;
+      transition: opacity .28s ease, visibility 0s linear .28s;
+    }
+    #vote-card.show { opacity: 1; visibility: visible; pointer-events: auto; transition-delay: 0s; }
+    .vc-inner {
+      position: relative; width: min(92vw, 340px); background: var(--surface);
+      border-radius: 18px; padding: 22px 20px 16px; text-align: center;
+      box-shadow: 0 18px 50px rgba(15,18,26,.34); border: 1px solid var(--line);
+      transform: translateY(10px) scale(.98);
+      transition: transform .28s cubic-bezier(.34,1.4,.44,1);
+    }
+    #vote-card.show .vc-inner { transform: none; }
+    @media (prefers-reduced-motion: reduce) { #vote-card, .vc-inner { transition: none; } }
+    #vc-close {
+      position: absolute; top: 8px; right: 8px; width: 32px; height: 32px;
+      display: inline-flex; align-items: center; justify-content: center;
+      color: var(--muted); border-radius: 8px;
+    }
+    #vc-close svg { width: 16px; height: 16px; }
+    .vc-eyebrow {
+      display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: .06em;
+      text-transform: uppercase; color: var(--accent); background: rgba(220,38,38,.08);
+      padding: 4px 11px; border-radius: 999px; margin-bottom: 12px;
+    }
+    .vc-head { font-size: 18px; font-weight: 700; color: var(--ink); line-height: 1.3; margin-bottom: 8px; }
+    .vc-sub { font-size: 12.8px; color: var(--muted); line-height: 1.5; margin-bottom: 16px; }
+    .vc-actions { display: flex; gap: 9px; }
+    .vc-actions button {
+      flex: 1; min-height: 46px; border-radius: 11px; font: inherit; font-size: 14px; font-weight: 700;
+      border: 1.5px solid var(--line); background: var(--bg); color: var(--ink);
+    }
+    #vc-yes { border-color: var(--accent); background: var(--accent); color: #fff; box-shadow: 0 2px 0 var(--accent-down); }
+    #vc-yes:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    /* two-step machine: s1 (vote) by default, s2 (tester opt-in) after .step2 */
+    .vc-s2 { display: none; }
+    #vote-card.step2 .vc-s1 { display: none; }
+    #vote-card.step2 .vc-s2 { display: block; }
+    #vc-tester {
+      display: block; width: 100%; min-height: 46px; line-height: 46px; border-radius: 11px;
+      background: var(--accent); color: #fff; font-weight: 700; font-size: 14px; text-decoration: none;
+      box-shadow: 0 2px 0 var(--accent-down);
+    }
+    #vc-tester:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    #vc-later {
+      display: block; margin: 10px auto 0; color: var(--muted); font-size: 12px;
+      text-decoration: underline; min-height: 32px; padding: 0 8px;
+    }
 
     #toast {
       position: fixed; left: 50%; transform: translateX(-50%); bottom: 130px; z-index: 40;
@@ -1101,6 +1154,35 @@
       <a id="ic-guide" class="ic-guide" target="_blank" rel="noopener" hidden>Lihat panduan resmi →</a>
     </div>
     <button id="ic-never">jangan tampilkan lagi</button>
+  </div>
+
+  <!-- TEMPORARY: Play Store demand-validation vote. Shown at the download moment
+       IN PLACE OF the share/tip card during the drive (js/v2/playstore-vote.js;
+       toggled by PLAYSTORE_CAMPAIGN in celebrate.js). Two steps: binary vote →
+       tester opt-in for "Ya" voters only. Centered + scrim (founder call: more
+       attention than the quiet bottom card). -->
+  <div id="vote-card" aria-hidden="true">
+    <div class="vc-inner" role="dialog" aria-label="Mau PDFLokal di Play Store?">
+      <button id="vc-close" aria-label="Tutup">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+      <div class="vc-step vc-s1">
+        <span class="vc-eyebrow">Kabar PDFLokal</span>
+        <div class="vc-head">Mau PDFLokal ada di Play Store?</div>
+        <p class="vc-sub">Biar bisa kamu install sekali tap — jalan tanpa internet, layar penuh buat ngedit, dan tetap 100% di HP-mu.</p>
+        <div class="vc-actions">
+          <button id="vc-no">Nggak perlu</button>
+          <button id="vc-yes">Ya, mau</button>
+        </div>
+      </div>
+      <div class="vc-step vc-s2">
+        <span class="vc-eyebrow">Bantu wujudkan</span>
+        <div class="vc-head">Mau bantu jadi tester?</div>
+        <p class="vc-sub">Google minta 15 orang nyoba dulu selama 2 minggu biar PDFLokal lolos. Gampang — cukup install &amp; sesekali dibuka.</p>
+        <a id="vc-tester" href="#" target="_blank" rel="noopener">Jadi tester &rarr;</a>
+        <button id="vc-later">Nanti aja</button>
+      </div>
+    </div>
   </div>
 
   <dialog id="pm-sheet" aria-label="Kelola halaman">

--- a/kompres-pdf-200kb.html
+++ b/kompres-pdf-200kb.html
@@ -766,6 +766,59 @@
       display: block; margin: 8px auto 0; color: var(--muted); font-size: 11px;
       text-decoration: underline; min-height: 32px; padding: 0 8px;
     }
+    /* ---- Play Store vote (TEMPORARY drive) — centered + scrim, more presence
+       than the quiet cards; still non-modal (scrim tap dismisses, file saved) ---- */
+    #vote-card {
+      position: fixed; inset: 0; z-index: 120; display: flex;
+      align-items: center; justify-content: center; padding: 20px;
+      background: rgba(20,16,12,.42);
+      opacity: 0; visibility: hidden; pointer-events: none;
+      transition: opacity .28s ease, visibility 0s linear .28s;
+    }
+    #vote-card.show { opacity: 1; visibility: visible; pointer-events: auto; transition-delay: 0s; }
+    .vc-inner {
+      position: relative; width: min(92vw, 340px); background: var(--surface);
+      border-radius: 18px; padding: 22px 20px 16px; text-align: center;
+      box-shadow: 0 18px 50px rgba(15,18,26,.34); border: 1px solid var(--line);
+      transform: translateY(10px) scale(.98);
+      transition: transform .28s cubic-bezier(.34,1.4,.44,1);
+    }
+    #vote-card.show .vc-inner { transform: none; }
+    @media (prefers-reduced-motion: reduce) { #vote-card, .vc-inner { transition: none; } }
+    #vc-close {
+      position: absolute; top: 8px; right: 8px; width: 32px; height: 32px;
+      display: inline-flex; align-items: center; justify-content: center;
+      color: var(--muted); border-radius: 8px;
+    }
+    #vc-close svg { width: 16px; height: 16px; }
+    .vc-eyebrow {
+      display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: .06em;
+      text-transform: uppercase; color: var(--accent); background: rgba(220,38,38,.08);
+      padding: 4px 11px; border-radius: 999px; margin-bottom: 12px;
+    }
+    .vc-head { font-size: 18px; font-weight: 700; color: var(--ink); line-height: 1.3; margin-bottom: 8px; }
+    .vc-sub { font-size: 12.8px; color: var(--muted); line-height: 1.5; margin-bottom: 16px; }
+    .vc-actions { display: flex; gap: 9px; }
+    .vc-actions button {
+      flex: 1; min-height: 46px; border-radius: 11px; font: inherit; font-size: 14px; font-weight: 700;
+      border: 1.5px solid var(--line); background: var(--bg); color: var(--ink);
+    }
+    #vc-yes { border-color: var(--accent); background: var(--accent); color: #fff; box-shadow: 0 2px 0 var(--accent-down); }
+    #vc-yes:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    /* two-step machine: s1 (vote) by default, s2 (tester opt-in) after .step2 */
+    .vc-s2 { display: none; }
+    #vote-card.step2 .vc-s1 { display: none; }
+    #vote-card.step2 .vc-s2 { display: block; }
+    #vc-tester {
+      display: block; width: 100%; min-height: 46px; line-height: 46px; border-radius: 11px;
+      background: var(--accent); color: #fff; font-weight: 700; font-size: 14px; text-decoration: none;
+      box-shadow: 0 2px 0 var(--accent-down);
+    }
+    #vc-tester:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    #vc-later {
+      display: block; margin: 10px auto 0; color: var(--muted); font-size: 12px;
+      text-decoration: underline; min-height: 32px; padding: 0 8px;
+    }
 
     #toast {
       position: fixed; left: 50%; transform: translateX(-50%); bottom: 130px; z-index: 40;
@@ -1101,6 +1154,35 @@
       <a id="ic-guide" class="ic-guide" target="_blank" rel="noopener" hidden>Lihat panduan resmi →</a>
     </div>
     <button id="ic-never">jangan tampilkan lagi</button>
+  </div>
+
+  <!-- TEMPORARY: Play Store demand-validation vote. Shown at the download moment
+       IN PLACE OF the share/tip card during the drive (js/v2/playstore-vote.js;
+       toggled by PLAYSTORE_CAMPAIGN in celebrate.js). Two steps: binary vote →
+       tester opt-in for "Ya" voters only. Centered + scrim (founder call: more
+       attention than the quiet bottom card). -->
+  <div id="vote-card" aria-hidden="true">
+    <div class="vc-inner" role="dialog" aria-label="Mau PDFLokal di Play Store?">
+      <button id="vc-close" aria-label="Tutup">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+      <div class="vc-step vc-s1">
+        <span class="vc-eyebrow">Kabar PDFLokal</span>
+        <div class="vc-head">Mau PDFLokal ada di Play Store?</div>
+        <p class="vc-sub">Biar bisa kamu install sekali tap — jalan tanpa internet, layar penuh buat ngedit, dan tetap 100% di HP-mu.</p>
+        <div class="vc-actions">
+          <button id="vc-no">Nggak perlu</button>
+          <button id="vc-yes">Ya, mau</button>
+        </div>
+      </div>
+      <div class="vc-step vc-s2">
+        <span class="vc-eyebrow">Bantu wujudkan</span>
+        <div class="vc-head">Mau bantu jadi tester?</div>
+        <p class="vc-sub">Google minta 15 orang nyoba dulu selama 2 minggu biar PDFLokal lolos. Gampang — cukup install &amp; sesekali dibuka.</p>
+        <a id="vc-tester" href="#" target="_blank" rel="noopener">Jadi tester &rarr;</a>
+        <button id="vc-later">Nanti aja</button>
+      </div>
+    </div>
   </div>
 
   <dialog id="pm-sheet" aria-label="Kelola halaman">

--- a/kompres-pdf-500kb.html
+++ b/kompres-pdf-500kb.html
@@ -766,6 +766,59 @@
       display: block; margin: 8px auto 0; color: var(--muted); font-size: 11px;
       text-decoration: underline; min-height: 32px; padding: 0 8px;
     }
+    /* ---- Play Store vote (TEMPORARY drive) — centered + scrim, more presence
+       than the quiet cards; still non-modal (scrim tap dismisses, file saved) ---- */
+    #vote-card {
+      position: fixed; inset: 0; z-index: 120; display: flex;
+      align-items: center; justify-content: center; padding: 20px;
+      background: rgba(20,16,12,.42);
+      opacity: 0; visibility: hidden; pointer-events: none;
+      transition: opacity .28s ease, visibility 0s linear .28s;
+    }
+    #vote-card.show { opacity: 1; visibility: visible; pointer-events: auto; transition-delay: 0s; }
+    .vc-inner {
+      position: relative; width: min(92vw, 340px); background: var(--surface);
+      border-radius: 18px; padding: 22px 20px 16px; text-align: center;
+      box-shadow: 0 18px 50px rgba(15,18,26,.34); border: 1px solid var(--line);
+      transform: translateY(10px) scale(.98);
+      transition: transform .28s cubic-bezier(.34,1.4,.44,1);
+    }
+    #vote-card.show .vc-inner { transform: none; }
+    @media (prefers-reduced-motion: reduce) { #vote-card, .vc-inner { transition: none; } }
+    #vc-close {
+      position: absolute; top: 8px; right: 8px; width: 32px; height: 32px;
+      display: inline-flex; align-items: center; justify-content: center;
+      color: var(--muted); border-radius: 8px;
+    }
+    #vc-close svg { width: 16px; height: 16px; }
+    .vc-eyebrow {
+      display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: .06em;
+      text-transform: uppercase; color: var(--accent); background: rgba(220,38,38,.08);
+      padding: 4px 11px; border-radius: 999px; margin-bottom: 12px;
+    }
+    .vc-head { font-size: 18px; font-weight: 700; color: var(--ink); line-height: 1.3; margin-bottom: 8px; }
+    .vc-sub { font-size: 12.8px; color: var(--muted); line-height: 1.5; margin-bottom: 16px; }
+    .vc-actions { display: flex; gap: 9px; }
+    .vc-actions button {
+      flex: 1; min-height: 46px; border-radius: 11px; font: inherit; font-size: 14px; font-weight: 700;
+      border: 1.5px solid var(--line); background: var(--bg); color: var(--ink);
+    }
+    #vc-yes { border-color: var(--accent); background: var(--accent); color: #fff; box-shadow: 0 2px 0 var(--accent-down); }
+    #vc-yes:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    /* two-step machine: s1 (vote) by default, s2 (tester opt-in) after .step2 */
+    .vc-s2 { display: none; }
+    #vote-card.step2 .vc-s1 { display: none; }
+    #vote-card.step2 .vc-s2 { display: block; }
+    #vc-tester {
+      display: block; width: 100%; min-height: 46px; line-height: 46px; border-radius: 11px;
+      background: var(--accent); color: #fff; font-weight: 700; font-size: 14px; text-decoration: none;
+      box-shadow: 0 2px 0 var(--accent-down);
+    }
+    #vc-tester:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    #vc-later {
+      display: block; margin: 10px auto 0; color: var(--muted); font-size: 12px;
+      text-decoration: underline; min-height: 32px; padding: 0 8px;
+    }
 
     #toast {
       position: fixed; left: 50%; transform: translateX(-50%); bottom: 130px; z-index: 40;
@@ -1093,6 +1146,35 @@
       <a id="ic-guide" class="ic-guide" target="_blank" rel="noopener" hidden>Lihat panduan resmi →</a>
     </div>
     <button id="ic-never">jangan tampilkan lagi</button>
+  </div>
+
+  <!-- TEMPORARY: Play Store demand-validation vote. Shown at the download moment
+       IN PLACE OF the share/tip card during the drive (js/v2/playstore-vote.js;
+       toggled by PLAYSTORE_CAMPAIGN in celebrate.js). Two steps: binary vote →
+       tester opt-in for "Ya" voters only. Centered + scrim (founder call: more
+       attention than the quiet bottom card). -->
+  <div id="vote-card" aria-hidden="true">
+    <div class="vc-inner" role="dialog" aria-label="Mau PDFLokal di Play Store?">
+      <button id="vc-close" aria-label="Tutup">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+      <div class="vc-step vc-s1">
+        <span class="vc-eyebrow">Kabar PDFLokal</span>
+        <div class="vc-head">Mau PDFLokal ada di Play Store?</div>
+        <p class="vc-sub">Biar bisa kamu install sekali tap — jalan tanpa internet, layar penuh buat ngedit, dan tetap 100% di HP-mu.</p>
+        <div class="vc-actions">
+          <button id="vc-no">Nggak perlu</button>
+          <button id="vc-yes">Ya, mau</button>
+        </div>
+      </div>
+      <div class="vc-step vc-s2">
+        <span class="vc-eyebrow">Bantu wujudkan</span>
+        <div class="vc-head">Mau bantu jadi tester?</div>
+        <p class="vc-sub">Google minta 15 orang nyoba dulu selama 2 minggu biar PDFLokal lolos. Gampang — cukup install &amp; sesekali dibuka.</p>
+        <a id="vc-tester" href="#" target="_blank" rel="noopener">Jadi tester &rarr;</a>
+        <button id="vc-later">Nanti aja</button>
+      </div>
+    </div>
   </div>
 
   <dialog id="pm-sheet" aria-label="Kelola halaman">

--- a/kompres-pdf.html
+++ b/kompres-pdf.html
@@ -766,6 +766,59 @@
       display: block; margin: 8px auto 0; color: var(--muted); font-size: 11px;
       text-decoration: underline; min-height: 32px; padding: 0 8px;
     }
+    /* ---- Play Store vote (TEMPORARY drive) — centered + scrim, more presence
+       than the quiet cards; still non-modal (scrim tap dismisses, file saved) ---- */
+    #vote-card {
+      position: fixed; inset: 0; z-index: 120; display: flex;
+      align-items: center; justify-content: center; padding: 20px;
+      background: rgba(20,16,12,.42);
+      opacity: 0; visibility: hidden; pointer-events: none;
+      transition: opacity .28s ease, visibility 0s linear .28s;
+    }
+    #vote-card.show { opacity: 1; visibility: visible; pointer-events: auto; transition-delay: 0s; }
+    .vc-inner {
+      position: relative; width: min(92vw, 340px); background: var(--surface);
+      border-radius: 18px; padding: 22px 20px 16px; text-align: center;
+      box-shadow: 0 18px 50px rgba(15,18,26,.34); border: 1px solid var(--line);
+      transform: translateY(10px) scale(.98);
+      transition: transform .28s cubic-bezier(.34,1.4,.44,1);
+    }
+    #vote-card.show .vc-inner { transform: none; }
+    @media (prefers-reduced-motion: reduce) { #vote-card, .vc-inner { transition: none; } }
+    #vc-close {
+      position: absolute; top: 8px; right: 8px; width: 32px; height: 32px;
+      display: inline-flex; align-items: center; justify-content: center;
+      color: var(--muted); border-radius: 8px;
+    }
+    #vc-close svg { width: 16px; height: 16px; }
+    .vc-eyebrow {
+      display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: .06em;
+      text-transform: uppercase; color: var(--accent); background: rgba(220,38,38,.08);
+      padding: 4px 11px; border-radius: 999px; margin-bottom: 12px;
+    }
+    .vc-head { font-size: 18px; font-weight: 700; color: var(--ink); line-height: 1.3; margin-bottom: 8px; }
+    .vc-sub { font-size: 12.8px; color: var(--muted); line-height: 1.5; margin-bottom: 16px; }
+    .vc-actions { display: flex; gap: 9px; }
+    .vc-actions button {
+      flex: 1; min-height: 46px; border-radius: 11px; font: inherit; font-size: 14px; font-weight: 700;
+      border: 1.5px solid var(--line); background: var(--bg); color: var(--ink);
+    }
+    #vc-yes { border-color: var(--accent); background: var(--accent); color: #fff; box-shadow: 0 2px 0 var(--accent-down); }
+    #vc-yes:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    /* two-step machine: s1 (vote) by default, s2 (tester opt-in) after .step2 */
+    .vc-s2 { display: none; }
+    #vote-card.step2 .vc-s1 { display: none; }
+    #vote-card.step2 .vc-s2 { display: block; }
+    #vc-tester {
+      display: block; width: 100%; min-height: 46px; line-height: 46px; border-radius: 11px;
+      background: var(--accent); color: #fff; font-weight: 700; font-size: 14px; text-decoration: none;
+      box-shadow: 0 2px 0 var(--accent-down);
+    }
+    #vc-tester:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    #vc-later {
+      display: block; margin: 10px auto 0; color: var(--muted); font-size: 12px;
+      text-decoration: underline; min-height: 32px; padding: 0 8px;
+    }
 
     #toast {
       position: fixed; left: 50%; transform: translateX(-50%); bottom: 130px; z-index: 40;
@@ -1114,6 +1167,35 @@
       <a id="ic-guide" class="ic-guide" target="_blank" rel="noopener" hidden>Lihat panduan resmi →</a>
     </div>
     <button id="ic-never">jangan tampilkan lagi</button>
+  </div>
+
+  <!-- TEMPORARY: Play Store demand-validation vote. Shown at the download moment
+       IN PLACE OF the share/tip card during the drive (js/v2/playstore-vote.js;
+       toggled by PLAYSTORE_CAMPAIGN in celebrate.js). Two steps: binary vote →
+       tester opt-in for "Ya" voters only. Centered + scrim (founder call: more
+       attention than the quiet bottom card). -->
+  <div id="vote-card" aria-hidden="true">
+    <div class="vc-inner" role="dialog" aria-label="Mau PDFLokal di Play Store?">
+      <button id="vc-close" aria-label="Tutup">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+      <div class="vc-step vc-s1">
+        <span class="vc-eyebrow">Kabar PDFLokal</span>
+        <div class="vc-head">Mau PDFLokal ada di Play Store?</div>
+        <p class="vc-sub">Biar bisa kamu install sekali tap — jalan tanpa internet, layar penuh buat ngedit, dan tetap 100% di HP-mu.</p>
+        <div class="vc-actions">
+          <button id="vc-no">Nggak perlu</button>
+          <button id="vc-yes">Ya, mau</button>
+        </div>
+      </div>
+      <div class="vc-step vc-s2">
+        <span class="vc-eyebrow">Bantu wujudkan</span>
+        <div class="vc-head">Mau bantu jadi tester?</div>
+        <p class="vc-sub">Google minta 15 orang nyoba dulu selama 2 minggu biar PDFLokal lolos. Gampang — cukup install &amp; sesekali dibuka.</p>
+        <a id="vc-tester" href="#" target="_blank" rel="noopener">Jadi tester &rarr;</a>
+        <button id="vc-later">Nanti aja</button>
+      </div>
+    </div>
   </div>
 
   <dialog id="pm-sheet" aria-label="Kelola halaman">

--- a/pdf-ke-jpg.html
+++ b/pdf-ke-jpg.html
@@ -766,6 +766,59 @@
       display: block; margin: 8px auto 0; color: var(--muted); font-size: 11px;
       text-decoration: underline; min-height: 32px; padding: 0 8px;
     }
+    /* ---- Play Store vote (TEMPORARY drive) — centered + scrim, more presence
+       than the quiet cards; still non-modal (scrim tap dismisses, file saved) ---- */
+    #vote-card {
+      position: fixed; inset: 0; z-index: 120; display: flex;
+      align-items: center; justify-content: center; padding: 20px;
+      background: rgba(20,16,12,.42);
+      opacity: 0; visibility: hidden; pointer-events: none;
+      transition: opacity .28s ease, visibility 0s linear .28s;
+    }
+    #vote-card.show { opacity: 1; visibility: visible; pointer-events: auto; transition-delay: 0s; }
+    .vc-inner {
+      position: relative; width: min(92vw, 340px); background: var(--surface);
+      border-radius: 18px; padding: 22px 20px 16px; text-align: center;
+      box-shadow: 0 18px 50px rgba(15,18,26,.34); border: 1px solid var(--line);
+      transform: translateY(10px) scale(.98);
+      transition: transform .28s cubic-bezier(.34,1.4,.44,1);
+    }
+    #vote-card.show .vc-inner { transform: none; }
+    @media (prefers-reduced-motion: reduce) { #vote-card, .vc-inner { transition: none; } }
+    #vc-close {
+      position: absolute; top: 8px; right: 8px; width: 32px; height: 32px;
+      display: inline-flex; align-items: center; justify-content: center;
+      color: var(--muted); border-radius: 8px;
+    }
+    #vc-close svg { width: 16px; height: 16px; }
+    .vc-eyebrow {
+      display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: .06em;
+      text-transform: uppercase; color: var(--accent); background: rgba(220,38,38,.08);
+      padding: 4px 11px; border-radius: 999px; margin-bottom: 12px;
+    }
+    .vc-head { font-size: 18px; font-weight: 700; color: var(--ink); line-height: 1.3; margin-bottom: 8px; }
+    .vc-sub { font-size: 12.8px; color: var(--muted); line-height: 1.5; margin-bottom: 16px; }
+    .vc-actions { display: flex; gap: 9px; }
+    .vc-actions button {
+      flex: 1; min-height: 46px; border-radius: 11px; font: inherit; font-size: 14px; font-weight: 700;
+      border: 1.5px solid var(--line); background: var(--bg); color: var(--ink);
+    }
+    #vc-yes { border-color: var(--accent); background: var(--accent); color: #fff; box-shadow: 0 2px 0 var(--accent-down); }
+    #vc-yes:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    /* two-step machine: s1 (vote) by default, s2 (tester opt-in) after .step2 */
+    .vc-s2 { display: none; }
+    #vote-card.step2 .vc-s1 { display: none; }
+    #vote-card.step2 .vc-s2 { display: block; }
+    #vc-tester {
+      display: block; width: 100%; min-height: 46px; line-height: 46px; border-radius: 11px;
+      background: var(--accent); color: #fff; font-weight: 700; font-size: 14px; text-decoration: none;
+      box-shadow: 0 2px 0 var(--accent-down);
+    }
+    #vc-tester:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    #vc-later {
+      display: block; margin: 10px auto 0; color: var(--muted); font-size: 12px;
+      text-decoration: underline; min-height: 32px; padding: 0 8px;
+    }
 
     #toast {
       position: fixed; left: 50%; transform: translateX(-50%); bottom: 130px; z-index: 40;
@@ -1111,6 +1164,35 @@
       <a id="ic-guide" class="ic-guide" target="_blank" rel="noopener" hidden>Lihat panduan resmi →</a>
     </div>
     <button id="ic-never">jangan tampilkan lagi</button>
+  </div>
+
+  <!-- TEMPORARY: Play Store demand-validation vote. Shown at the download moment
+       IN PLACE OF the share/tip card during the drive (js/v2/playstore-vote.js;
+       toggled by PLAYSTORE_CAMPAIGN in celebrate.js). Two steps: binary vote →
+       tester opt-in for "Ya" voters only. Centered + scrim (founder call: more
+       attention than the quiet bottom card). -->
+  <div id="vote-card" aria-hidden="true">
+    <div class="vc-inner" role="dialog" aria-label="Mau PDFLokal di Play Store?">
+      <button id="vc-close" aria-label="Tutup">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+      <div class="vc-step vc-s1">
+        <span class="vc-eyebrow">Kabar PDFLokal</span>
+        <div class="vc-head">Mau PDFLokal ada di Play Store?</div>
+        <p class="vc-sub">Biar bisa kamu install sekali tap — jalan tanpa internet, layar penuh buat ngedit, dan tetap 100% di HP-mu.</p>
+        <div class="vc-actions">
+          <button id="vc-no">Nggak perlu</button>
+          <button id="vc-yes">Ya, mau</button>
+        </div>
+      </div>
+      <div class="vc-step vc-s2">
+        <span class="vc-eyebrow">Bantu wujudkan</span>
+        <div class="vc-head">Mau bantu jadi tester?</div>
+        <p class="vc-sub">Google minta 15 orang nyoba dulu selama 2 minggu biar PDFLokal lolos. Gampang — cukup install &amp; sesekali dibuka.</p>
+        <a id="vc-tester" href="#" target="_blank" rel="noopener">Jadi tester &rarr;</a>
+        <button id="vc-later">Nanti aja</button>
+      </div>
+    </div>
   </div>
 
   <dialog id="pm-sheet" aria-label="Kelola halaman">

--- a/pisah-pdf.html
+++ b/pisah-pdf.html
@@ -766,6 +766,59 @@
       display: block; margin: 8px auto 0; color: var(--muted); font-size: 11px;
       text-decoration: underline; min-height: 32px; padding: 0 8px;
     }
+    /* ---- Play Store vote (TEMPORARY drive) — centered + scrim, more presence
+       than the quiet cards; still non-modal (scrim tap dismisses, file saved) ---- */
+    #vote-card {
+      position: fixed; inset: 0; z-index: 120; display: flex;
+      align-items: center; justify-content: center; padding: 20px;
+      background: rgba(20,16,12,.42);
+      opacity: 0; visibility: hidden; pointer-events: none;
+      transition: opacity .28s ease, visibility 0s linear .28s;
+    }
+    #vote-card.show { opacity: 1; visibility: visible; pointer-events: auto; transition-delay: 0s; }
+    .vc-inner {
+      position: relative; width: min(92vw, 340px); background: var(--surface);
+      border-radius: 18px; padding: 22px 20px 16px; text-align: center;
+      box-shadow: 0 18px 50px rgba(15,18,26,.34); border: 1px solid var(--line);
+      transform: translateY(10px) scale(.98);
+      transition: transform .28s cubic-bezier(.34,1.4,.44,1);
+    }
+    #vote-card.show .vc-inner { transform: none; }
+    @media (prefers-reduced-motion: reduce) { #vote-card, .vc-inner { transition: none; } }
+    #vc-close {
+      position: absolute; top: 8px; right: 8px; width: 32px; height: 32px;
+      display: inline-flex; align-items: center; justify-content: center;
+      color: var(--muted); border-radius: 8px;
+    }
+    #vc-close svg { width: 16px; height: 16px; }
+    .vc-eyebrow {
+      display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: .06em;
+      text-transform: uppercase; color: var(--accent); background: rgba(220,38,38,.08);
+      padding: 4px 11px; border-radius: 999px; margin-bottom: 12px;
+    }
+    .vc-head { font-size: 18px; font-weight: 700; color: var(--ink); line-height: 1.3; margin-bottom: 8px; }
+    .vc-sub { font-size: 12.8px; color: var(--muted); line-height: 1.5; margin-bottom: 16px; }
+    .vc-actions { display: flex; gap: 9px; }
+    .vc-actions button {
+      flex: 1; min-height: 46px; border-radius: 11px; font: inherit; font-size: 14px; font-weight: 700;
+      border: 1.5px solid var(--line); background: var(--bg); color: var(--ink);
+    }
+    #vc-yes { border-color: var(--accent); background: var(--accent); color: #fff; box-shadow: 0 2px 0 var(--accent-down); }
+    #vc-yes:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    /* two-step machine: s1 (vote) by default, s2 (tester opt-in) after .step2 */
+    .vc-s2 { display: none; }
+    #vote-card.step2 .vc-s1 { display: none; }
+    #vote-card.step2 .vc-s2 { display: block; }
+    #vc-tester {
+      display: block; width: 100%; min-height: 46px; line-height: 46px; border-radius: 11px;
+      background: var(--accent); color: #fff; font-weight: 700; font-size: 14px; text-decoration: none;
+      box-shadow: 0 2px 0 var(--accent-down);
+    }
+    #vc-tester:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    #vc-later {
+      display: block; margin: 10px auto 0; color: var(--muted); font-size: 12px;
+      text-decoration: underline; min-height: 32px; padding: 0 8px;
+    }
 
     #toast {
       position: fixed; left: 50%; transform: translateX(-50%); bottom: 130px; z-index: 40;
@@ -1111,6 +1164,35 @@
       <a id="ic-guide" class="ic-guide" target="_blank" rel="noopener" hidden>Lihat panduan resmi →</a>
     </div>
     <button id="ic-never">jangan tampilkan lagi</button>
+  </div>
+
+  <!-- TEMPORARY: Play Store demand-validation vote. Shown at the download moment
+       IN PLACE OF the share/tip card during the drive (js/v2/playstore-vote.js;
+       toggled by PLAYSTORE_CAMPAIGN in celebrate.js). Two steps: binary vote →
+       tester opt-in for "Ya" voters only. Centered + scrim (founder call: more
+       attention than the quiet bottom card). -->
+  <div id="vote-card" aria-hidden="true">
+    <div class="vc-inner" role="dialog" aria-label="Mau PDFLokal di Play Store?">
+      <button id="vc-close" aria-label="Tutup">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+      <div class="vc-step vc-s1">
+        <span class="vc-eyebrow">Kabar PDFLokal</span>
+        <div class="vc-head">Mau PDFLokal ada di Play Store?</div>
+        <p class="vc-sub">Biar bisa kamu install sekali tap — jalan tanpa internet, layar penuh buat ngedit, dan tetap 100% di HP-mu.</p>
+        <div class="vc-actions">
+          <button id="vc-no">Nggak perlu</button>
+          <button id="vc-yes">Ya, mau</button>
+        </div>
+      </div>
+      <div class="vc-step vc-s2">
+        <span class="vc-eyebrow">Bantu wujudkan</span>
+        <div class="vc-head">Mau bantu jadi tester?</div>
+        <p class="vc-sub">Google minta 15 orang nyoba dulu selama 2 minggu biar PDFLokal lolos. Gampang — cukup install &amp; sesekali dibuka.</p>
+        <a id="vc-tester" href="#" target="_blank" rel="noopener">Jadi tester &rarr;</a>
+        <button id="vc-later">Nanti aja</button>
+      </div>
+    </div>
   </div>
 
   <dialog id="pm-sheet" aria-label="Kelola halaman">

--- a/tanda-tangan-pdf.html
+++ b/tanda-tangan-pdf.html
@@ -766,6 +766,59 @@
       display: block; margin: 8px auto 0; color: var(--muted); font-size: 11px;
       text-decoration: underline; min-height: 32px; padding: 0 8px;
     }
+    /* ---- Play Store vote (TEMPORARY drive) — centered + scrim, more presence
+       than the quiet cards; still non-modal (scrim tap dismisses, file saved) ---- */
+    #vote-card {
+      position: fixed; inset: 0; z-index: 120; display: flex;
+      align-items: center; justify-content: center; padding: 20px;
+      background: rgba(20,16,12,.42);
+      opacity: 0; visibility: hidden; pointer-events: none;
+      transition: opacity .28s ease, visibility 0s linear .28s;
+    }
+    #vote-card.show { opacity: 1; visibility: visible; pointer-events: auto; transition-delay: 0s; }
+    .vc-inner {
+      position: relative; width: min(92vw, 340px); background: var(--surface);
+      border-radius: 18px; padding: 22px 20px 16px; text-align: center;
+      box-shadow: 0 18px 50px rgba(15,18,26,.34); border: 1px solid var(--line);
+      transform: translateY(10px) scale(.98);
+      transition: transform .28s cubic-bezier(.34,1.4,.44,1);
+    }
+    #vote-card.show .vc-inner { transform: none; }
+    @media (prefers-reduced-motion: reduce) { #vote-card, .vc-inner { transition: none; } }
+    #vc-close {
+      position: absolute; top: 8px; right: 8px; width: 32px; height: 32px;
+      display: inline-flex; align-items: center; justify-content: center;
+      color: var(--muted); border-radius: 8px;
+    }
+    #vc-close svg { width: 16px; height: 16px; }
+    .vc-eyebrow {
+      display: inline-block; font-size: 11px; font-weight: 700; letter-spacing: .06em;
+      text-transform: uppercase; color: var(--accent); background: rgba(220,38,38,.08);
+      padding: 4px 11px; border-radius: 999px; margin-bottom: 12px;
+    }
+    .vc-head { font-size: 18px; font-weight: 700; color: var(--ink); line-height: 1.3; margin-bottom: 8px; }
+    .vc-sub { font-size: 12.8px; color: var(--muted); line-height: 1.5; margin-bottom: 16px; }
+    .vc-actions { display: flex; gap: 9px; }
+    .vc-actions button {
+      flex: 1; min-height: 46px; border-radius: 11px; font: inherit; font-size: 14px; font-weight: 700;
+      border: 1.5px solid var(--line); background: var(--bg); color: var(--ink);
+    }
+    #vc-yes { border-color: var(--accent); background: var(--accent); color: #fff; box-shadow: 0 2px 0 var(--accent-down); }
+    #vc-yes:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    /* two-step machine: s1 (vote) by default, s2 (tester opt-in) after .step2 */
+    .vc-s2 { display: none; }
+    #vote-card.step2 .vc-s1 { display: none; }
+    #vote-card.step2 .vc-s2 { display: block; }
+    #vc-tester {
+      display: block; width: 100%; min-height: 46px; line-height: 46px; border-radius: 11px;
+      background: var(--accent); color: #fff; font-weight: 700; font-size: 14px; text-decoration: none;
+      box-shadow: 0 2px 0 var(--accent-down);
+    }
+    #vc-tester:active { transform: translateY(1px); box-shadow: 0 1px 0 var(--accent-down); }
+    #vc-later {
+      display: block; margin: 10px auto 0; color: var(--muted); font-size: 12px;
+      text-decoration: underline; min-height: 32px; padding: 0 8px;
+    }
 
     #toast {
       position: fixed; left: 50%; transform: translateX(-50%); bottom: 130px; z-index: 40;
@@ -1110,6 +1163,35 @@
       <a id="ic-guide" class="ic-guide" target="_blank" rel="noopener" hidden>Lihat panduan resmi →</a>
     </div>
     <button id="ic-never">jangan tampilkan lagi</button>
+  </div>
+
+  <!-- TEMPORARY: Play Store demand-validation vote. Shown at the download moment
+       IN PLACE OF the share/tip card during the drive (js/v2/playstore-vote.js;
+       toggled by PLAYSTORE_CAMPAIGN in celebrate.js). Two steps: binary vote →
+       tester opt-in for "Ya" voters only. Centered + scrim (founder call: more
+       attention than the quiet bottom card). -->
+  <div id="vote-card" aria-hidden="true">
+    <div class="vc-inner" role="dialog" aria-label="Mau PDFLokal di Play Store?">
+      <button id="vc-close" aria-label="Tutup">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+      </button>
+      <div class="vc-step vc-s1">
+        <span class="vc-eyebrow">Kabar PDFLokal</span>
+        <div class="vc-head">Mau PDFLokal ada di Play Store?</div>
+        <p class="vc-sub">Biar bisa kamu install sekali tap — jalan tanpa internet, layar penuh buat ngedit, dan tetap 100% di HP-mu.</p>
+        <div class="vc-actions">
+          <button id="vc-no">Nggak perlu</button>
+          <button id="vc-yes">Ya, mau</button>
+        </div>
+      </div>
+      <div class="vc-step vc-s2">
+        <span class="vc-eyebrow">Bantu wujudkan</span>
+        <div class="vc-head">Mau bantu jadi tester?</div>
+        <p class="vc-sub">Google minta 15 orang nyoba dulu selama 2 minggu biar PDFLokal lolos. Gampang — cukup install &amp; sesekali dibuka.</p>
+        <a id="vc-tester" href="#" target="_blank" rel="noopener">Jadi tester &rarr;</a>
+        <button id="vc-later">Nanti aja</button>
+      </div>
+    </div>
   </div>
 
   <dialog id="pm-sheet" aria-label="Kelola halaman">

--- a/tests/mobile/growth-loop.spec.js
+++ b/tests/mobile/growth-loop.spec.js
@@ -23,6 +23,15 @@ async function openDoc(page) {
 }
 
 test.describe('growth loop — mobile', () => {
+  // TEMPORARY: during the Play Store drive the vote card takes the download
+  // moment from share/tip for un-voted users. These tests exercise share/tip
+  // itself, so we mark the vote as already cast — the moment then falls through
+  // to share/tip, exactly as it does for a voted user or once the drive ends.
+  // (Remove this hook when PLAYSTORE_CAMPAIGN is retired.)
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => localStorage.setItem('pdflokal-ps-voted', '1'));
+  });
+
   test('download celebrates (BERES stamp) and then invites — once per day', async ({ page }) => {
     await openDoc(page);
     await downloadOnce(page);

--- a/tests/mobile/playstore-vote.spec.js
+++ b/tests/mobile/playstore-vote.spec.js
@@ -1,0 +1,110 @@
+/*
+ * TEMPORARY — Play Store demand-validation vote (js/v2/playstore-vote.js).
+ * At the download moment, during the drive, the binary vote takes the slot from
+ * share/tip. Two steps: vote → tester opt-in (only for "Ya"). GA4 events +
+ * gating (vote once, never re-ask; dismiss backs off for the day).
+ *
+ * When PLAYSTORE_CAMPAIGN flips to false in celebrate.js, retire this file with
+ * the module. Until then, this suite is the guard on the drive's behavior.
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(__dirname, '..', 'fixtures', 'sample-2pages.pdf');
+
+async function downloadOnce(page) {
+  await page.tap('#btn-download');
+  const dl = page.waitForEvent('download');
+  await page.tap('#ds-cta');
+  await dl;
+}
+async function openDoc(page) {
+  await page.goto('/');
+  await page.setInputFiles('#file-input', FIXTURE);
+  await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+}
+// track() bails before gtag unless Vercel Analytics (window.va) is "loaded" —
+// locally the insights script 404s, so stub va as a function. track() then fans
+// out to the app's real inline gtag(), which pushes to window.dataLayer, where
+// we read the events (our own stub would be clobbered by that inline gtag).
+async function armAnalytics(page) {
+  await page.addInitScript(() => { window.va = () => {}; });
+}
+async function events(page) {
+  return page.evaluate(() => (window.dataLayer || []).map((a) => Array.from(a)));
+}
+
+test.describe('Play Store vote — mobile', () => {
+  test('download shows the vote (not share/tip); "Ya" reveals tester opt-in → form', async ({ page }) => {
+    await armAnalytics(page);
+    await openDoc(page);
+    await downloadOnce(page);
+
+    // The vote takes the moment; the share/tip card stays hidden.
+    await expect(page.locator('#vote-card')).toBeVisible({ timeout: 4000 });
+    await expect(page.locator('.vc-s1 .vc-head')).toContainText('Play Store');
+    await expect(page.locator('#support-card')).toBeHidden();
+
+    // "Ya, mau" → GA4 yes vote + step 2 (tester opt-in) revealed in place.
+    await page.tap('#vc-yes');
+    await expect(page.locator('#vote-card .vc-s2')).toBeVisible();
+    await expect(page.locator('#vote-card .vc-s1')).toBeHidden();
+    await expect(page.locator('#vc-tester')).toHaveAttribute('href', /forms\.gle\//);
+
+    const ev = await events(page);
+    expect(ev.some((a) => a[1] === 'vote_playstore' && a[2]?.choice === 'yes')).toBe(true);
+  });
+
+  test('"Nggak perlu" counts the no, closes, and never re-asks (voted)', async ({ page }) => {
+    await armAnalytics(page);
+    await openDoc(page);
+    await downloadOnce(page);
+    await expect(page.locator('#vote-card')).toBeVisible({ timeout: 4000 });
+
+    await page.tap('#vc-no');
+    await expect(page.locator('#vote-card')).toBeHidden();
+    const ev = await events(page);
+    expect(ev.some((a) => a[1] === 'vote_playstore' && a[2]?.choice === 'no')).toBe(true);
+
+    // Voted → the next download falls through to the normal share/tip card.
+    await downloadOnce(page);
+    await expect(page.locator('#support-card')).toBeVisible({ timeout: 4000 });
+    await expect(page.locator('#vote-card')).toBeHidden();
+  });
+
+  test('tester_optin fires on click-through to the form', async ({ page }) => {
+    await armAnalytics(page);
+    await openDoc(page);
+    await downloadOnce(page);
+    await page.tap('#vc-yes');
+    // Neutralize the real navigation (target _blank would open a popup); the
+    // click still runs the module's handler that fires the event.
+    await page.evaluate(() => {
+      const a = document.getElementById('vc-tester');
+      a.setAttribute('target', '_self');
+      a.setAttribute('href', '#');
+    });
+    await page.tap('#vc-tester');
+    const ev = await events(page);
+    expect(ev.some((a) => a[1] === 'tester_optin')).toBe(true);
+  });
+
+  test('scrim tap dismisses without voting; same day stays quiet', async ({ page }) => {
+    await openDoc(page);
+    await downloadOnce(page);
+    await expect(page.locator('#vote-card')).toBeVisible({ timeout: 4000 });
+
+    // Tap the scrim (top-left corner, outside the inner card) → dismiss, no vote.
+    await page.locator('#vote-card').click({ position: { x: 8, y: 8 } });
+    await expect(page.locator('#vote-card')).toBeHidden();
+    const voted = await page.evaluate(() => localStorage.getItem('pdflokal-ps-voted'));
+    expect(voted).toBeNull(); // dismissed ≠ voted; the file was never held hostage
+
+    // Same calendar day → no second ask.
+    await downloadOnce(page);
+    await page.waitForTimeout(1600);
+    await expect(page.locator('#vote-card')).toBeHidden();
+  });
+});


### PR DESCRIPTION
**TEMPORARY drive** (founder call 2026-07-19). During a Play Store demand test, the download moment shows a binary **"Mau PDFLokal ada di Play Store?"** vote *in place of* the share/tip card — the peak-enthusiasm slot spent, deliberately and temporarily, on a go/no-go signal.

### Flow
1. **Vote** (binary) → GA4 event `vote_playstore {choice: yes|no}`
2. Only **"Ya"** voters see the tester opt-in → the Google Form (`forms.gle/cWaqHGvDXi1Dapie6`) → GA4 `tester_optin`

The **yes→optin drop-off** is the real signal (a free "yes" skews positive).

### What's in it
- `js/v2/playstore-vote.js` — vote module. GA4-only (no backend/DB/CSP change), gating (vote once → never re-ask; dismiss backs off for the day), null-guard.
- `js/v2/celebrate.js` — `PLAYSTORE_CAMPAIGN` flag + branch; voters fall through to share/tip. **Flip the flag to `false` to end the drive** — nothing else to revert.
- `index.html` — `#vote-card` markup + CSS (centered + scrim; scrim tap dismisses — file never held hostage).
- SEO pages regenerated from index.html.
- Tests: new `playstore-vote.spec.js` (4 ✓); `growth-loop` seeds "voted" so it still exercises share/tip.

### Analytics
- GA4 event-scoped custom dimension **`vote_choice`** (param `choice`) registered **before** deploy (so votes are queryable forward — not retroactive).
- Post-deploy: verify `choice` populates in DebugView (the "check the last layer" step).

### Verification
- lint clean · `playstore-vote` 4/4 · `growth-loop + stamps + vote` 11/11 · both steps rendered on the real page (mobile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)