### PR TITLE
feat(pwa): install chip visible by default (drop the 2nd-visit gate)

### DIFF
--- a/js/v2/install-prompt.js
+++ b/js/v2/install-prompt.js
@@ -3,7 +3,8 @@
  * ============================================================================
  * Lives on the HOMEPAGE, never on the download moment — install must not compete
  * with the share ask (founder call, Jul 2026). A quiet chip under the dropzone,
- * shown only to RETURNING users, opens a card that ADAPTS to the browser:
+ * shown by DEFAULT on every visit (founder call, Jul 20: the 2nd-visit gate was
+ * wrong — the chip should just be there), opens a card that ADAPTS to the browser:
  *   - one-tap when the native prompt is armed (Chromium desktop + Android),
  *   - point-by-point instructions otherwise (iOS Safari, Android menu, desktop…).
  * Goal: recall — get PDFLokal onto the home screen so the next PDF job returns
@@ -12,8 +13,6 @@
 import { track } from '../lib/analytics.js';
 
 const DISMISS_KEY = 'pdflokal-install-dismissed';
-const VISITS_KEY = 'pdflokal-visits';
-const SESSION_FLAG = 'pdflokal-visit-counted';
 
 function lget(k) { try { return localStorage.getItem(k); } catch { return null; } }
 function lset(k, v) { try { localStorage.setItem(k, v); } catch { /* private mode */ } }
@@ -39,15 +38,6 @@ function isMobile() {
 }
 function deviceWord() { return isMobile() ? 'hapemu' : 'komputermu'; }
 
-// One visit counted per browser session; "returning" = the 2nd session onward.
-function countVisit() {
-  try {
-    if (window.sessionStorage.getItem(SESSION_FLAG)) return;
-    window.sessionStorage.setItem(SESSION_FLAG, '1');
-  } catch { /* private mode: count every load — harmless */ }
-  lset(VISITS_KEY, String((parseInt(lget(VISITS_KEY), 10) || 0) + 1));
-}
-function isReturning() { return (parseInt(lget(VISITS_KEY), 10) || 0) >= 2; }
 
 // Official install guides — the authoritative source for the EXACT, current UI
 // labels (which drift by browser version + OS + locale). We keep a friendly
@@ -132,7 +122,6 @@ export function initInstallPrompt() {
   const guideLink = stepsBox.querySelector('#ic-guide');
   const installBtn = card.querySelector('#ic-install');
 
-  countVisit();
   const where = deviceWord();                          // hapemu | komputermu
   const screen = isMobile() ? 'layar HP' : 'desktop';  // where the icon lands
   chipLabel.textContent = `Install PDFLokal di ${where}`;
@@ -189,9 +178,12 @@ export function initInstallPrompt() {
     track('pwa_installed');
   });
 
-  // Reveal the chip for returning, non-installed, non-dismissed users. (Whether it
-  // opens to one-tap or steps is decided at tap time by detectInstall.)
-  if (!isStandalone() && lget(DISMISS_KEY) !== '1' && isReturning()) {
+  // Reveal the chip by DEFAULT — every visit — for non-installed, non-dismissed
+  // users (founder call, Jul 20: the 2nd-visit gate was wrong; the chip should
+  // just be there). Still suppressed for anyone already running the installed
+  // PWA, or who tapped "jangan tampilkan lagi". One-tap vs steps is decided at
+  // tap time by detectInstall.
+  if (!isStandalone() && lget(DISMISS_KEY) !== '1') {
     chip.hidden = false;
   }
 }

--- a/tests/mobile/pwa-install.spec.js
+++ b/tests/mobile/pwa-install.spec.js
@@ -1,19 +1,12 @@
 // PWA install — the recall play on the HOMEPAGE (GA4 finding Jul 2026: paid users
 // complete the task but don't return unprompted). A quiet chip under the dropzone,
-// shown only to RETURNING users, opens an adaptive card: one-tap when Chrome has
-// armed beforeinstallprompt, point-by-point steps otherwise. Never on the download
+// shown by DEFAULT on every visit (founder call Jul 20: the 2nd-visit gate was
+// wrong), opens an adaptive card: one-tap when Chrome has armed
+// beforeinstallprompt, point-by-point steps otherwise. Still suppressed for
+// already-installed (standalone) or dismissed users. Never on the download
 // moment — install must not compete with the share ask.
 import { test, expect } from '@playwright/test';
 
-// Simulate a returning visitor (2nd session onward) so the chip is eligible.
-async function seedReturning(page) {
-  await page.addInitScript(() => {
-    try {
-      localStorage.setItem('pdflokal-visits', '2');
-      sessionStorage.setItem('pdflokal-visit-counted', '1');
-    } catch { /* private mode */ }
-  });
-}
 async function armInstallPrompt(page) {
   await page.evaluate(() => {
     const e = new Event('beforeinstallprompt');
@@ -32,17 +25,12 @@ test.describe('PWA install — mobile', () => {
       .toBe(true);
   });
 
-  test('chip is hidden on a first visit, shown for a returning visitor', async ({ page }) => {
-    await page.goto('/'); // first visit → counted as visit 1
-    await expect(page.locator('#ip-chip')).toBeHidden();
-
-    await seedReturning(page);
-    await page.goto('/');
+  test('chip shows by default on the very first visit (non-installed, non-dismissed)', async ({ page }) => {
+    await page.goto('/'); // first visit — no returning gate any more
     await expect(page.locator('#ip-chip')).toBeVisible();
   });
 
-  test('returning + one-tap armed → chip opens the one-tap card', async ({ page }) => {
-    await seedReturning(page);
+  test('one-tap armed → chip opens the one-tap card', async ({ page }) => {
     await page.goto('/');
     await armInstallPrompt(page);
     await page.locator('#ip-chip').click();
@@ -56,13 +44,12 @@ test.describe('PWA install — mobile', () => {
   });
 
   test('"jangan tampilkan lagi" hides the chip permanently', async ({ page }) => {
-    await seedReturning(page);
     await page.goto('/');
     await page.locator('#ip-chip').click();
     await page.locator('#ic-never').click();
     await expect(page.locator('#ip-chip')).toBeHidden();
 
-    await page.goto('/'); // still a returning visit, but dismissed → stays gone
+    await page.goto('/'); // dismissed → stays gone even though the chip is now default-on
     await expect(page.locator('#ip-chip')).toBeHidden();
   });
 });
@@ -71,8 +58,7 @@ test.describe('PWA install — mobile', () => {
 test.describe('PWA install — iOS steps', () => {
   test.use({ userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1' });
 
-  test('returning iPhone user → chip opens the step-by-step card', async ({ page }) => {
-    await seedReturning(page);
+  test('iPhone user → chip opens the step-by-step card', async ({ page }) => {
     await page.goto('/');
     await page.locator('#ip-chip').click();
 


### PR DESCRIPTION
Founder call (Jul 20): hiding the install chip until a user's second visit was wrong — the chip should just be there.

**Change:** drop the returning-visitor gate in `install-prompt.js` (and remove the now-dead visit-counting: `countVisit`/`isReturning`/`VISITS_KEY`/`SESSION_FLAG`). The chip now reveals on every visit for non-installed, non-dismissed users.

**Kept (correct suppression, not the 2nd-visit hide):**
- hidden when already running the installed PWA (standalone)
- hidden after 'jangan tampilkan lagi' (dismiss-forever)

Chip markup + CSS untouched — it looks exactly as returning visitors already saw it, just shown to everyone. Spec retargeted to the new contract. Full sweep 185 green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)