### PR TITLE
fix(pwa): clean-URL internal links so navigation works in the installed app

### DIFF
--- a/alat-gambar.html
+++ b/alat-gambar.html
@@ -142,7 +142,7 @@
   <!-- Header -->
   <header class="header">
     <div class="container header-inner">
-      <a href="index.html" class="logo">
+      <a href="/" class="logo">
         <div class="logo-icon">P</div>
         <span>PDFLokal</span>
       </a>
@@ -169,7 +169,7 @@
             <div class="theme-toggle-thumb"></div>
           </div>
         </label>
-        <a href="dukung.html" class="btn btn-primary">
+        <a href="/dukung" class="btn btn-primary">
           ☕ <span class="btn-text">Dukung Kami</span>
         </a>
       </div>
@@ -659,7 +659,7 @@
         <div class="editor-bottom-center">
           <a href="https://forms.gle/KPDWVAuc91pVjuWq6" target="_blank" class="editor-bottom-support">Hubungi Kami</a>
           <span class="editor-bottom-separator">•</span>
-          <a href="dukung.html" target="_blank" class="editor-bottom-support">Dukung Kami</a>
+          <a href="/dukung" target="_blank" class="editor-bottom-support">Dukung Kami</a>
         </div>
         <div class="editor-bottom-right">
           <div class="editor-bottom-zoom">
@@ -1560,7 +1560,7 @@
     <div class="container">
       <div class="footer-inner">
         <div class="footer-brand">
-          <a href="index.html" class="logo">
+          <a href="/" class="logo">
             <div class="logo-icon">P</div>
             <span>PDFLokal</span>
           </a>
@@ -1568,8 +1568,8 @@
         </div>
         <div class="footer-links">
           <a href="https://forms.gle/KPDWVAuc91pVjuWq6" target="_blank">Hubungi Kami</a>
-          <a href="dukung.html">Dukung Kami</a>
-          <a href="privasi.html">Kebijakan Privasi</a>
+          <a href="/dukung">Dukung Kami</a>
+          <a href="/privasi">Kebijakan Privasi</a>
           <a href="https://github.com/ojanlubis/pdflokal" target="_blank">Repository GitHub</a>
         </div>
       </div>

--- a/dukung.html
+++ b/dukung.html
@@ -153,7 +153,7 @@
   <!-- Header -->
   <header class="header">
     <div class="container header-inner">
-      <a href="index.html" class="logo">
+      <a href="/" class="logo">
         <div class="logo-icon">P</div>
         <span>PDFLokal</span>
       </a>
@@ -318,7 +318,7 @@
         <p style="font-size: 1.125rem; color: var(--text-secondary);">
           Makasih udah pakai PDFLokal!
         </p>
-        <a href="index.html" class="btn btn-primary btn-lg" style="margin-top: var(--space-lg);">
+        <a href="/" class="btn btn-primary btn-lg" style="margin-top: var(--space-lg);">
           Balik ke Tools
         </a>
       </div>
@@ -330,7 +330,7 @@
     <div class="container">
       <div class="footer-inner">
         <div class="footer-brand">
-          <a href="index.html" class="logo">
+          <a href="/" class="logo">
             <div class="logo-icon">P</div>
             <span>PDFLokal</span>
           </a>
@@ -338,8 +338,8 @@
         </div>
         <div class="footer-links">
           <a href="https://forms.gle/KPDWVAuc91pVjuWq6" target="_blank">Hubungi Kami</a>
-          <a href="dukung.html">Dukung Kami</a>
-          <a href="privasi.html">Kebijakan Privasi</a>
+          <a href="/dukung">Dukung Kami</a>
+          <a href="/privasi">Kebijakan Privasi</a>
           <a href="https://github.com/ojanlubis/pdflokal" target="_blank">Repository GitHub</a>
         </div>
       </div>

--- a/edit-pdf.html
+++ b/edit-pdf.html
@@ -901,7 +901,7 @@
       <div class="ld">
         <div class="ld-hd">
           <span class="ld-mark">PDF<em>Lokal</em></span>
-          <a href="dukung.html">Dukung Kami</a>
+          <a href="/dukung">Dukung Kami</a>
         </div>
         <div class="ld-hero">
           <div class="ld-hero-copy">
@@ -974,19 +974,19 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
             <b>Atur Halaman</b><span>Urutkan, putar, hapus halaman</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="m14 10 4-4"/><path d="M18 10V6h-4"/><path d="m10 14-4 4"/><path d="M6 14v4h4"/></svg>
             <b>Kompres Gambar</b><span>Foto jadi ringan dikirim</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 3 9 15"/><path d="M21 8V3h-5"/><path d="M3 21l6-6"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>
             <b>Ubah Ukuran Gambar</b><span>Pas buat syarat unggahan</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m17 2 4 4-4 4"/><path d="M3 11v-1a4 4 0 0 1 4-4h14"/><path d="m7 22-4-4 4-4"/><path d="M21 13v1a4 4 0 0 1-4 4H3"/></svg>
             <b>Konversi Gambar</b><span>JPG, PNG, atau WebP</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 21-4.3-4.3c-1-1-1-2.5 0-3.4l9.6-9.6c1-1 2.5-1 3.4 0l5.6 5.6c1 1 1 2.5 0 3.4L13 21"/><path d="M22 21H7"/></svg>
             <b>Hapus Background</b><span>Foto ttd atau produk jadi bersih</span>
           </a>
@@ -998,7 +998,7 @@
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
           <div>
             <b>Filemu nggak pernah ninggalin perangkatmu.</b>
-            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="privasi.html">Baca janji privasi kami</a></p>
+            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="/privasi">Baca janji privasi kami</a></p>
           </div>
         </div>
         <div class="ld-copy">
@@ -1078,8 +1078,8 @@
           </nav>
         </div>
         <footer class="ld-foot">
-          <a href="dukung.html">Dukung Kami</a>
-          <a href="privasi.html">Privasi</a>
+          <a href="/dukung">Dukung Kami</a>
+          <a href="/privasi">Privasi</a>
           <a href="https://github.com/ojanlubis/pdflokal" rel="noopener">GitHub</a>
           <span>Dibuat di Indonesia</span>
         </footer>

--- a/gabung-pdf.html
+++ b/gabung-pdf.html
@@ -901,7 +901,7 @@
       <div class="ld">
         <div class="ld-hd">
           <span class="ld-mark">PDF<em>Lokal</em></span>
-          <a href="dukung.html">Dukung Kami</a>
+          <a href="/dukung">Dukung Kami</a>
         </div>
         <div class="ld-hero">
           <div class="ld-hero-copy">
@@ -974,19 +974,19 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
             <b>Atur Halaman</b><span>Urutkan, putar, hapus halaman</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="m14 10 4-4"/><path d="M18 10V6h-4"/><path d="m10 14-4 4"/><path d="M6 14v4h4"/></svg>
             <b>Kompres Gambar</b><span>Foto jadi ringan dikirim</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 3 9 15"/><path d="M21 8V3h-5"/><path d="M3 21l6-6"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>
             <b>Ubah Ukuran Gambar</b><span>Pas buat syarat unggahan</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m17 2 4 4-4 4"/><path d="M3 11v-1a4 4 0 0 1 4-4h14"/><path d="m7 22-4-4 4-4"/><path d="M21 13v1a4 4 0 0 1-4 4H3"/></svg>
             <b>Konversi Gambar</b><span>JPG, PNG, atau WebP</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 21-4.3-4.3c-1-1-1-2.5 0-3.4l9.6-9.6c1-1 2.5-1 3.4 0l5.6 5.6c1 1 1 2.5 0 3.4L13 21"/><path d="M22 21H7"/></svg>
             <b>Hapus Background</b><span>Foto ttd atau produk jadi bersih</span>
           </a>
@@ -998,7 +998,7 @@
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
           <div>
             <b>Filemu nggak pernah ninggalin perangkatmu.</b>
-            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="privasi.html">Baca janji privasi kami</a></p>
+            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="/privasi">Baca janji privasi kami</a></p>
           </div>
         </div>
         <div class="ld-copy">
@@ -1085,8 +1085,8 @@
           </nav>
         </div>
         <footer class="ld-foot">
-          <a href="dukung.html">Dukung Kami</a>
-          <a href="privasi.html">Privasi</a>
+          <a href="/dukung">Dukung Kami</a>
+          <a href="/privasi">Privasi</a>
           <a href="https://github.com/ojanlubis/pdflokal" rel="noopener">GitHub</a>
           <span>Dibuat di Indonesia</span>
         </footer>

--- a/hapus-halaman-pdf.html
+++ b/hapus-halaman-pdf.html
@@ -901,7 +901,7 @@
       <div class="ld">
         <div class="ld-hd">
           <span class="ld-mark">PDF<em>Lokal</em></span>
-          <a href="dukung.html">Dukung Kami</a>
+          <a href="/dukung">Dukung Kami</a>
         </div>
         <div class="ld-hero">
           <div class="ld-hero-copy">
@@ -974,19 +974,19 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
             <b>Atur Halaman</b><span>Urutkan, putar, hapus halaman</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="m14 10 4-4"/><path d="M18 10V6h-4"/><path d="m10 14-4 4"/><path d="M6 14v4h4"/></svg>
             <b>Kompres Gambar</b><span>Foto jadi ringan dikirim</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 3 9 15"/><path d="M21 8V3h-5"/><path d="M3 21l6-6"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>
             <b>Ubah Ukuran Gambar</b><span>Pas buat syarat unggahan</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m17 2 4 4-4 4"/><path d="M3 11v-1a4 4 0 0 1 4-4h14"/><path d="m7 22-4-4 4-4"/><path d="M21 13v1a4 4 0 0 1-4 4H3"/></svg>
             <b>Konversi Gambar</b><span>JPG, PNG, atau WebP</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 21-4.3-4.3c-1-1-1-2.5 0-3.4l9.6-9.6c1-1 2.5-1 3.4 0l5.6 5.6c1 1 1 2.5 0 3.4L13 21"/><path d="M22 21H7"/></svg>
             <b>Hapus Background</b><span>Foto ttd atau produk jadi bersih</span>
           </a>
@@ -998,7 +998,7 @@
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
           <div>
             <b>Filemu nggak pernah ninggalin perangkatmu.</b>
-            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="privasi.html">Baca janji privasi kami</a></p>
+            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="/privasi">Baca janji privasi kami</a></p>
           </div>
         </div>
         <div class="ld-copy">
@@ -1083,8 +1083,8 @@
           </nav>
         </div>
         <footer class="ld-foot">
-          <a href="dukung.html">Dukung Kami</a>
-          <a href="privasi.html">Privasi</a>
+          <a href="/dukung">Dukung Kami</a>
+          <a href="/privasi">Privasi</a>
           <a href="https://github.com/ojanlubis/pdflokal" rel="noopener">GitHub</a>
           <span>Dibuat di Indonesia</span>
         </footer>

--- a/index.html
+++ b/index.html
@@ -901,7 +901,7 @@
       <div class="ld">
         <div class="ld-hd">
           <span class="ld-mark">PDF<em>Lokal</em></span>
-          <a href="dukung.html">Dukung Kami</a>
+          <a href="/dukung">Dukung Kami</a>
         </div>
         <div class="ld-hero">
           <div class="ld-hero-copy">
@@ -975,19 +975,19 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
             <b>Atur Halaman</b><span>Urutkan, putar, hapus halaman</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="m14 10 4-4"/><path d="M18 10V6h-4"/><path d="m10 14-4 4"/><path d="M6 14v4h4"/></svg>
             <b>Kompres Gambar</b><span>Foto jadi ringan dikirim</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 3 9 15"/><path d="M21 8V3h-5"/><path d="M3 21l6-6"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>
             <b>Ubah Ukuran Gambar</b><span>Pas buat syarat unggahan</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m17 2 4 4-4 4"/><path d="M3 11v-1a4 4 0 0 1 4-4h14"/><path d="m7 22-4-4 4-4"/><path d="M21 13v1a4 4 0 0 1-4 4H3"/></svg>
             <b>Konversi Gambar</b><span>JPG, PNG, atau WebP</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 21-4.3-4.3c-1-1-1-2.5 0-3.4l9.6-9.6c1-1 2.5-1 3.4 0l5.6 5.6c1 1 1 2.5 0 3.4L13 21"/><path d="M22 21H7"/></svg>
             <b>Hapus Background</b><span>Foto ttd atau produk jadi bersih</span>
           </a>
@@ -999,7 +999,7 @@
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
           <div>
             <b>Filemu nggak pernah ninggalin perangkatmu.</b>
-            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="privasi.html">Baca janji privasi kami</a></p>
+            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="/privasi">Baca janji privasi kami</a></p>
           </div>
         </div>
         <section class="ld-faq">
@@ -1041,8 +1041,8 @@
           </nav>
         </div>
         <footer class="ld-foot">
-          <a href="dukung.html">Dukung Kami</a>
-          <a href="privasi.html">Privasi</a>
+          <a href="/dukung">Dukung Kami</a>
+          <a href="/privasi">Privasi</a>
           <a href="https://github.com/ojanlubis/pdflokal" rel="noopener">GitHub</a>
           <span>Dibuat di Indonesia</span>
         </footer>

--- a/jpg-ke-pdf.html
+++ b/jpg-ke-pdf.html
@@ -901,7 +901,7 @@
       <div class="ld">
         <div class="ld-hd">
           <span class="ld-mark">PDF<em>Lokal</em></span>
-          <a href="dukung.html">Dukung Kami</a>
+          <a href="/dukung">Dukung Kami</a>
         </div>
         <div class="ld-hero">
           <div class="ld-hero-copy">
@@ -974,19 +974,19 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
             <b>Atur Halaman</b><span>Urutkan, putar, hapus halaman</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="m14 10 4-4"/><path d="M18 10V6h-4"/><path d="m10 14-4 4"/><path d="M6 14v4h4"/></svg>
             <b>Kompres Gambar</b><span>Foto jadi ringan dikirim</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 3 9 15"/><path d="M21 8V3h-5"/><path d="M3 21l6-6"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>
             <b>Ubah Ukuran Gambar</b><span>Pas buat syarat unggahan</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m17 2 4 4-4 4"/><path d="M3 11v-1a4 4 0 0 1 4-4h14"/><path d="m7 22-4-4 4-4"/><path d="M21 13v1a4 4 0 0 1-4 4H3"/></svg>
             <b>Konversi Gambar</b><span>JPG, PNG, atau WebP</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 21-4.3-4.3c-1-1-1-2.5 0-3.4l9.6-9.6c1-1 2.5-1 3.4 0l5.6 5.6c1 1 1 2.5 0 3.4L13 21"/><path d="M22 21H7"/></svg>
             <b>Hapus Background</b><span>Foto ttd atau produk jadi bersih</span>
           </a>
@@ -998,7 +998,7 @@
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
           <div>
             <b>Filemu nggak pernah ninggalin perangkatmu.</b>
-            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="privasi.html">Baca janji privasi kami</a></p>
+            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="/privasi">Baca janji privasi kami</a></p>
           </div>
         </div>
         <div class="ld-copy">
@@ -1086,8 +1086,8 @@
           </nav>
         </div>
         <footer class="ld-foot">
-          <a href="dukung.html">Dukung Kami</a>
-          <a href="privasi.html">Privasi</a>
+          <a href="/dukung">Dukung Kami</a>
+          <a href="/privasi">Privasi</a>
           <a href="https://github.com/ojanlubis/pdflokal" rel="noopener">GitHub</a>
           <span>Dibuat di Indonesia</span>
         </footer>

--- a/kompres-pdf-100kb.html
+++ b/kompres-pdf-100kb.html
@@ -901,7 +901,7 @@
       <div class="ld">
         <div class="ld-hd">
           <span class="ld-mark">PDF<em>Lokal</em></span>
-          <a href="dukung.html">Dukung Kami</a>
+          <a href="/dukung">Dukung Kami</a>
         </div>
         <div class="ld-hero">
           <div class="ld-hero-copy">
@@ -974,19 +974,19 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
             <b>Atur Halaman</b><span>Urutkan, putar, hapus halaman</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="m14 10 4-4"/><path d="M18 10V6h-4"/><path d="m10 14-4 4"/><path d="M6 14v4h4"/></svg>
             <b>Kompres Gambar</b><span>Foto jadi ringan dikirim</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 3 9 15"/><path d="M21 8V3h-5"/><path d="M3 21l6-6"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>
             <b>Ubah Ukuran Gambar</b><span>Pas buat syarat unggahan</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m17 2 4 4-4 4"/><path d="M3 11v-1a4 4 0 0 1 4-4h14"/><path d="m7 22-4-4 4-4"/><path d="M21 13v1a4 4 0 0 1-4 4H3"/></svg>
             <b>Konversi Gambar</b><span>JPG, PNG, atau WebP</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 21-4.3-4.3c-1-1-1-2.5 0-3.4l9.6-9.6c1-1 2.5-1 3.4 0l5.6 5.6c1 1 1 2.5 0 3.4L13 21"/><path d="M22 21H7"/></svg>
             <b>Hapus Background</b><span>Foto ttd atau produk jadi bersih</span>
           </a>
@@ -998,7 +998,7 @@
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
           <div>
             <b>Filemu nggak pernah ninggalin perangkatmu.</b>
-            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="privasi.html">Baca janji privasi kami</a></p>
+            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="/privasi">Baca janji privasi kami</a></p>
           </div>
         </div>
         <div class="ld-copy">
@@ -1073,8 +1073,8 @@
           </nav>
         </div>
         <footer class="ld-foot">
-          <a href="dukung.html">Dukung Kami</a>
-          <a href="privasi.html">Privasi</a>
+          <a href="/dukung">Dukung Kami</a>
+          <a href="/privasi">Privasi</a>
           <a href="https://github.com/ojanlubis/pdflokal" rel="noopener">GitHub</a>
           <span>Dibuat di Indonesia</span>
         </footer>

--- a/kompres-pdf-1mb.html
+++ b/kompres-pdf-1mb.html
@@ -901,7 +901,7 @@
       <div class="ld">
         <div class="ld-hd">
           <span class="ld-mark">PDF<em>Lokal</em></span>
-          <a href="dukung.html">Dukung Kami</a>
+          <a href="/dukung">Dukung Kami</a>
         </div>
         <div class="ld-hero">
           <div class="ld-hero-copy">
@@ -974,19 +974,19 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
             <b>Atur Halaman</b><span>Urutkan, putar, hapus halaman</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="m14 10 4-4"/><path d="M18 10V6h-4"/><path d="m10 14-4 4"/><path d="M6 14v4h4"/></svg>
             <b>Kompres Gambar</b><span>Foto jadi ringan dikirim</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 3 9 15"/><path d="M21 8V3h-5"/><path d="M3 21l6-6"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>
             <b>Ubah Ukuran Gambar</b><span>Pas buat syarat unggahan</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m17 2 4 4-4 4"/><path d="M3 11v-1a4 4 0 0 1 4-4h14"/><path d="m7 22-4-4 4-4"/><path d="M21 13v1a4 4 0 0 1-4 4H3"/></svg>
             <b>Konversi Gambar</b><span>JPG, PNG, atau WebP</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 21-4.3-4.3c-1-1-1-2.5 0-3.4l9.6-9.6c1-1 2.5-1 3.4 0l5.6 5.6c1 1 1 2.5 0 3.4L13 21"/><path d="M22 21H7"/></svg>
             <b>Hapus Background</b><span>Foto ttd atau produk jadi bersih</span>
           </a>
@@ -998,7 +998,7 @@
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
           <div>
             <b>Filemu nggak pernah ninggalin perangkatmu.</b>
-            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="privasi.html">Baca janji privasi kami</a></p>
+            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="/privasi">Baca janji privasi kami</a></p>
           </div>
         </div>
         <div class="ld-copy">
@@ -1073,8 +1073,8 @@
           </nav>
         </div>
         <footer class="ld-foot">
-          <a href="dukung.html">Dukung Kami</a>
-          <a href="privasi.html">Privasi</a>
+          <a href="/dukung">Dukung Kami</a>
+          <a href="/privasi">Privasi</a>
           <a href="https://github.com/ojanlubis/pdflokal" rel="noopener">GitHub</a>
           <span>Dibuat di Indonesia</span>
         </footer>

--- a/kompres-pdf-200kb.html
+++ b/kompres-pdf-200kb.html
@@ -901,7 +901,7 @@
       <div class="ld">
         <div class="ld-hd">
           <span class="ld-mark">PDF<em>Lokal</em></span>
-          <a href="dukung.html">Dukung Kami</a>
+          <a href="/dukung">Dukung Kami</a>
         </div>
         <div class="ld-hero">
           <div class="ld-hero-copy">
@@ -974,19 +974,19 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
             <b>Atur Halaman</b><span>Urutkan, putar, hapus halaman</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="m14 10 4-4"/><path d="M18 10V6h-4"/><path d="m10 14-4 4"/><path d="M6 14v4h4"/></svg>
             <b>Kompres Gambar</b><span>Foto jadi ringan dikirim</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 3 9 15"/><path d="M21 8V3h-5"/><path d="M3 21l6-6"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>
             <b>Ubah Ukuran Gambar</b><span>Pas buat syarat unggahan</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m17 2 4 4-4 4"/><path d="M3 11v-1a4 4 0 0 1 4-4h14"/><path d="m7 22-4-4 4-4"/><path d="M21 13v1a4 4 0 0 1-4 4H3"/></svg>
             <b>Konversi Gambar</b><span>JPG, PNG, atau WebP</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 21-4.3-4.3c-1-1-1-2.5 0-3.4l9.6-9.6c1-1 2.5-1 3.4 0l5.6 5.6c1 1 1 2.5 0 3.4L13 21"/><path d="M22 21H7"/></svg>
             <b>Hapus Background</b><span>Foto ttd atau produk jadi bersih</span>
           </a>
@@ -998,7 +998,7 @@
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
           <div>
             <b>Filemu nggak pernah ninggalin perangkatmu.</b>
-            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="privasi.html">Baca janji privasi kami</a></p>
+            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="/privasi">Baca janji privasi kami</a></p>
           </div>
         </div>
         <div class="ld-copy">
@@ -1073,8 +1073,8 @@
           </nav>
         </div>
         <footer class="ld-foot">
-          <a href="dukung.html">Dukung Kami</a>
-          <a href="privasi.html">Privasi</a>
+          <a href="/dukung">Dukung Kami</a>
+          <a href="/privasi">Privasi</a>
           <a href="https://github.com/ojanlubis/pdflokal" rel="noopener">GitHub</a>
           <span>Dibuat di Indonesia</span>
         </footer>

--- a/kompres-pdf-500kb.html
+++ b/kompres-pdf-500kb.html
@@ -901,7 +901,7 @@
       <div class="ld">
         <div class="ld-hd">
           <span class="ld-mark">PDF<em>Lokal</em></span>
-          <a href="dukung.html">Dukung Kami</a>
+          <a href="/dukung">Dukung Kami</a>
         </div>
         <div class="ld-hero">
           <div class="ld-hero-copy">
@@ -974,19 +974,19 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
             <b>Atur Halaman</b><span>Urutkan, putar, hapus halaman</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="m14 10 4-4"/><path d="M18 10V6h-4"/><path d="m10 14-4 4"/><path d="M6 14v4h4"/></svg>
             <b>Kompres Gambar</b><span>Foto jadi ringan dikirim</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 3 9 15"/><path d="M21 8V3h-5"/><path d="M3 21l6-6"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>
             <b>Ubah Ukuran Gambar</b><span>Pas buat syarat unggahan</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m17 2 4 4-4 4"/><path d="M3 11v-1a4 4 0 0 1 4-4h14"/><path d="m7 22-4-4 4-4"/><path d="M21 13v1a4 4 0 0 1-4 4H3"/></svg>
             <b>Konversi Gambar</b><span>JPG, PNG, atau WebP</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 21-4.3-4.3c-1-1-1-2.5 0-3.4l9.6-9.6c1-1 2.5-1 3.4 0l5.6 5.6c1 1 1 2.5 0 3.4L13 21"/><path d="M22 21H7"/></svg>
             <b>Hapus Background</b><span>Foto ttd atau produk jadi bersih</span>
           </a>
@@ -998,7 +998,7 @@
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
           <div>
             <b>Filemu nggak pernah ninggalin perangkatmu.</b>
-            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="privasi.html">Baca janji privasi kami</a></p>
+            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="/privasi">Baca janji privasi kami</a></p>
           </div>
         </div>
         <div class="ld-copy">
@@ -1065,8 +1065,8 @@
           </nav>
         </div>
         <footer class="ld-foot">
-          <a href="dukung.html">Dukung Kami</a>
-          <a href="privasi.html">Privasi</a>
+          <a href="/dukung">Dukung Kami</a>
+          <a href="/privasi">Privasi</a>
           <a href="https://github.com/ojanlubis/pdflokal" rel="noopener">GitHub</a>
           <span>Dibuat di Indonesia</span>
         </footer>

--- a/kompres-pdf.html
+++ b/kompres-pdf.html
@@ -901,7 +901,7 @@
       <div class="ld">
         <div class="ld-hd">
           <span class="ld-mark">PDF<em>Lokal</em></span>
-          <a href="dukung.html">Dukung Kami</a>
+          <a href="/dukung">Dukung Kami</a>
         </div>
         <div class="ld-hero">
           <div class="ld-hero-copy">
@@ -974,19 +974,19 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
             <b>Atur Halaman</b><span>Urutkan, putar, hapus halaman</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="m14 10 4-4"/><path d="M18 10V6h-4"/><path d="m10 14-4 4"/><path d="M6 14v4h4"/></svg>
             <b>Kompres Gambar</b><span>Foto jadi ringan dikirim</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 3 9 15"/><path d="M21 8V3h-5"/><path d="M3 21l6-6"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>
             <b>Ubah Ukuran Gambar</b><span>Pas buat syarat unggahan</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m17 2 4 4-4 4"/><path d="M3 11v-1a4 4 0 0 1 4-4h14"/><path d="m7 22-4-4 4-4"/><path d="M21 13v1a4 4 0 0 1-4 4H3"/></svg>
             <b>Konversi Gambar</b><span>JPG, PNG, atau WebP</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 21-4.3-4.3c-1-1-1-2.5 0-3.4l9.6-9.6c1-1 2.5-1 3.4 0l5.6 5.6c1 1 1 2.5 0 3.4L13 21"/><path d="M22 21H7"/></svg>
             <b>Hapus Background</b><span>Foto ttd atau produk jadi bersih</span>
           </a>
@@ -998,7 +998,7 @@
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
           <div>
             <b>Filemu nggak pernah ninggalin perangkatmu.</b>
-            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="privasi.html">Baca janji privasi kami</a></p>
+            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="/privasi">Baca janji privasi kami</a></p>
           </div>
         </div>
         <div class="ld-copy">
@@ -1086,8 +1086,8 @@
           </nav>
         </div>
         <footer class="ld-foot">
-          <a href="dukung.html">Dukung Kami</a>
-          <a href="privasi.html">Privasi</a>
+          <a href="/dukung">Dukung Kami</a>
+          <a href="/privasi">Privasi</a>
           <a href="https://github.com/ojanlubis/pdflokal" rel="noopener">GitHub</a>
           <span>Dibuat di Indonesia</span>
         </footer>

--- a/pdf-ke-jpg.html
+++ b/pdf-ke-jpg.html
@@ -901,7 +901,7 @@
       <div class="ld">
         <div class="ld-hd">
           <span class="ld-mark">PDF<em>Lokal</em></span>
-          <a href="dukung.html">Dukung Kami</a>
+          <a href="/dukung">Dukung Kami</a>
         </div>
         <div class="ld-hero">
           <div class="ld-hero-copy">
@@ -974,19 +974,19 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
             <b>Atur Halaman</b><span>Urutkan, putar, hapus halaman</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="m14 10 4-4"/><path d="M18 10V6h-4"/><path d="m10 14-4 4"/><path d="M6 14v4h4"/></svg>
             <b>Kompres Gambar</b><span>Foto jadi ringan dikirim</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 3 9 15"/><path d="M21 8V3h-5"/><path d="M3 21l6-6"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>
             <b>Ubah Ukuran Gambar</b><span>Pas buat syarat unggahan</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m17 2 4 4-4 4"/><path d="M3 11v-1a4 4 0 0 1 4-4h14"/><path d="m7 22-4-4 4-4"/><path d="M21 13v1a4 4 0 0 1-4 4H3"/></svg>
             <b>Konversi Gambar</b><span>JPG, PNG, atau WebP</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 21-4.3-4.3c-1-1-1-2.5 0-3.4l9.6-9.6c1-1 2.5-1 3.4 0l5.6 5.6c1 1 1 2.5 0 3.4L13 21"/><path d="M22 21H7"/></svg>
             <b>Hapus Background</b><span>Foto ttd atau produk jadi bersih</span>
           </a>
@@ -998,7 +998,7 @@
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
           <div>
             <b>Filemu nggak pernah ninggalin perangkatmu.</b>
-            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="privasi.html">Baca janji privasi kami</a></p>
+            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="/privasi">Baca janji privasi kami</a></p>
           </div>
         </div>
         <div class="ld-copy">
@@ -1083,8 +1083,8 @@
           </nav>
         </div>
         <footer class="ld-foot">
-          <a href="dukung.html">Dukung Kami</a>
-          <a href="privasi.html">Privasi</a>
+          <a href="/dukung">Dukung Kami</a>
+          <a href="/privasi">Privasi</a>
           <a href="https://github.com/ojanlubis/pdflokal" rel="noopener">GitHub</a>
           <span>Dibuat di Indonesia</span>
         </footer>

--- a/pisah-pdf.html
+++ b/pisah-pdf.html
@@ -901,7 +901,7 @@
       <div class="ld">
         <div class="ld-hd">
           <span class="ld-mark">PDF<em>Lokal</em></span>
-          <a href="dukung.html">Dukung Kami</a>
+          <a href="/dukung">Dukung Kami</a>
         </div>
         <div class="ld-hero">
           <div class="ld-hero-copy">
@@ -974,19 +974,19 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
             <b>Atur Halaman</b><span>Urutkan, putar, hapus halaman</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="m14 10 4-4"/><path d="M18 10V6h-4"/><path d="m10 14-4 4"/><path d="M6 14v4h4"/></svg>
             <b>Kompres Gambar</b><span>Foto jadi ringan dikirim</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 3 9 15"/><path d="M21 8V3h-5"/><path d="M3 21l6-6"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>
             <b>Ubah Ukuran Gambar</b><span>Pas buat syarat unggahan</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m17 2 4 4-4 4"/><path d="M3 11v-1a4 4 0 0 1 4-4h14"/><path d="m7 22-4-4 4-4"/><path d="M21 13v1a4 4 0 0 1-4 4H3"/></svg>
             <b>Konversi Gambar</b><span>JPG, PNG, atau WebP</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 21-4.3-4.3c-1-1-1-2.5 0-3.4l9.6-9.6c1-1 2.5-1 3.4 0l5.6 5.6c1 1 1 2.5 0 3.4L13 21"/><path d="M22 21H7"/></svg>
             <b>Hapus Background</b><span>Foto ttd atau produk jadi bersih</span>
           </a>
@@ -998,7 +998,7 @@
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
           <div>
             <b>Filemu nggak pernah ninggalin perangkatmu.</b>
-            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="privasi.html">Baca janji privasi kami</a></p>
+            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="/privasi">Baca janji privasi kami</a></p>
           </div>
         </div>
         <div class="ld-copy">
@@ -1083,8 +1083,8 @@
           </nav>
         </div>
         <footer class="ld-foot">
-          <a href="dukung.html">Dukung Kami</a>
-          <a href="privasi.html">Privasi</a>
+          <a href="/dukung">Dukung Kami</a>
+          <a href="/privasi">Privasi</a>
           <a href="https://github.com/ojanlubis/pdflokal" rel="noopener">GitHub</a>
           <span>Dibuat di Indonesia</span>
         </footer>

--- a/privasi.html
+++ b/privasi.html
@@ -162,7 +162,7 @@
   <!-- Header -->
   <header class="header">
     <div class="container header-inner">
-      <a href="index.html" class="logo">
+      <a href="/" class="logo">
         <div class="logo-icon">P</div>
         <span>PDFLokal</span>
       </a>
@@ -339,7 +339,7 @@
         <p style="font-size: 1rem; color: var(--text-tertiary); margin-bottom: var(--space-md);">
           Terakhir diupdate: 18 Januari 2026
         </p>
-        <a href="index.html" class="btn btn-primary btn-lg">
+        <a href="/" class="btn btn-primary btn-lg">
           Balik ke Tools
         </a>
       </div>
@@ -351,7 +351,7 @@
     <div class="container">
       <div class="footer-inner">
         <div class="footer-brand">
-          <a href="index.html" class="logo">
+          <a href="/" class="logo">
             <div class="logo-icon">P</div>
             <span>PDFLokal</span>
           </a>
@@ -359,8 +359,8 @@
         </div>
         <div class="footer-links">
           <a href="https://forms.gle/KPDWVAuc91pVjuWq6" target="_blank">Hubungi Kami</a>
-          <a href="dukung.html">Dukung Kami</a>
-          <a href="privasi.html">Kebijakan Privasi</a>
+          <a href="/dukung">Dukung Kami</a>
+          <a href="/privasi">Kebijakan Privasi</a>
           <a href="https://github.com/ojanlubis/pdflokal" target="_blank">Repository GitHub</a>
         </div>
       </div>

--- a/tanda-tangan-pdf.html
+++ b/tanda-tangan-pdf.html
@@ -901,7 +901,7 @@
       <div class="ld">
         <div class="ld-hd">
           <span class="ld-mark">PDF<em>Lokal</em></span>
-          <a href="dukung.html">Dukung Kami</a>
+          <a href="/dukung">Dukung Kami</a>
         </div>
         <div class="ld-hero">
           <div class="ld-hero-copy">
@@ -974,19 +974,19 @@
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
             <b>Atur Halaman</b><span>Urutkan, putar, hapus halaman</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="m14 10 4-4"/><path d="M18 10V6h-4"/><path d="m10 14-4 4"/><path d="M6 14v4h4"/></svg>
             <b>Kompres Gambar</b><span>Foto jadi ringan dikirim</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 3 9 15"/><path d="M21 8V3h-5"/><path d="M3 21l6-6"/><rect x="3" y="14" width="7" height="7" rx="1"/></svg>
             <b>Ubah Ukuran Gambar</b><span>Pas buat syarat unggahan</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m17 2 4 4-4 4"/><path d="M3 11v-1a4 4 0 0 1 4-4h14"/><path d="m7 22-4-4 4-4"/><path d="M21 13v1a4 4 0 0 1-4 4H3"/></svg>
             <b>Konversi Gambar</b><span>JPG, PNG, atau WebP</span>
           </a>
-          <a class="ld-card" href="alat-gambar.html">
+          <a class="ld-card" href="/alat-gambar">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m7 21-4.3-4.3c-1-1-1-2.5 0-3.4l9.6-9.6c1-1 2.5-1 3.4 0l5.6 5.6c1 1 1 2.5 0 3.4L13 21"/><path d="M22 21H7"/></svg>
             <b>Hapus Background</b><span>Foto ttd atau produk jadi bersih</span>
           </a>
@@ -998,7 +998,7 @@
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
           <div>
             <b>Filemu nggak pernah ninggalin perangkatmu.</b>
-            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="privasi.html">Baca janji privasi kami</a></p>
+            <p>Ijazah, KTP, kontrak. Semua diproses di browser-mu sendiri, bukan di server orang. <a href="/privasi">Baca janji privasi kami</a></p>
           </div>
         </div>
         <div class="ld-copy">
@@ -1082,8 +1082,8 @@
           </nav>
         </div>
         <footer class="ld-foot">
-          <a href="dukung.html">Dukung Kami</a>
-          <a href="privasi.html">Privasi</a>
+          <a href="/dukung">Dukung Kami</a>
+          <a href="/privasi">Privasi</a>
           <a href="https://github.com/ojanlubis/pdflokal" rel="noopener">GitHub</a>
           <span>Dibuat di Indonesia</span>
         </footer>

--- a/tests/pwa-clean-links.spec.js
+++ b/tests/pwa-clean-links.spec.js
@@ -1,0 +1,30 @@
+/*
+ * PWA navigation guard.
+ * On Vercel, an internal link to "/x.html" 308-redirects to "/x". When that
+ * redirect passes through the service worker's navigate handler, the browser
+ * refuses the redirected response and the navigation SILENTLY FAILS in an
+ * installed PWA — the "Dukung Kami does nothing" field report (Jul 2026, a
+ * friend's Lenovo). Clean URLs (no ".html") never redirect, so they navigate
+ * everywhere: browser tab AND installed PWA.
+ *
+ * This pins the fix: no landing/static page may link to a ".html" internal URL.
+ */
+import { test, expect } from '@playwright/test';
+
+const PAGES = ['/', '/dukung', '/privasi', '/alat-gambar'];
+
+for (const path of PAGES) {
+  test(`${path} has no internal .html links (they redirect → break PWA nav)`, async ({ page }) => {
+    await page.goto(path);
+    const htmlLinks = await page
+      .locator('a[href$=".html"]')
+      .evaluateAll((els) => els.map((a) => a.getAttribute('href')));
+    expect(htmlLinks).toEqual([]);
+  });
+}
+
+test('"Dukung Kami" points at the clean URL', async ({ page }) => {
+  await page.goto('/');
+  const href = await page.locator('.ld-foot a', { hasText: 'Dukung' }).first().getAttribute('href');
+  expect(href).toBe('/dukung');
+});


### PR DESCRIPTION
Field bug: in the installed PWA, tapping "Dukung Kami" did nothing (worked in a browser tab). Root cause: internal .html links get 308-redirected by Vercel cleanUrls, and that redirect through the service worker's navigate handler fails silently in installed/standalone PWAs. Fix: point all internal links at clean URLs (no .html) — index.html + 3 static pages + 12 regenerated SEO pages. Guard: tests/pwa-clean-links.spec.js (5/5 green). 🤖 Generated with [Claude Code](https://claude.com/claude-code)