### PR TITLE
feat(telemetry): first-party typed content-blind telemetry rail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.MD - PDFLokal Project Guide
 
+> Role: a session here is the pdflokal DEVELOPER. The PM seat is `../` — read for context; write only shipped-fact reports. See `../CLAUDE.md`.
+
 ## ⚡ STATUS (July 3, 2026): V2 SHIPPED — pdflokal.id IS the clean rebuild
 
 **Read this section first; much of the rest of this file describes the OLD wing and awaits the demolition-phase rewrite.** Current product status/priorities live at the project seat: `../STATE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,5 @@
 # CLAUDE.MD - PDFLokal Project Guide
 
-> Role: a session here is the pdflokal DEVELOPER. The PM seat is `../` — read for context; write only shipped-fact reports. See `../CLAUDE.md`.
-
 ## ⚡ STATUS (July 3, 2026): V2 SHIPPED — pdflokal.id IS the clean rebuild
 
 **Read this section first; much of the rest of this file describes the OLD wing and awaits the demolition-phase rewrite.** Current product status/priorities live at the project seat: `../STATE.md`.

--- a/api/t.js
+++ b/api/t.js
@@ -1,0 +1,132 @@
+/*
+ * PDFLokal — api/t.js  (telemetry sink — Vercel serverless function, Node ESM)
+ * ============================================================================
+ * spec-telemetry.md §1/§6. POST-only. Validates every event against the SAME
+ * schema module the client uses (js/core/telemetry-schema.js) so client and
+ * server can never drift on what's allowed. An off-schema event, or a
+ * malformed envelope, is a DECLINE (dropped) — never a 400 that would fail
+ * an otherwise-good batch for one bad event, or an error the client has to
+ * handle. This endpoint responds 204 in every case except a non-POST method.
+ *
+ * No npm dependencies at all (task law: the client stays no-build-step; this
+ * function is server code Vercel deploys, but it stays equally dependency-
+ * free) — inserts go straight to Supabase's PostgREST endpoint via plain
+ * fetch with the service-role key, which bypasses RLS (the migration leaves
+ * the `events` table RLS-on-with-no-policies: service key in, anon/
+ * authenticated get nothing).
+ *
+ * Never stores IP or UA raw (spec §2) — neither is read from the request at
+ * all; the client already sends a coarse, typed `device` prop where relevant.
+ */
+
+// bodyParser MUST be off: we enforce the ≤32KB cap by counting raw bytes off
+// the stream ourselves. If Vercel's default JSON body-parser ran first, it
+// would already have consumed the request stream by the time this handler
+// sees `req`, and our own req.on('data') would never fire (readBody() would
+// hang until the function times out). Same config key on Vercel's Node
+// functions as Next.js API routes (@vercel/node implements the same bridge).
+export const config = { runtime: 'nodejs', api: { bodyParser: false } };
+
+import { validateEvent } from '../js/core/telemetry-schema.js';
+
+const MAX_EVENTS = 50;
+const MAX_BODY_BYTES = 32 * 1024;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const APP_VERSION_RE = /^[0-9a-f]{7,40}$|^dev$/;
+
+// Reads the request body as text, capping at maxBytes. Returns null (never
+// throws) if the stream errors OR the cap is exceeded — both are treated as
+// "can't use this request", which the handler turns into a fast 204.
+function readBody(req, maxBytes) {
+  return new Promise((resolve) => {
+    let size = 0;
+    let over = false;
+    const chunks = [];
+    req.on('data', (chunk) => {
+      if (over) return;
+      size += chunk.length;
+      if (size > maxBytes) { over = true; return; }
+      chunks.push(chunk);
+    });
+    req.on('end', () => resolve(over ? null : Buffer.concat(chunks).toString('utf8')));
+    req.on('error', () => resolve(null));
+  });
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).end();
+    return;
+  }
+
+  try {
+    const raw = await readBody(req, MAX_BODY_BYTES);
+    if (raw === null) { res.status(204).end(); return; } // over budget or unreadable — drop
+
+    let envelope;
+    try {
+      envelope = JSON.parse(raw);
+    } catch {
+      res.status(204).end(); // malformed envelope — drop, never error to the client
+      return;
+    }
+
+    const sessionId = envelope?.session_id;
+    const appVersion = envelope?.app_version;
+    const events = Array.isArray(envelope?.events) ? envelope.events : null;
+
+    // session_id must be a real UUID and app_version must match the expected
+    // shape (a commit SHA or literally 'dev') — either failing means we
+    // can't trust the envelope at all, so the WHOLE batch is dropped (per
+    // spec: "if ALL are invalid or the envelope is malformed, 204 anyway").
+    if (
+      typeof sessionId !== 'string' || !UUID_RE.test(sessionId)
+      || typeof appVersion !== 'string' || !APP_VERSION_RE.test(appVersion)
+      || !events || events.length === 0
+    ) {
+      res.status(204).end();
+      return;
+    }
+
+    const capped = events.slice(0, MAX_EVENTS);
+    const ts = new Date().toISOString();
+    const rows = [];
+    for (const e of capped) {
+      if (!e || typeof e.event !== 'string') continue; // malformed single event — drop it, not the batch
+      const { ok, clean } = validateEvent(e.event, e.props);
+      if (!ok) continue; // off-schema single event — silently dropped, never 400s the batch
+      rows.push({ ts, session_id: sessionId, app_version: appVersion, event: e.event, props: clean });
+    }
+
+    if (rows.length === 0) { res.status(204).end(); return; }
+
+    const url = process.env.TELEMETRY_SUPABASE_URL;
+    const key = process.env.TELEMETRY_SUPABASE_SERVICE_KEY;
+    if (!url || !key) { res.status(204).end(); return; } // rail dark (env not configured yet), never broken
+
+    // Awaited on purpose (not true fire-and-forget): a Vercel Node invocation
+    // can be frozen the instant a response is sent, so an un-awaited insert
+    // could silently never land. The extra Supabase round-trip (tens of ms)
+    // is invisible to the browser — sendBeacon doesn't wait on this response.
+    try {
+      await fetch(`${url}/rest/v1/events`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: key,
+          Authorization: `Bearer ${key}`,
+          Prefer: 'return=minimal',
+        },
+        body: JSON.stringify(rows),
+      });
+    } catch {
+      // Insert failed (network, Supabase down, etc.) — still a fast 204;
+      // the client never learns telemetry failed (spec: never block/delay UX).
+    }
+
+    res.status(204).end();
+  } catch {
+    // Absolutely never surface a 5xx for a telemetry drop.
+    res.status(204).end();
+  }
+}

--- a/js/core/import.js
+++ b/js/core/import.js
@@ -47,6 +47,25 @@ export async function importPdf(doc, { name, bytes }) {
   return pages;
 }
 
+// Additive, standalone from importPdf's own document handle (already
+// destroyed by the time telemetry fires): checks ONLY page 1's text content
+// for telemetry's doc_open (spec-telemetry.md §3 — scan-vs-born-digital
+// ratio). Full-document text extraction would cost real time on a 200-page
+// file for a bucketed yes/no the first page already answers accurately in
+// practice. Never throws — a probe failure just means "don't know", and the
+// caller treats that as "no text layer" rather than blocking the import.
+export async function probeTextLayer(bytes) {
+  const pdfjsLib = await ensurePdfJs();
+  const pdf = await pdfjsLib.getDocument({ data: bytes.slice() }).promise;
+  try {
+    const page = await pdf.getPage(1);
+    const content = await page.getTextContent();
+    return content.items.some((it) => it.str && it.str.trim().length > 0);
+  } finally {
+    await pdf.destroy();
+  }
+}
+
 // pdf-lib (the export adapter) can only embed PNG and JPEG. Anything else
 // (WEBP/GIF/BMP/…) is transcoded to PNG HERE, at the browser edge, so the bytes
 // stored on the Source are always export-safe and export never has to sniff for

--- a/js/core/telemetry-schema.js
+++ b/js/core/telemetry-schema.js
@@ -1,0 +1,183 @@
+/*
+ * PDFLokal — core/telemetry-schema.js  (TELEMETRY SSOT — spec-telemetry.md §2/§3)
+ * ============================================================================
+ * The machine→human boundary law, applied machine→database (spec §2): an LLM
+ * (or any code) fills a free field with anything; the boundary may not BE a
+ * free field. SCHEMA is the ONE place that decides what a telemetry event IS.
+ * Imported VERBATIM by both js/v2/telemetry.js (client) and api/t.js (the
+ * endpoint) — client and server can never disagree about what's allowed.
+ * NO string-typed prop exists anywhere in this file: every value is an enum,
+ * a bool, a pre-bucketed int, or a clamped/rounded duration.
+ *
+ * Type descriptors (the value each SCHEMA[event][prop] entry may hold):
+ *   - Array<string>  → enum: the prop value must be exactly one of these.
+ *   - 'bool'         → boolean.
+ *   - 'int'          → finite, non-negative INTEGER — for a value that is
+ *                       already bucketed/counted upstream, never a raw
+ *                       unbounded magnitude. (No v1 event uses this yet; kept
+ *                       for schema completeness per spec §2's type list.)
+ *   - 'duration'     → finite integer ms, 0 <= v <= 600000, a multiple of 10.
+ *                       Callers should always produce this via
+ *                       durationBucket() below rather than hand-rolling a
+ *                       number — that's what guarantees the invariant holds
+ *                       by the time validateEvent() sees it.
+ *
+ * Adding a new event = one SCHEMA entry (+ a call site once the code path
+ * exists). The ladder events (font_seen, ganti_tap, ganti_commit, surgery,
+ * insert, block_edit, commit_paint) are listed here for completeness NOW
+ * (spec §6 step 5) even though their call sites land later, on the ladder
+ * branch, as those code paths stabilize. Their enum values were checked
+ * against the actual ladder code on feat/edit-teks-asli where it already
+ * exists (reinsert.js's decline reasons, text-walk.js's match/decline paths,
+ * text-blocks.js's align classifier) — see the telemetry PR notes for the
+ * one enum that's a best-effort naming (surgery.reason) rather than a
+ * verbatim existing constant, since the match step itself has no named
+ * reason in the code today, only a matched:boolean.
+ */
+
+// ---- shared enum/bucket vocab (reused by more than one event) -----------------
+const PAGES_BUCKET = ['1', '2-5', '6-20', '21+'];
+const DEVICE = ['phone', 'tablet', 'desktop'];
+
+const DURATION_MAX_MS = 600000;
+const DURATION_STEP_MS = 10;
+
+// n (a page count) → the spec's bucket string. Defensive on garbage input
+// (NaN, negative, undefined) — collapses to the smallest bucket rather than
+// producing an off-schema value that validateEvent would then have to reject.
+export function pagesBucket(n) {
+  const v = Number(n);
+  if (!Number.isFinite(v) || v <= 1) return '1';
+  if (v <= 5) return '2-5';
+  if (v <= 20) return '6-20';
+  return '21+';
+}
+
+// ms (a raw duration) → clamped to [0, 600000] and rounded to the nearest
+// 10ms (spec §2). This is the ONLY place a 'duration' value should be
+// produced — validateEvent then just has to check the invariant holds.
+export function durationBucket(ms) {
+  // NaN (incl. anything that doesn't coerce to a number, e.g. undefined)
+  // can't be reasoned about as "too big" or "too small" — floor it. A real
+  // Infinity (or any other out-of-range number) DOES have a direction, so
+  // Math.max/min below clamp it to the correct end instead.
+  const num = Number(ms);
+  const v = Number.isNaN(num) ? 0 : num;
+  const clamped = Math.min(DURATION_MAX_MS, Math.max(0, v));
+  return Math.round(clamped / DURATION_STEP_MS) * DURATION_STEP_MS;
+}
+
+// ---- SCHEMA -------------------------------------------------------------------
+export const SCHEMA = {
+  // ---- live today (js/v2/app.js, js/v2/download-sheet.js) ----
+  doc_open: {
+    text_layer: 'bool',
+    pages: PAGES_BUCKET,
+    device: DEVICE,
+  },
+  // tool: the v2 toolbar's own verbs (Pilih/Teks/Tip-Ex/TTD/Hapus/Halaman) —
+  // 'ganti' (Rung B's smart-replace tool) is listed now for schema
+  // completeness even though it doesn't exist as a toolbar entry until the
+  // ladder merges (same forward-looking stance as the ladder events below).
+  // action: the specific thing that happened — deliberately finer than
+  // "which tool" so e.g. "pressed Halaman" (discoverability — nothing told
+  // us this before, see app.js's armIntent() note) is distinguishable from
+  // a committed edit.
+  tool_use: {
+    tool: ['select', 'teks', 'tipex', 'ganti', 'ttd', 'hapus', 'halaman'],
+    action: ['select', 'whiteout', 'text', 'text_inline', 'signature', 'paraf', 'delete', 'pages_open'],
+  },
+  export: {
+    // surgery_used/fallback are always false/'none' from call sites on this
+    // branch (Rung B/C don't exist here yet) — the props still ship now so
+    // the ladder branch only has to start SENDING true values, never add a
+    // new prop (spec §6 step 5: "the ladder props land later").
+    surgery_used: 'bool',
+    fallback: ['none', 'cover', 'twin'],
+    duration: 'duration',
+  },
+
+  // ---- ladder (Rung A–D) — schema-complete now, call sites land on the ladder branch ----
+
+  // flavor mirrors spec §2's FLAVOR list exactly (never the font's own name).
+  font_seen: {
+    flavor: ['type0-identity-h', 'truetype-simple', 'type1', 'standard14', 'other'],
+    extract: ['ok', 'declined', 'failed'],
+  },
+  ganti_tap: {
+    hit: 'bool',
+  },
+  ganti_commit: {
+    outcome: ['commit', 'cancel', 'noop'],
+    font_path: ['doc-font', 'twin'],
+  },
+  // matched/reason describe ONLY the Rung B match/cut step (text-walk.js's
+  // planRunRemoval): a target is either matched cleanly, has NO geometric
+  // candidate at all ('no-match'), or sits in a text object the walk marked
+  // untrustworthy and declined out of caution ('untrustworthy-run' — the
+  // literal word the code uses at the decline site).
+  surgery: {
+    matched: 'bool',
+    reason: ['clean', 'no-match', 'untrustworthy-run'],
+  },
+  // path/reason describe the Rung C re-insert step (core/reinsert.js):
+  // 'native' when the doc's own font could be reused, 'twin' when any guard
+  // declined and export fell back to the metric-twin annotation. reason
+  // enumerates reinsert.js's own named decline reasons verbatim, plus
+  // 'clean' for the native-succeeded case.
+  insert: {
+    path: ['native', 'twin'],
+    reason: [
+      'clean', 'unsupported-font', 'mixed-fonts', 'multiline', 'empty',
+      'font-parse-failed', 'missing-glyph', 'font-name-unwritable',
+    ],
+  },
+  // reason/align values are given verbatim in spec-telemetry.md §3's own
+  // table (reason) and text-blocks.js's classifyAlign() (align).
+  block_edit: {
+    editable: 'bool',
+    reason: ['single-line', 'align-unknown', 'mixed-fonts', 'list'],
+    align: ['left', 'right', 'center', 'justify', 'unknown'],
+  },
+  commit_paint: {
+    duration: 'duration',
+    pages: PAGES_BUCKET,
+    device: DEVICE,
+  },
+};
+
+function validateProp(descriptor, value) {
+  if (Array.isArray(descriptor)) return typeof value === 'string' && descriptor.includes(value);
+  if (descriptor === 'bool') return typeof value === 'boolean';
+  if (descriptor === 'int') return Number.isInteger(value) && value >= 0;
+  if (descriptor === 'duration') {
+    return Number.isInteger(value) && value >= 0 && value <= DURATION_MAX_MS && value % DURATION_STEP_MS === 0;
+  }
+  // An unrecognised descriptor is a bug IN this file, not a caller mistake —
+  // fail closed rather than silently accept anything.
+  return false;
+}
+
+// Pure, no I/O. {ok:true, clean} | {ok:false}. Strict on every axis the spec
+// calls out: unknown event, unknown prop, missing required prop, enum value
+// outside the list, and wrong type all fail the WHOLE event (never a partial
+// pass) — a bad call site should be loud, not silently half-recorded.
+export function validateEvent(name, props) {
+  const shape = SCHEMA[name];
+  if (!shape) return { ok: false };
+
+  const src = props && typeof props === 'object' && !Array.isArray(props) ? props : {};
+  const declaredKeys = Object.keys(shape);
+
+  for (const key of Object.keys(src)) {
+    if (!(key in shape)) return { ok: false }; // unknown prop
+  }
+
+  const clean = {};
+  for (const key of declaredKeys) {
+    if (!(key in src)) return { ok: false }; // missing a required prop
+    if (!validateProp(shape[key], src[key])) return { ok: false }; // wrong type / bad enum
+    clean[key] = src[key];
+  }
+  return { ok: true, clean };
+}

--- a/js/v2/app.js
+++ b/js/v2/app.js
@@ -22,7 +22,8 @@ import {
   moveAnnotation,
 } from '../core/operations.js';
 import { createHistory, record, undo, redo, canUndo, canRedo } from '../core/history.js';
-import { importPdf, importImage, createPageRasterizer } from '../core/import.js';
+import { importPdf, importImage, createPageRasterizer, probeTextLayer } from '../core/import.js';
+import { pagesBucket } from '../core/telemetry-schema.js';
 import { createPageSlot, syncOverlay, textFontCss } from '../render/page-view.js';
 import { createViewportStream } from '../render/viewport.js';
 import { createInteraction } from '../render/interaction.js';
@@ -31,6 +32,7 @@ import { createPageManager } from './page-manager.js';
 import { createSignatureModal } from './signature-modal.js';
 import { createDownloadSheet } from './download-sheet.js';
 import { track } from '../lib/analytics.js';
+import { tel } from './telemetry.js';
 import { createCelebration } from './celebrate.js';
 import { applyIntentCopy } from './intent-copy.js';
 import { ensurePdfLib } from '../core/vendor.js';
@@ -39,6 +41,18 @@ import { ensurePdfLib } from '../core/vendor.js';
 // loaded on demand now (core/vendor.js), so touching it at module top-level
 // would resurrect the very boot-time dependency we removed. The worker path is
 // set inside ensurePdfJs(), the instant the lib lands.
+
+// ---- telemetry: device class (spec-telemetry.md §3's doc_open/commit_paint) --
+// Mirrors the old wing's detectMobile() thresholds (js/init.js) exactly — that
+// SSOT convention (vw<=599 phone, <=900 tablet, else desktop) already matches
+// this app's own 900px mobile-layout breakpoint, so v2 gets the same bucket a
+// user on the old wing would have gotten, for free comparability.
+function deviceClass() {
+  const vw = window.innerWidth;
+  if (vw <= 599) return 'phone';
+  if (vw <= 900) return 'tablet';
+  return 'desktop';
+}
 
 // ---- state (ONE doc, ONE history — everything else is DOM or derived) -------
 let doc = createDoc(); // replaced wholesale by "Buka Baru" (File menu)
@@ -412,7 +426,11 @@ const interaction = createInteraction({
   onChange: (kind) => {
     // Tip-Ex stroke finished (color was already matched at stroke START):
     // return home to Pilih (founder: whiteout should NOT stay sticky).
-    if (kind === 'draw') { track('editor_action', { action: 'whiteout' }); setTool('select'); }
+    if (kind === 'draw') {
+      track('editor_action', { action: 'whiteout' });
+      tel('tool_use', { tool: 'tipex', action: 'whiteout' }); // spec-telemetry.md §6.2
+      setTool('select');
+    }
     refreshChrome();
   },
   onDeleteTap: (annoId, pageId) => {
@@ -434,6 +452,7 @@ const interaction = createInteraction({
         x: Math.max(0, x - w / 2), y: Math.max(0, y - h / 2), width: w, height: h,
       }));
       track('editor_action', { action: storedSignature.subtype === 'paraf' ? 'paraf' : 'signature' });
+      tel('tool_use', { tool: 'ttd', action: storedSignature.subtype === 'paraf' ? 'paraf' : 'signature' });
       selectAnnotation(doc, created.id); // selected → "Semua Hal." is one tap away
       syncPage(pageId);
       setTool('select'); // tools are verbs; back home
@@ -486,7 +505,12 @@ const pageManager = createPageManager({
   },
   toast,
 });
-document.getElementById('btn-pages').addEventListener('click', () => pageManager.open());
+document.getElementById('btn-pages').addEventListener('click', () => {
+  pageManager.open();
+  // Discoverability signal (spec-telemetry.md §6.2) — armIntent()'s own note
+  // above explains why this never existed before: card clicks fired NOTHING.
+  tel('tool_use', { tool: 'halaman', action: 'pages_open' });
+});
 document.getElementById('pm-close').addEventListener('click', () => pageManager.close());
 
 // ---- inline text editing ------------------------------------------------------------
@@ -529,6 +553,7 @@ function openTextEditor({ pageId, x, y, anno }) {
         record(history, doc);
         updateAnnotation(doc, anno.id, { text });
         track('editor_action', { action: 'text_inline' });
+        tel('tool_use', { tool: 'teks', action: 'text_inline' });
       } else if (!text) {
         record(history, doc);
         removeAnnotation(doc, anno.id);
@@ -545,6 +570,7 @@ function openTextEditor({ pageId, x, y, anno }) {
       // format-bar dropdown change right after the blur-commit still lands.
       selectAnnotation(doc, created.id);
       track('editor_action', { action: 'text' });
+      tel('tool_use', { tool: 'teks', action: 'text' });
     }
     syncPage(pageId);
     setTool('select');
@@ -652,6 +678,7 @@ function deleteSelected() {
   }
   record(history, doc);
   removeAnnotation(doc, id);
+  tel('tool_use', { tool: 'hapus', action: 'delete' }); // spec-telemetry.md §6.2
   if (pageId) syncPage(pageId);
 }
 
@@ -755,8 +782,23 @@ async function loadFilesInner(files) {
     try {
       const bytes = new Uint8Array(await f.arrayBuffer());
       if (bytes.length === 0) throw new Error('empty file'); // 0-byte → JAVASCRIPT-H
-      if (isPdf(f)) await importPdf(doc, { name: f.name, bytes });
-      else await importImage(doc, { name: f.name, bytes, mimeType: f.type });
+      if (isPdf(f)) {
+        const importedPages = await importPdf(doc, { name: f.name, bytes });
+        // doc_open (spec-telemetry.md §3 — scan-vs-born-digital ratio). The
+        // text-layer probe re-opens the PDF independently (probeTextLayer,
+        // core/import.js) — NOT awaited: it must never slow down a multi-file
+        // merge loop, and a probe failure is just "don't know" (dropped).
+        probeTextLayer(bytes)
+          .then((hasText) => tel('doc_open', {
+            text_layer: hasText, pages: pagesBucket(importedPages.length), device: deviceClass(),
+          }))
+          .catch(() => {});
+      } else {
+        await importImage(doc, { name: f.name, bytes, mimeType: f.type });
+        // An image page has no text layer at all — that's the scan ladder's
+        // own job (spec-edit-dokumen-foto.md), not this rail's.
+        tel('doc_open', { text_layer: false, pages: pagesBucket(1), device: deviceClass() });
+      }
       // Carry the intent so the funnel joins up: intent_armed → file_loaded →
       // download. Without it we'd know people PRESSED "Pisah PDF" but not whether
       // any ever brought a file — the half that matters. applyIntent() clears it below.

--- a/js/v2/download-sheet.js
+++ b/js/v2/download-sheet.js
@@ -17,6 +17,8 @@
 import { buildPdfBytes } from '../core/export.js';
 import { ensurePdfJs, ensurePdfLib, ensureFflate } from '../core/vendor.js';
 import { track } from '../lib/analytics.js';
+import { tel } from './telemetry.js';
+import { durationBucket } from '../core/telemetry-schema.js';
 import { showStamp } from './celebrate.js';
 
 const COMPRESS_QUALITY = 0.72; // the "Otomatis" preset — one sane default, still
@@ -326,6 +328,7 @@ export function createDownloadSheet(deps) {
     state.exporting = true;
     render();
     const seq = state.seq;
+    const t0 = performance.now(); // spec-telemetry.md §3 export.duration — tap to bytes-in-hand
     try {
       // Belt-and-braces: if Compress is selected but its bytes are missing and
       // nothing is computing them (any invalidation path), start it here.
@@ -380,6 +383,14 @@ export function createDownloadSheet(deps) {
         format: state.format === 'pdf' ? 'pdf' : state.imgfmt,
         size: state.size,
         pages: state.picked ? 'some' : 'all',
+      });
+      // surgery_used/fallback are hardcoded for now — Rung B/C (the ladder)
+      // don't exist on this branch yet; those props start carrying real
+      // values the moment the ladder merges (spec-telemetry.md §6 step 5).
+      tel('export', {
+        surgery_used: false,
+        fallback: 'none',
+        duration: durationBucket(performance.now() - t0),
       });
       modal.close();
     } catch (err) {

--- a/js/v2/telemetry.js
+++ b/js/v2/telemetry.js
@@ -1,0 +1,107 @@
+/*
+ * PDFLokal — v2/telemetry.js  (TELEMETRY CLIENT — spec-telemetry.md)
+ * ============================================================================
+ * Fire-and-forget, same-origin telemetry: tel(event, props) validates LOCALLY
+ * against the shared SCHEMA (js/core/telemetry-schema.js — the SAME module
+ * api/t.js imports server-side, so client and server can never disagree
+ * about what's allowed), queues, and flushes via sendBeacon once the queue
+ * hits FLUSH_AT or the tab goes hidden. Every exported function is
+ * try/catch-armored: a bug in here must never become a bug in the editor.
+ * No cookies, no localStorage, no retries — a lost batch is lost, never
+ * queued for later (spec §2, §7's falsifier: accept residual loss, never
+ * escalate to blocking sends).
+ *
+ * NOT the same rail as js/lib/analytics.js (GA4 + Vercel Web Analytics,
+ * acquisition-focused, third-party) — that module is untouched. This one is
+ * first-party product telemetry; the two are never dual-written to the same
+ * event.
+ */
+import { validateEvent } from '../core/telemetry-schema.js';
+
+const ENDPOINT = '/api/t';
+const FLUSH_AT = 10;
+
+// WHY crypto.randomUUID, generated ONCE per pageload and never persisted:
+// enough to join events into one funnel (this open → this download), useless
+// for tracking a person across visits (spec §2 — no cookies, no
+// localStorage id, no fingerprinting).
+const sessionId = crypto.randomUUID();
+
+// <meta name="pdflokal-rev"> is stamped at deploy time (commit SHA) when
+// present; local dev and any page that doesn't carry it are honestly 'dev'
+// rather than guessing — api/t.js's own APP_VERSION_RE only accepts exactly
+// these two shapes.
+function readAppVersion() {
+  try {
+    const meta = document.querySelector('meta[name="pdflokal-rev"]');
+    const v = meta?.content;
+    return v && /^[0-9a-f]{7,40}$/.test(v) ? v : 'dev';
+  } catch {
+    return 'dev';
+  }
+}
+const appVersion = readAppVersion();
+
+// WHY localhost-only console.warn: an off-schema call site is a bug in OUR
+// code (a typo'd prop, a stale enum) — dev needs to see it loudly, but a
+// warning has no business reaching a real user's console.
+const isLocalDev = (() => {
+  try {
+    return typeof location !== 'undefined'
+      && (location.hostname === 'localhost' || location.hostname === '127.0.0.1');
+  } catch {
+    return false;
+  }
+})();
+
+let queue = [];
+
+function flush() {
+  try {
+    if (queue.length === 0) return;
+    const batch = queue;
+    queue = [];
+    const payload = JSON.stringify({ session_id: sessionId, app_version: appVersion, events: batch });
+    if (typeof navigator?.sendBeacon !== 'function') return; // no beacon support — drop, never retry
+    const blob = new Blob([payload], { type: 'application/json' });
+    navigator.sendBeacon(ENDPOINT, blob);
+  } catch {
+    // Telemetry can NEVER throw into app code (spec §2).
+  }
+}
+
+// Flush on hide, not on 'unload'/'beforeunload' (unreliable on mobile and
+// actively discouraged — bfcache eviction). visibilitychange:hidden fires on
+// tab-switch, app-switch, and navigation alike, which is the spec's own
+// mitigation for sendBeacon loss on Android WebView/iOS Safari (spec §7).
+try {
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden') flush();
+    });
+  }
+} catch {
+  // Never let wiring the listener itself break page load.
+}
+
+/**
+ * Record a telemetry event. Validates against SCHEMA locally, queues it, and
+ * flushes when the queue is full. Silently drops anything off-schema.
+ * @param {string} event
+ * @param {Record<string, string|number|boolean>} [props]
+ */
+export function tel(event, props = {}) {
+  try {
+    const { ok, clean } = validateEvent(event, props);
+    if (!ok) {
+      if (isLocalDev) {
+        console.warn(`[telemetry] dropped off-schema event "${event}"`, props);
+      }
+      return;
+    }
+    queue.push({ event, props: clean });
+    if (queue.length >= FLUSH_AT) flush();
+  } catch {
+    // Telemetry can NEVER throw into app code (spec §2).
+  }
+}

--- a/privasi.html
+++ b/privasi.html
@@ -255,6 +255,35 @@
         </ul>
       </div>
 
+      <!-- Telemetri Produk -->
+      <div class="privacy-section">
+        <h2>Telemetri Produk</h2>
+        <p style="color: var(--text-secondary); line-height: 1.6; margin-bottom: var(--space-md);">
+          Selain analytics kunjungan di atas, PDFLokal juga mengirim data teknis kecil ke server kami
+          sendiri (bukan pihak ketiga) tentang bagaimana fitur-fitur dipakai — supaya kami tahu alat
+          mana yang berguna dan mana yang perlu diperbaiki. Datanya sengaja dibuat sesempit mungkin:
+        </p>
+        <ul class="privacy-list">
+          <li>Alat mana yang kamu pakai (Teks, Tip-Ex, Tanda Tangan, dll) dan berapa lama sebuah proses berjalan</li>
+          <li>Apakah sebuah font di dokumen berhasil dikenali atau tidak</li>
+          <li>Jenis perangkat secara umum (HP / tablet / desktop) dan jumlah halaman dalam rentang (1, 2-5, 6-20, 21+)</li>
+        </ul>
+        <div class="privacy-highlight">
+          <p>
+            <strong>Yang TIDAK pernah kami kirim:</strong> isi dokumen, teks yang kamu tulis atau edit,
+            nama file, gambar, atau nama font asli. Prinsip "<em>filenya tidak pernah diunggah</em>"
+            tetap 100% berlaku — telemetri ini cuma menghitung APA yang sebuah fitur lakukan, bukan
+            APA isi dokumenmu.
+          </p>
+        </div>
+        <p style="color: var(--text-secondary); line-height: 1.6;">
+          Nggak ada cookie, nggak ada ID yang mengikuti kamu antar kunjungan — setiap sesi cuma dapat
+          ID acak yang hilang begitu tab ditutup. Datanya kami simpan sendiri di infrastruktur kami
+          sendiri, nggak dijual atau dibagikan ke siapa pun — justru ini lebih privat dibanding Google
+          Analytics yang dipakai kebanyakan situs lain, karena datanya nggak pernah keluar dari server kami.
+        </p>
+      </div>
+
       <!-- Local Storage -->
       <div class="privacy-section">
         <h2>Penyimpanan Lokal (Local Storage)</h2>

--- a/scripts/telemetry-migration.sql
+++ b/scripts/telemetry-migration.sql
@@ -27,6 +27,7 @@ create index if not exists events_ts_idx on events (ts desc);
 create index if not exists events_event_idx on events (event);
 
 alter table events enable row level security;
+revoke all on table events from anon, authenticated;
 -- No policies are created — intentionally. RLS with zero policies denies
 -- ALL access to anon and authenticated roles by default in PostgREST. The
 -- service-role key api/t.js uses BYPASSES RLS entirely (Supabase's
@@ -37,7 +38,8 @@ alter table events enable row level security;
 
 -- Daily volume per event — the first thing any PM session should look at
 -- before writing a new spec: is the wild sending anything at all.
-create or replace view v_daily_events as
+create or replace view v_daily_events
+with (security_invoker = on) as
 select
   date_trunc('day', ts) as day,
   event,
@@ -50,7 +52,8 @@ order by 1 desc, 2;
 -- `reason` prop (surgery / insert / block_edit) — the honesty rate: how often
 -- the real world declines each rung, and why, verbatim per the code's own
 -- named reasons (js/core/telemetry-schema.js's SCHEMA).
-create or replace view v_decline_reasons as
+create or replace view v_decline_reasons
+with (security_invoker = on) as
 select
   event,
   props->>'reason' as reason,
@@ -65,7 +68,8 @@ order by 1, n desc;
 -- Android column, now live from day one of the ladder merge. duration is
 -- stored as a number (ms, already clamped+rounded by durationBucket()) inside
 -- props, so it's cast numeric here rather than compared as text.
-create or replace view v_commit_latency as
+create or replace view v_commit_latency
+with (security_invoker = on) as
 select
   props->>'device' as device,
   percentile_cont(0.5) within group (order by (props->>'duration')::numeric) as p50_ms,
@@ -77,6 +81,15 @@ where event = 'commit_paint'
   and props ? 'duration'
 group by 1
 order by 1;
+
+-- WHY security_invoker + revokes (hardening, applied 2026-07-20): a default
+-- Postgres view runs with its OWNER's privileges, which BYPASSES the events
+-- table's RLS — through PostgREST the anon key could have read the aggregate
+-- views even though the table denies everything. security_invoker=on makes
+-- each view respect the CALLER's rights (PG15+), and the revokes close direct
+-- REST access to the views themselves. Applied to project gvtknjudulezpoyhlmzx
+-- as migration telemetry_events_v1 (this file is its source of truth).
+revoke all on v_daily_events, v_decline_reasons, v_commit_latency from anon, authenticated;
 
 -- ---- retention (spec §2/§7): 180 days, instrumentation not a warehouse --------
 -- This is NOT scheduled by this migration (no pg_cron dependency assumed).

--- a/scripts/telemetry-migration.sql
+++ b/scripts/telemetry-migration.sql
@@ -1,0 +1,84 @@
+-- PDFLokal — telemetry-migration.sql  (spec-telemetry.md §1/§5/§6)
+-- =============================================================================
+-- One table (events), RLS on with ZERO policies (service key bypasses RLS
+-- entirely; anon/authenticated get nothing — no policy means no access), and
+-- the three canonical read-side views the spec asks for so PM sessions can
+-- query distributions/funnels/latency in one SELECT, not archaeology.
+--
+-- Run this once, by hand, against the Supabase project Fauzan creates/blesses
+-- for telemetry (🤚 spec §1) — via the Supabase SQL editor or the MCP's
+-- apply_migration. Nothing here depends on any other pdflokal table.
+
+create table if not exists events (
+  id bigint generated always as identity primary key,
+  ts timestamptz not null default now(),
+  session_id uuid not null,
+  app_version text not null,
+  event text not null,
+  props jsonb not null default '{}'::jsonb
+);
+
+-- Read patterns are always "recent, by event, filtered on a prop" — index the
+-- two columns every view below actually filters/groups on. props is jsonb
+-- without a GIN index on purpose: v1's read volume (PM sessions, ad hoc) does
+-- not justify the write-side cost yet: add one (`using gin (props)`) if a
+-- specific prop lookup becomes a hot path.
+create index if not exists events_ts_idx on events (ts desc);
+create index if not exists events_event_idx on events (event);
+
+alter table events enable row level security;
+-- No policies are created — intentionally. RLS with zero policies denies
+-- ALL access to anon and authenticated roles by default in PostgREST. The
+-- service-role key api/t.js uses BYPASSES RLS entirely (Supabase's
+-- service_role always does, policies or not), so inserts from the endpoint
+-- keep working; nothing else — no client, no anon key — can read or write.
+
+-- ---- read side (spec §5): 3 canonical views, one query not archaeology --------
+
+-- Daily volume per event — the first thing any PM session should look at
+-- before writing a new spec: is the wild sending anything at all.
+create or replace view v_daily_events as
+select
+  date_trunc('day', ts) as day,
+  event,
+  count(*) as n
+from events
+group by 1, 2
+order by 1 desc, 2;
+
+-- Decline-reason distribution across every ladder event that carries a
+-- `reason` prop (surgery / insert / block_edit) — the honesty rate: how often
+-- the real world declines each rung, and why, verbatim per the code's own
+-- named reasons (js/core/telemetry-schema.js's SCHEMA).
+create or replace view v_decline_reasons as
+select
+  event,
+  props->>'reason' as reason,
+  count(*) as n
+from events
+where event in ('surgery', 'insert', 'block_edit')
+  and props ? 'reason'
+group by 1, 2
+order by 1, n desc;
+
+-- commit_paint latency percentiles by device class — the spike's missing
+-- Android column, now live from day one of the ladder merge. duration is
+-- stored as a number (ms, already clamped+rounded by durationBucket()) inside
+-- props, so it's cast numeric here rather than compared as text.
+create or replace view v_commit_latency as
+select
+  props->>'device' as device,
+  percentile_cont(0.5) within group (order by (props->>'duration')::numeric) as p50_ms,
+  percentile_cont(0.9) within group (order by (props->>'duration')::numeric) as p90_ms,
+  percentile_cont(0.99) within group (order by (props->>'duration')::numeric) as p99_ms,
+  count(*) as n
+from events
+where event = 'commit_paint'
+  and props ? 'duration'
+group by 1
+order by 1;
+
+-- ---- retention (spec §2/§7): 180 days, instrumentation not a warehouse --------
+-- This is NOT scheduled by this migration (no pg_cron dependency assumed).
+-- Run on a schedule (pg_cron, or a periodic call from a PM/ops session):
+--   delete from events where ts < now() - interval '180 days';

--- a/tests/core/telemetry-schema.test.mjs
+++ b/tests/core/telemetry-schema.test.mjs
@@ -1,0 +1,155 @@
+/*
+ * Headless tests for core/telemetry-schema.js — the telemetry SSOT shared by
+ * the client (js/v2/telemetry.js) and the endpoint (api/t.js).
+ * Run: npm run test:core   (node --test, no browser)
+ *
+ * The contract (spec-telemetry.md §2): validateEvent is pure, no I/O, and
+ * strict on every axis — unknown event, unknown prop, missing prop, bad enum,
+ * wrong type all fail the WHOLE event, never a partial pass.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { SCHEMA, validateEvent, pagesBucket, durationBucket } from '../../js/core/telemetry-schema.js';
+
+// A minimal, schema-valid props object for each event — used to prove every
+// declared event validates cleanly at least once, and as a base to mutate
+// for the negative tests below.
+const VALID_PROPS = {
+  doc_open: { text_layer: true, pages: '1', device: 'desktop' },
+  tool_use: { tool: 'teks', action: 'text' },
+  export: { surgery_used: false, fallback: 'none', duration: 100 },
+  font_seen: { flavor: 'type0-identity-h', extract: 'ok' },
+  ganti_tap: { hit: true },
+  ganti_commit: { outcome: 'commit', font_path: 'doc-font' },
+  surgery: { matched: true, reason: 'clean' },
+  insert: { path: 'native', reason: 'clean' },
+  block_edit: { editable: true, reason: 'single-line', align: 'left' },
+  commit_paint: { duration: 250, pages: '2-5', device: 'phone' },
+};
+
+test('every SCHEMA event has a VALID_PROPS fixture (test coverage stays complete as events are added)', () => {
+  for (const name of Object.keys(SCHEMA)) {
+    assert.ok(name in VALID_PROPS, `no fixture for event "${name}" — add one to VALID_PROPS`);
+  }
+  for (const name of Object.keys(VALID_PROPS)) {
+    assert.ok(name in SCHEMA, `fixture "${name}" has no matching SCHEMA entry`);
+  }
+});
+
+test('every v1 event validates cleanly with its correct props', () => {
+  for (const [name, props] of Object.entries(VALID_PROPS)) {
+    const result = validateEvent(name, props);
+    assert.equal(result.ok, true, `${name} should validate`);
+    assert.deepEqual(result.clean, props);
+  }
+});
+
+test('clean strips nothing extra and is a fresh object (not the same reference)', () => {
+  const props = { ...VALID_PROPS.doc_open };
+  const { clean } = validateEvent('doc_open', props);
+  assert.notEqual(clean, props);
+  assert.deepEqual(clean, props);
+});
+
+test('unknown event name fails', () => {
+  assert.equal(validateEvent('not_a_real_event', {}).ok, false);
+  assert.equal(validateEvent('', {}).ok, false);
+  assert.equal(validateEvent(undefined, {}).ok, false);
+});
+
+test('unknown prop fails the whole event', () => {
+  const props = { ...VALID_PROPS.doc_open, extra_field: 'nope' };
+  assert.equal(validateEvent('doc_open', props).ok, false);
+});
+
+test('missing a required prop fails', () => {
+  const { text_layer, ...rest } = VALID_PROPS.doc_open; // eslint-disable-line no-unused-vars
+  assert.equal(validateEvent('doc_open', rest).ok, false);
+});
+
+test('enum value outside the declared list fails', () => {
+  assert.equal(validateEvent('doc_open', { ...VALID_PROPS.doc_open, device: 'smart-fridge' }).ok, false);
+  assert.equal(validateEvent('tool_use', { ...VALID_PROPS.tool_use, tool: 'scissors' }).ok, false);
+  assert.equal(validateEvent('export', { ...VALID_PROPS.export, fallback: 'server' }).ok, false);
+});
+
+test('wrong type fails for bool props', () => {
+  assert.equal(validateEvent('doc_open', { ...VALID_PROPS.doc_open, text_layer: 'true' }).ok, false);
+  assert.equal(validateEvent('doc_open', { ...VALID_PROPS.doc_open, text_layer: 1 }).ok, false);
+  assert.equal(validateEvent('ganti_tap', { hit: 'yes' }).ok, false);
+});
+
+test('wrong type fails for enum props (numbers, arrays, objects are never enum values)', () => {
+  assert.equal(validateEvent('doc_open', { ...VALID_PROPS.doc_open, pages: 1 }).ok, false);
+  assert.equal(validateEvent('doc_open', { ...VALID_PROPS.doc_open, device: ['desktop'] }).ok, false);
+  assert.equal(validateEvent('doc_open', { ...VALID_PROPS.doc_open, device: null }).ok, false);
+});
+
+test('NO string-typed prop exists anywhere in SCHEMA (spec §2 law)', () => {
+  for (const [event, shape] of Object.entries(SCHEMA)) {
+    for (const [prop, descriptor] of Object.entries(shape)) {
+      const isEnum = Array.isArray(descriptor);
+      const isTyped = descriptor === 'bool' || descriptor === 'int' || descriptor === 'duration';
+      assert.ok(isEnum || isTyped, `${event}.${prop} has a free-string type descriptor — forbidden`);
+      if (isEnum) {
+        assert.ok(descriptor.length > 0, `${event}.${prop} enum must not be empty`);
+        for (const v of descriptor) assert.equal(typeof v, 'string', `${event}.${prop} enum values must be strings`);
+      }
+    }
+  }
+});
+
+test('duration type: must be an integer multiple of 10, within [0, 600000]', () => {
+  assert.equal(validateEvent('export', { ...VALID_PROPS.export, duration: 100.5 }).ok, false);
+  assert.equal(validateEvent('export', { ...VALID_PROPS.export, duration: -10 }).ok, false);
+  assert.equal(validateEvent('export', { ...VALID_PROPS.export, duration: 15 }).ok, false); // not a multiple of 10
+  assert.equal(validateEvent('export', { ...VALID_PROPS.export, duration: 600001 }).ok, false); // over the cap
+  assert.equal(validateEvent('export', { ...VALID_PROPS.export, duration: 600000 }).ok, true); // at the cap, inclusive
+  assert.equal(validateEvent('export', { ...VALID_PROPS.export, duration: 0 }).ok, true); // at the floor, inclusive
+});
+
+test('props that are not a plain object (null/array/undefined/string) are treated as empty, not crashed on', () => {
+  assert.equal(validateEvent('ganti_tap', null).ok, false); // required prop "hit" then missing
+  assert.equal(validateEvent('ganti_tap', undefined).ok, false);
+  assert.equal(validateEvent('ganti_tap', []).ok, false);
+  assert.equal(validateEvent('ganti_tap', 'nope').ok, false);
+});
+
+// ---- bucketing helpers --------------------------------------------------------
+
+test('pagesBucket: boundaries per spec-telemetry.md §3 (1 | 2-5 | 6-20 | 21+)', () => {
+  assert.equal(pagesBucket(1), '1');
+  assert.equal(pagesBucket(2), '2-5');
+  assert.equal(pagesBucket(5), '2-5');
+  assert.equal(pagesBucket(6), '6-20');
+  assert.equal(pagesBucket(20), '6-20');
+  assert.equal(pagesBucket(21), '21+');
+  assert.equal(pagesBucket(1000), '21+');
+});
+
+test('pagesBucket: defensive on garbage input — never throws, never off-schema', () => {
+  assert.equal(pagesBucket(0), '1');
+  assert.equal(pagesBucket(-5), '1');
+  assert.equal(pagesBucket(NaN), '1');
+  assert.equal(pagesBucket(undefined), '1');
+  assert.equal(pagesBucket('banyak'), '1');
+});
+
+test('durationBucket: clamps to [0, 600000] and rounds to the nearest 10ms', () => {
+  assert.equal(durationBucket(-500), 0);
+  assert.equal(durationBucket(0), 0);
+  assert.equal(durationBucket(1234), 1230);
+  assert.equal(durationBucket(1235), 1240); // Math.round ties away from zero at .5
+  assert.equal(durationBucket(700000), 600000);
+  assert.equal(durationBucket(Infinity), 600000);
+  assert.equal(durationBucket(NaN), 0);
+});
+
+test('durationBucket output always satisfies the "duration" type descriptor', () => {
+  for (const ms of [-100, 0, 1, 9, 10, 12345, 600000, 999999]) {
+    const bucketed = durationBucket(ms);
+    const result = validateEvent('export', { surgery_used: false, fallback: 'none', duration: bucketed });
+    assert.equal(result.ok, true, `durationBucket(${ms}) = ${bucketed} should be schema-valid`);
+  }
+});

--- a/tests/golden/golden.spec.js
+++ b/tests/golden/golden.spec.js
@@ -24,7 +24,10 @@ const BASELINES_DIR = path.join(__dirname, 'baselines');
 const ACTUAL_DIR = path.join(__dirname, 'actual');
 
 async function loadSamplePdf(page) {
-  await page.goto('/');
+  // The OLD wing (this suite drives ueState/#file-input) moved to
+  // /alat-gambar.html when v2 became `/` (Jul 3) — every old suite was
+  // repointed then except this one, which sat broken until 2026-07-19.
+  await page.goto('/alat-gambar.html');
   await page.setInputFiles('#file-input', SAMPLE_PDF);
   await page.waitForFunction(() => document.body.classList.contains('editor-active'));
   await page.waitForSelector('.ue-page-slot canvas', { state: 'attached' });

--- a/tests/telemetry.spec.js
+++ b/tests/telemetry.spec.js
@@ -1,0 +1,120 @@
+/*
+ * PDFLokal — telemetry client integration spec (spec-telemetry.md).
+ *
+ * WHY page.route, not a real endpoint: `npx serve` (this suite's dev server —
+ * see playwright.config.js) has no /api runtime at all — there is no Vercel
+ * function to hit locally. Route interception at the browser's network layer
+ * is the correct integration seam here: navigator.sendBeacon is a real
+ * network request Playwright can intercept, so this proves the CLIENT builds
+ * the right envelope and calls the right endpoint — everything testable
+ * without a deployed function. api/t.js's own logic (validation, caps, the
+ * Supabase insert) is Node code with zero DOM/browser surface and belongs in
+ * its own unit coverage, not here.
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SAMPLE_PDF = path.join(__dirname, 'fixtures', 'sample-2pages.pdf');
+
+// Intercepts every beacon POST to /api/t and returns the array it appends
+// parsed bodies to. sendBeacon's body is a Blob of JSON — postDataJSON()
+// parses it for us.
+async function captureBeacons(page) {
+  const bodies = [];
+  await page.route('**/api/t', async (route) => {
+    bodies.push(route.request().postDataJSON());
+    await route.fulfill({ status: 204, body: '' });
+  });
+  return bodies;
+}
+
+// visibilityState is normally read-only — this is the standard way to fake
+// a tab going hidden in a headless browser (no real second tab to switch to).
+function fakeTabHidden(page) {
+  return page.evaluate(() => {
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+}
+
+test.describe('telemetry client', () => {
+  test('batches events and flushes at the 10-event threshold with the right envelope shape', async ({ page }) => {
+    await page.goto('/');
+    const bodies = await captureBeacons(page);
+
+    await page.evaluate(async () => {
+      const { tel } = await import('/js/v2/telemetry.js');
+      for (let i = 0; i < 10; i += 1) tel('tool_use', { tool: 'teks', action: 'text' });
+    });
+
+    await expect.poll(() => bodies.length).toBe(1);
+    const payload = bodies[0];
+    // (b) payload shape: {session_id, app_version, events:[...]}
+    expect(payload).toHaveProperty('session_id');
+    expect(payload.session_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+    expect(payload).toHaveProperty('app_version');
+    expect(typeof payload.app_version).toBe('string');
+    expect(Array.isArray(payload.events)).toBe(true);
+    expect(payload.events).toHaveLength(10);
+    expect(payload.events[0]).toEqual({ event: 'tool_use', props: { tool: 'teks', action: 'text' } });
+  });
+
+  test('(a) flushes on visibilitychange:hidden even under the 10-event threshold', async ({ page }) => {
+    await page.goto('/');
+    const bodies = await captureBeacons(page);
+
+    await page.evaluate(async () => {
+      const { tel } = await import('/js/v2/telemetry.js');
+      tel('ganti_tap', { hit: true });
+      tel('ganti_tap', { hit: false });
+    });
+    expect(bodies).toHaveLength(0); // nothing sent yet — under threshold, tab still visible
+
+    await fakeTabHidden(page);
+
+    await expect.poll(() => bodies.length).toBe(1);
+    expect(bodies[0].events).toHaveLength(2);
+  });
+
+  test('(c) an off-schema event never appears in any flush', async ({ page }) => {
+    await page.goto('/');
+    const bodies = await captureBeacons(page);
+
+    await page.evaluate(async () => {
+      const { tel } = await import('/js/v2/telemetry.js');
+      tel('not_a_real_event', { anything: 'goes' });               // unknown event
+      tel('doc_open', { text_layer: true, pages: '1', device: 'smart-fridge' }); // bad enum value
+      tel('tool_use', { tool: 'teks' });                            // missing required prop "action"
+      for (let i = 0; i < 10; i += 1) tel('ganti_tap', { hit: true }); // 10 valid — trips the flush
+    });
+
+    await expect.poll(() => bodies.length).toBe(1);
+    const events = bodies[0].events;
+    expect(events).toHaveLength(10);
+    expect(events.every((e) => e.event === 'ganti_tap')).toBe(true);
+  });
+
+  test('(d) doc_open fires on import with valid props', async ({ page }) => {
+    await page.goto('/');
+    const bodies = await captureBeacons(page);
+
+    await page.setInputFiles('#file-input', SAMPLE_PDF);
+    await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
+
+    // doc_open alone won't trip the 10-event threshold — force the flush the
+    // same way a real navigating-away user would (spec §2's own mitigation).
+    await fakeTabHidden(page);
+
+    await expect.poll(() => bodies.length).toBeGreaterThan(0);
+    const events = bodies.flatMap((b) => b.events);
+    const docOpen = events.find((e) => e.event === 'doc_open');
+    expect(docOpen).toBeTruthy();
+    // fixtures/sample-2pages.pdf has real "(Test Page N) Tj" show-text ops on
+    // both pages (born-digital, not a scan) — text_layer must read true; the
+    // file is 2 pages → pagesBucket puts it in '2-5'; Desktop Chrome's default
+    // viewport (>900px) reads as 'desktop' (js/v2/app.js's deviceClass()).
+    expect(docOpen.props).toEqual({ text_layer: true, pages: '2-5', device: 'desktop' });
+  });
+});

--- a/tests/telemetry.spec.js
+++ b/tests/telemetry.spec.js
@@ -1,15 +1,16 @@
 /*
  * PDFLokal — telemetry client integration spec (spec-telemetry.md).
  *
- * WHY page.route, not a real endpoint: `npx serve` (this suite's dev server —
- * see playwright.config.js) has no /api runtime at all — there is no Vercel
- * function to hit locally. Route interception at the browser's network layer
- * is the correct integration seam here: navigator.sendBeacon is a real
- * network request Playwright can intercept, so this proves the CLIENT builds
- * the right envelope and calls the right endpoint — everything testable
- * without a deployed function. api/t.js's own logic (validation, caps, the
- * Supabase insert) is Node code with zero DOM/browser surface and belongs in
- * its own unit coverage, not here.
+ * WHY an in-page sendBeacon override, not page.route: `npx serve` (this suite's
+ * dev server) has no /api runtime — there is no Vercel function to hit locally,
+ * so the seam has to be the browser. sendBeacon is a fire-and-forget BACKGROUND
+ * request; intercepting it at Playwright's network layer is unreliable headless
+ * — it CI-flaked (the 10-event flush timed out on GitHub Actions while passing
+ * locally, PR #123). Overriding the exact API the client calls
+ * (navigator.sendBeacon) is deterministic: no network round-trip, no
+ * interception race, we read the payload the client actually built. api/t.js's
+ * own logic (validation, caps, the Supabase insert) is Node code with zero
+ * browser surface and lives in tests/core/telemetry-schema.test.mjs.
  */
 import { test, expect } from '@playwright/test';
 import path from 'path';
@@ -18,16 +19,25 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SAMPLE_PDF = path.join(__dirname, 'fixtures', 'sample-2pages.pdf');
 
-// Intercepts every beacon POST to /api/t and returns the array it appends
-// parsed bodies to. sendBeacon's body is a Blob of JSON — postDataJSON()
-// parses it for us.
+// Installs an in-page navigator.sendBeacon override that parses each beacon's
+// JSON Blob onto window.__beacons. MUST run before page.goto (addInitScript
+// executes on every navigation, before page scripts) so the override is in
+// place the instant the telemetry module first flushes. blob.text() is async;
+// the tests poll window.__beacons, which absorbs that microtask latency.
 async function captureBeacons(page) {
-  const bodies = [];
-  await page.route('**/api/t', async (route) => {
-    bodies.push(route.request().postDataJSON());
-    await route.fulfill({ status: 204, body: '' });
+  await page.addInitScript(() => {
+    window.__beacons = [];
+    navigator.sendBeacon = (url, blob) => {
+      Promise.resolve(blob && blob.text ? blob.text() : blob)
+        .then((txt) => { try { window.__beacons.push(JSON.parse(txt)); } catch { /* non-JSON ignored */ } });
+      return true;
+    };
   });
-  return bodies;
+}
+
+// The parsed beacon payloads captured so far, newest-inclusive snapshot.
+function beaconBodies(page) {
+  return page.evaluate(() => (window.__beacons || []).slice());
 }
 
 // visibilityState is normally read-only — this is the standard way to fake
@@ -41,16 +51,16 @@ function fakeTabHidden(page) {
 
 test.describe('telemetry client', () => {
   test('batches events and flushes at the 10-event threshold with the right envelope shape', async ({ page }) => {
+    await captureBeacons(page);
     await page.goto('/');
-    const bodies = await captureBeacons(page);
 
     await page.evaluate(async () => {
       const { tel } = await import('/js/v2/telemetry.js');
       for (let i = 0; i < 10; i += 1) tel('tool_use', { tool: 'teks', action: 'text' });
     });
 
-    await expect.poll(() => bodies.length).toBe(1);
-    const payload = bodies[0];
+    await expect.poll(async () => (await beaconBodies(page)).length).toBe(1);
+    const payload = (await beaconBodies(page))[0];
     // (b) payload shape: {session_id, app_version, events:[...]}
     expect(payload).toHaveProperty('session_id');
     expect(payload.session_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
@@ -62,25 +72,25 @@ test.describe('telemetry client', () => {
   });
 
   test('(a) flushes on visibilitychange:hidden even under the 10-event threshold', async ({ page }) => {
+    await captureBeacons(page);
     await page.goto('/');
-    const bodies = await captureBeacons(page);
 
     await page.evaluate(async () => {
       const { tel } = await import('/js/v2/telemetry.js');
       tel('ganti_tap', { hit: true });
       tel('ganti_tap', { hit: false });
     });
-    expect(bodies).toHaveLength(0); // nothing sent yet — under threshold, tab still visible
+    expect(await beaconBodies(page)).toHaveLength(0); // nothing sent yet — under threshold, tab still visible
 
     await fakeTabHidden(page);
 
-    await expect.poll(() => bodies.length).toBe(1);
-    expect(bodies[0].events).toHaveLength(2);
+    await expect.poll(async () => (await beaconBodies(page)).length).toBe(1);
+    expect((await beaconBodies(page))[0].events).toHaveLength(2);
   });
 
   test('(c) an off-schema event never appears in any flush', async ({ page }) => {
+    await captureBeacons(page);
     await page.goto('/');
-    const bodies = await captureBeacons(page);
 
     await page.evaluate(async () => {
       const { tel } = await import('/js/v2/telemetry.js');
@@ -90,15 +100,15 @@ test.describe('telemetry client', () => {
       for (let i = 0; i < 10; i += 1) tel('ganti_tap', { hit: true }); // 10 valid — trips the flush
     });
 
-    await expect.poll(() => bodies.length).toBe(1);
-    const events = bodies[0].events;
+    await expect.poll(async () => (await beaconBodies(page)).length).toBe(1);
+    const events = (await beaconBodies(page))[0].events;
     expect(events).toHaveLength(10);
     expect(events.every((e) => e.event === 'ganti_tap')).toBe(true);
   });
 
   test('(d) doc_open fires on import with valid props', async ({ page }) => {
+    await captureBeacons(page);
     await page.goto('/');
-    const bodies = await captureBeacons(page);
 
     await page.setInputFiles('#file-input', SAMPLE_PDF);
     await expect(page.locator('.pv-page .pv-bg').first()).toBeVisible();
@@ -107,8 +117,8 @@ test.describe('telemetry client', () => {
     // same way a real navigating-away user would (spec §2's own mitigation).
     await fakeTabHidden(page);
 
-    await expect.poll(() => bodies.length).toBeGreaterThan(0);
-    const events = bodies.flatMap((b) => b.events);
+    await expect.poll(async () => (await beaconBodies(page)).length).toBeGreaterThan(0);
+    const events = (await beaconBodies(page)).flatMap((b) => b.events);
     const docOpen = events.find((e) => e.event === 'doc_open');
     expect(docOpen).toBeTruthy();
     // fixtures/sample-2pages.pdf has real "(Test Page N) Tj" show-text ops on


### PR DESCRIPTION
First-party product telemetry per the seat spec (spec-telemetry.md): the closed loop — field data feeding the build, never document content.

- **Schema SSOT** (`js/core/telemetry-schema.js`): ten typed events, enum/bool/duration slots only — no string prop exists, so leaking document content is structurally impossible. Shared verbatim by client and endpoint.
- **`api/t.js`**: Vercel function, zero npm deps, plain fetch to Supabase PostgREST; raw-stream 32KB cap; never errors to the client; dark-safe without env vars. No IP/UA stored.
- **Client** (`js/v2/telemetry.js`): `tel()` — local validation, sendBeacon batches, visibilitychange flush, no cookies/IDs, throw-armored.
- **Live events wired**: doc_open (text-layer probe), tool_use, export. GA4 untouched.
- **privasi.html**: honest plain-language telemetry section.
- **Migration** applied live as `telemetry_events_v1` (incl. security_invoker view hardening — default view ownership would have bypassed RLS for anon); `scripts/telemetry-migration.sql` is the source of truth.
- Also carries the golden-suite repoint (aa06955 cherry-pick) main was missing.

Suites: 37 core + 171 Playwright green, lint clean. Field-caught during verify: import-shadow bug (`t` param vs `t` export) killed signature selection — export renamed to `tel`, one-letter exports banned from this rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)