### PR TITLE
Template row: center the card row, drop the stray subtitle

### DIFF
--- a/edit-pdf.html
+++ b/edit-pdf.html
@@ -944,7 +944,7 @@
     .tl-doc:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; }
     .tl-doc svg { width: 20px; height: 20px; color: var(--accent); }
     .tl-doc span { font-size: var(--fs-n1); font-weight: 700; letter-spacing: -.01em; line-height: 1.2; }
-    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: start; } }
+    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: center; } }
     .ld-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-12); margin-top: var(--sp-16); }
     .ld-grid.more, #ld-more { margin-top: var(--sp-12); }
     #ld-more[hidden] { display: none; }
@@ -1670,7 +1670,6 @@
         <section class="tl-band" id="tl-band">
           <div class="tl-head">
             <b>Template</b>
-            <span>Gratis, jadi PDF</span>
           </div>
           <div class="tl-row" role="list">
           <a class="tl-doc" href="https://template.pdflokal.id/slip-gaji" data-doc="slip-gaji">

--- a/gabung-pdf.html
+++ b/gabung-pdf.html
@@ -944,7 +944,7 @@
     .tl-doc:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; }
     .tl-doc svg { width: 20px; height: 20px; color: var(--accent); }
     .tl-doc span { font-size: var(--fs-n1); font-weight: 700; letter-spacing: -.01em; line-height: 1.2; }
-    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: start; } }
+    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: center; } }
     .ld-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-12); margin-top: var(--sp-16); }
     .ld-grid.more, #ld-more { margin-top: var(--sp-12); }
     #ld-more[hidden] { display: none; }
@@ -1670,7 +1670,6 @@
         <section class="tl-band" id="tl-band">
           <div class="tl-head">
             <b>Template</b>
-            <span>Gratis, jadi PDF</span>
           </div>
           <div class="tl-row" role="list">
           <a class="tl-doc" href="https://template.pdflokal.id/slip-gaji" data-doc="slip-gaji">

--- a/hapus-halaman-pdf.html
+++ b/hapus-halaman-pdf.html
@@ -944,7 +944,7 @@
     .tl-doc:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; }
     .tl-doc svg { width: 20px; height: 20px; color: var(--accent); }
     .tl-doc span { font-size: var(--fs-n1); font-weight: 700; letter-spacing: -.01em; line-height: 1.2; }
-    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: start; } }
+    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: center; } }
     .ld-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-12); margin-top: var(--sp-16); }
     .ld-grid.more, #ld-more { margin-top: var(--sp-12); }
     #ld-more[hidden] { display: none; }
@@ -1670,7 +1670,6 @@
         <section class="tl-band" id="tl-band">
           <div class="tl-head">
             <b>Template</b>
-            <span>Gratis, jadi PDF</span>
           </div>
           <div class="tl-row" role="list">
           <a class="tl-doc" href="https://template.pdflokal.id/slip-gaji" data-doc="slip-gaji">

--- a/index.html
+++ b/index.html
@@ -944,7 +944,7 @@
     .tl-doc:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; }
     .tl-doc svg { width: 20px; height: 20px; color: var(--accent); }
     .tl-doc span { font-size: var(--fs-n1); font-weight: 700; letter-spacing: -.01em; line-height: 1.2; }
-    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: start; } }
+    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: center; } }
     .ld-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-12); margin-top: var(--sp-16); }
     .ld-grid.more, #ld-more { margin-top: var(--sp-12); }
     #ld-more[hidden] { display: none; }
@@ -1670,7 +1670,6 @@
         <section class="tl-band" id="tl-band">
           <div class="tl-head">
             <b>Template</b>
-            <span>Gratis, jadi PDF</span>
           </div>
           <div class="tl-row" role="list">
           <a class="tl-doc" href="https://template.pdflokal.id/slip-gaji" data-doc="slip-gaji">

--- a/jpg-ke-pdf.html
+++ b/jpg-ke-pdf.html
@@ -944,7 +944,7 @@
     .tl-doc:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; }
     .tl-doc svg { width: 20px; height: 20px; color: var(--accent); }
     .tl-doc span { font-size: var(--fs-n1); font-weight: 700; letter-spacing: -.01em; line-height: 1.2; }
-    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: start; } }
+    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: center; } }
     .ld-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-12); margin-top: var(--sp-16); }
     .ld-grid.more, #ld-more { margin-top: var(--sp-12); }
     #ld-more[hidden] { display: none; }
@@ -1670,7 +1670,6 @@
         <section class="tl-band" id="tl-band">
           <div class="tl-head">
             <b>Template</b>
-            <span>Gratis, jadi PDF</span>
           </div>
           <div class="tl-row" role="list">
           <a class="tl-doc" href="https://template.pdflokal.id/slip-gaji" data-doc="slip-gaji">

--- a/kompres-pdf-100kb.html
+++ b/kompres-pdf-100kb.html
@@ -944,7 +944,7 @@
     .tl-doc:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; }
     .tl-doc svg { width: 20px; height: 20px; color: var(--accent); }
     .tl-doc span { font-size: var(--fs-n1); font-weight: 700; letter-spacing: -.01em; line-height: 1.2; }
-    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: start; } }
+    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: center; } }
     .ld-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-12); margin-top: var(--sp-16); }
     .ld-grid.more, #ld-more { margin-top: var(--sp-12); }
     #ld-more[hidden] { display: none; }
@@ -1670,7 +1670,6 @@
         <section class="tl-band" id="tl-band">
           <div class="tl-head">
             <b>Template</b>
-            <span>Gratis, jadi PDF</span>
           </div>
           <div class="tl-row" role="list">
           <a class="tl-doc" href="https://template.pdflokal.id/slip-gaji" data-doc="slip-gaji">

--- a/kompres-pdf-1mb.html
+++ b/kompres-pdf-1mb.html
@@ -944,7 +944,7 @@
     .tl-doc:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; }
     .tl-doc svg { width: 20px; height: 20px; color: var(--accent); }
     .tl-doc span { font-size: var(--fs-n1); font-weight: 700; letter-spacing: -.01em; line-height: 1.2; }
-    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: start; } }
+    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: center; } }
     .ld-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-12); margin-top: var(--sp-16); }
     .ld-grid.more, #ld-more { margin-top: var(--sp-12); }
     #ld-more[hidden] { display: none; }
@@ -1670,7 +1670,6 @@
         <section class="tl-band" id="tl-band">
           <div class="tl-head">
             <b>Template</b>
-            <span>Gratis, jadi PDF</span>
           </div>
           <div class="tl-row" role="list">
           <a class="tl-doc" href="https://template.pdflokal.id/slip-gaji" data-doc="slip-gaji">

--- a/kompres-pdf-200kb.html
+++ b/kompres-pdf-200kb.html
@@ -944,7 +944,7 @@
     .tl-doc:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; }
     .tl-doc svg { width: 20px; height: 20px; color: var(--accent); }
     .tl-doc span { font-size: var(--fs-n1); font-weight: 700; letter-spacing: -.01em; line-height: 1.2; }
-    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: start; } }
+    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: center; } }
     .ld-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-12); margin-top: var(--sp-16); }
     .ld-grid.more, #ld-more { margin-top: var(--sp-12); }
     #ld-more[hidden] { display: none; }
@@ -1670,7 +1670,6 @@
         <section class="tl-band" id="tl-band">
           <div class="tl-head">
             <b>Template</b>
-            <span>Gratis, jadi PDF</span>
           </div>
           <div class="tl-row" role="list">
           <a class="tl-doc" href="https://template.pdflokal.id/slip-gaji" data-doc="slip-gaji">

--- a/kompres-pdf-500kb.html
+++ b/kompres-pdf-500kb.html
@@ -944,7 +944,7 @@
     .tl-doc:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; }
     .tl-doc svg { width: 20px; height: 20px; color: var(--accent); }
     .tl-doc span { font-size: var(--fs-n1); font-weight: 700; letter-spacing: -.01em; line-height: 1.2; }
-    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: start; } }
+    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: center; } }
     .ld-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-12); margin-top: var(--sp-16); }
     .ld-grid.more, #ld-more { margin-top: var(--sp-12); }
     #ld-more[hidden] { display: none; }
@@ -1670,7 +1670,6 @@
         <section class="tl-band" id="tl-band">
           <div class="tl-head">
             <b>Template</b>
-            <span>Gratis, jadi PDF</span>
           </div>
           <div class="tl-row" role="list">
           <a class="tl-doc" href="https://template.pdflokal.id/slip-gaji" data-doc="slip-gaji">

--- a/kompres-pdf.html
+++ b/kompres-pdf.html
@@ -944,7 +944,7 @@
     .tl-doc:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; }
     .tl-doc svg { width: 20px; height: 20px; color: var(--accent); }
     .tl-doc span { font-size: var(--fs-n1); font-weight: 700; letter-spacing: -.01em; line-height: 1.2; }
-    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: start; } }
+    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: center; } }
     .ld-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-12); margin-top: var(--sp-16); }
     .ld-grid.more, #ld-more { margin-top: var(--sp-12); }
     #ld-more[hidden] { display: none; }
@@ -1670,7 +1670,6 @@
         <section class="tl-band" id="tl-band">
           <div class="tl-head">
             <b>Template</b>
-            <span>Gratis, jadi PDF</span>
           </div>
           <div class="tl-row" role="list">
           <a class="tl-doc" href="https://template.pdflokal.id/slip-gaji" data-doc="slip-gaji">

--- a/pdf-ke-jpg.html
+++ b/pdf-ke-jpg.html
@@ -944,7 +944,7 @@
     .tl-doc:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; }
     .tl-doc svg { width: 20px; height: 20px; color: var(--accent); }
     .tl-doc span { font-size: var(--fs-n1); font-weight: 700; letter-spacing: -.01em; line-height: 1.2; }
-    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: start; } }
+    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: center; } }
     .ld-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-12); margin-top: var(--sp-16); }
     .ld-grid.more, #ld-more { margin-top: var(--sp-12); }
     #ld-more[hidden] { display: none; }
@@ -1670,7 +1670,6 @@
         <section class="tl-band" id="tl-band">
           <div class="tl-head">
             <b>Template</b>
-            <span>Gratis, jadi PDF</span>
           </div>
           <div class="tl-row" role="list">
           <a class="tl-doc" href="https://template.pdflokal.id/slip-gaji" data-doc="slip-gaji">

--- a/pisah-pdf.html
+++ b/pisah-pdf.html
@@ -944,7 +944,7 @@
     .tl-doc:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; }
     .tl-doc svg { width: 20px; height: 20px; color: var(--accent); }
     .tl-doc span { font-size: var(--fs-n1); font-weight: 700; letter-spacing: -.01em; line-height: 1.2; }
-    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: start; } }
+    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: center; } }
     .ld-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-12); margin-top: var(--sp-16); }
     .ld-grid.more, #ld-more { margin-top: var(--sp-12); }
     #ld-more[hidden] { display: none; }
@@ -1670,7 +1670,6 @@
         <section class="tl-band" id="tl-band">
           <div class="tl-head">
             <b>Template</b>
-            <span>Gratis, jadi PDF</span>
           </div>
           <div class="tl-row" role="list">
           <a class="tl-doc" href="https://template.pdflokal.id/slip-gaji" data-doc="slip-gaji">

--- a/tanda-tangan-pdf.html
+++ b/tanda-tangan-pdf.html
@@ -944,7 +944,7 @@
     .tl-doc:focus-visible { outline: 3px solid var(--accent); outline-offset: 2px; }
     .tl-doc svg { width: 20px; height: 20px; color: var(--accent); }
     .tl-doc span { font-size: var(--fs-n1); font-weight: 700; letter-spacing: -.01em; line-height: 1.2; }
-    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: start; } }
+    @media (min-width: 720px) { .tl-row { grid-auto-columns: 132px; justify-content: center; } }
     .ld-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-12); margin-top: var(--sp-16); }
     .ld-grid.more, #ld-more { margin-top: var(--sp-12); }
     #ld-more[hidden] { display: none; }
@@ -1670,7 +1670,6 @@
         <section class="tl-band" id="tl-band">
           <div class="tl-head">
             <b>Template</b>
-            <span>Gratis, jadi PDF</span>
           </div>
           <div class="tl-row" role="list">
           <a class="tl-doc" href="https://template.pdflokal.id/slip-gaji" data-doc="slip-gaji">


### PR DESCRIPTION
## Summary

- `.tl-row` (the Template card row) was left-aligned on desktop (`justify-content: start`) even though the 5 cards leave plenty of empty width in the 920px column — reads as off-balance against the centered sections around it. Now centers.
- The `<span>Gratis, jadi PDF</span>` in `.tl-head` had nothing constraining its width and was rendering out at the far right edge of the card, past the visual boundary — looked like a layout bug rather than a subtitle. Removed it. The divider line above the section (`.tl-band`'s `border-top`) is untouched.
- Regenerated the 12 SEO pages + sitemap (`npm run seo`) since `index.html`'s body changed — `seo:check` requires them to stay in sync.

Founder-directed live, 2026-09-04 (screenshot of the before/after taken locally, attached in the session).

## Test plan

- [x] `npm run gate` — GREEN (387 passed, 7 skipped). Two intermediate runs on this exact same tree hit `tests/ganti-teks-reedit.spec.js:212` and `tests/mobile/back-button.spec.js:48` — both are the pre-documented container-starvation flakes named in `CLAUDE.md` §6.5, rotating cast across otherwise-identical trees, unrelated to this change.
- [x] Verified visually via local `npx serve` screenshot: subtitle gone, divider intact, cards centered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yc5h5gGNyxfqxH2F9bf6ic

---
_Generated by [Claude Code](https://claude.ai/code/session_01Yc5h5gGNyxfqxH2F9bf6ic)_