### PR TITLE
Desktop chrome merge, feedback tab, and a pasted screenshot

### DIFF
--- a/api/feedback.js
+++ b/api/feedback.js
@@ -52,14 +52,43 @@ function makeQuery(dsn) {
 // Notes are short reactions, not essays — a much smaller cap than telemetry's
 // 32KB batch. NOTE_MAX bounds the stored string; MAX_BODY_BYTES bounds the raw
 // request so a hostile client can't stream megabytes at us before we slice.
-// MAX_BODY_BYTES is sized for the Increment D sample case (two base64 PNGs,
-// ~54.6KB each at the 40KB-raw cap, ~109KB combined) plus JSON/field
-// overhead and a safety margin — comfortably bounded either way, never
-// unbounded.
+// MAX_BODY_BYTES was sized for the Increment D sample case alone (two base64
+// PNGs, ~54.6KB each at the 40KB-raw cap, ~109KB combined). RAISED 2026-09-09
+// for the pasted screenshot: 200KB raw base64s to ~274KB, and the cap has to
+// hold that PLUS a sample, because a crafted body can carry both even though no
+// client sends both. Still a bound, never unbounded — that is the property.
 const NOTE_MAX = 1000;
-const MAX_BODY_BYTES = 200 * 1024;
+const MAX_BODY_BYTES = 420 * 1024;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const APP_VERSION_RE = /^[0-9a-f]{7,40}$|^dev$/;
+
+// ---- the pasted screenshot (mirrors js/core/feedback-shot.js) --------------
+// ⚠️ ITS OWN PREFIX, ITS OWN CAP, ITS OWN FUNCTION — not a widened sample
+// check. The crop pair is PNG at 40KB produced by our code; this is one JPEG at
+// 200KB chosen by a user. A single validator holding the union of both rule
+// sets enforces neither, and the looser half would silently become the rule for
+// the stricter object. Duplicated from core/ for the same reason readBody is:
+// this file must not import from the browser bundle.
+const SHOT_DATA_URL_PREFIX = 'data:image/jpeg;base64,';
+const SHOT_MAX_BYTES = 200 * 1024;
+
+function shotBytes(dataUrl) {
+  if (typeof dataUrl !== 'string' || !dataUrl.startsWith(SHOT_DATA_URL_PREFIX)) return Infinity;
+  const b64 = dataUrl.slice(SHOT_DATA_URL_PREFIX.length);
+  if (b64.length === 0 || b64.length % 4 !== 0 || !SAMPLE_BASE64_RE.test(b64)) return Infinity;
+  const padding = b64.endsWith('==') ? 2 : b64.endsWith('=') ? 1 : 0;
+  return Math.floor((b64.length * 3) / 4) - padding;
+}
+
+// Returns the data URL, or null. Never a repaired value — a screenshot that
+// fails here is simply not stored, and the rating and note land exactly as a
+// feedback with no screenshot always has.
+function validateShot(body) {
+  const url = body?.screenshot;
+  const bytes = shotBytes(url);
+  if (!(bytes > 0) || bytes > SHOT_MAX_BYTES) return null;
+  return url;
+}
 
 // ---- Increment D: sample validation (mirrors js/core/feedback-sample.js) ----
 const SAMPLE_DATA_URL_PREFIX = 'data:image/png;base64,';
@@ -165,6 +194,7 @@ export default async function handler(req, res) {
     // the WHOLE sample (never a partial one) on anything off — the rating+
     // note above are already extracted and land regardless.
     const sample = validateSample(body);
+    const shot = validateShot(body);
 
     // THE CLIENT'S OWN ANSWER WINS — mirroring api/t.js's 2026-07-29 reversal,
     // which this file missed until the 2026-08-09 audit (finding 4). The same
@@ -195,9 +225,9 @@ export default async function handler(req, res) {
     try {
       const query = queryOverride || makeQuery(dsn);
       const out = await query(
-        `insert into feedback (session_id, app_version, rating, note, sample_before, sample_after)
-         values ($1::uuid,$2,$3,$4,$5,$6)`,
-        [sessionId, storedVersion, rating, note, sample?.before ?? null, sample?.after ?? null],
+        `insert into feedback (session_id, app_version, rating, note, sample_before, sample_after, screenshot)
+         values ($1::uuid,$2,$3,$4,$5,$6,$7)`,
+        [sessionId, storedVersion, rating, note, sample?.before ?? null, sample?.after ?? null, shot],
       );
       if (out?.rowCount !== 1) {
         console.error(`[feedback] insert SHORT written=${out?.rowCount ?? 'unknown'} rows_expected=1`);

--- a/edit-pdf.html
+++ b/edit-pdf.html
@@ -287,6 +287,12 @@
          its own mode and page values must not be ported into it. A toolbar at
          --sp-48 is a toolbar that wastes the document's room. */
       --header-h: 44px; --toolbar-h: 52px;
+      /* THE HEIGHT EVERYTHING BELOW THE CHROME MEASURES AGAINST. It was
+         spelled `calc(var(--header-h) + var(--toolbar-h))` at each use site,
+         which stopped being true the moment the two could share a row. One
+         name, redefined once per breakpoint. */
+      --chrome-h: calc(var(--header-h) + var(--toolbar-h));
+      --header-merged-h: 52px;   /* the single-row height (tools are 36px + padding) */
     }
     /* Self-hosted fonts (preview parity with the PDF export) */
     @font-face { font-family: 'Montserrat'; src: url('fonts/montserrat-regular.woff2') format('woff2'); font-weight: 400; font-style: normal; font-display: swap; }
@@ -336,10 +342,17 @@
 
     /* ---- header ---- */
     header {
-      height: var(--header-h); flex: 0 0 auto;
+      min-height: var(--header-h); flex: 0 0 auto;
       display: flex; align-items: center; gap: 8px; padding: 0 10px;
-      background: var(--surface); border-bottom: 1px solid var(--line);
+      background: var(--surface);
+      /* WRAPS ON PURPOSE. Below the merge breakpoint the toolbar takes a full
+         row of its own; above it, everything stays on one line. No JS, no
+         second element, no duplicated tool buttons to keep in sync. */
+      flex-wrap: wrap;
     }
+    /* Narrow: the toolbar is a row of its own and carries the bottom edge, so
+       the header must NOT also draw one — two borders read as a seam. */
+    header > #toolbar { order: 9; flex: 1 0 100%; margin: 0 -10px; }
     .brand { font-weight: 700; font-size: 15px; letter-spacing: -.01em; }
     .brand-red { color: var(--accent); }
     /* home confirm: rides the standard dialog/.sheet system (the global
@@ -352,6 +365,18 @@
      * renders as a success. This system has one meaning for red and a second
      * colour meaning "good" is not being introduced here. */
     .fb-sheet { max-width: 380px; }
+    /* The byline under the question. Muted and small on purpose: it answers
+       "who am I writing to", it is not a place to go. The domain is the only
+       link, because it is the only one that leads anywhere useful. */
+    .fb-owner {
+      display: flex; align-items: center; gap: 9px;
+      margin: -2px 0 14px;
+    }
+    .fb-owner img { width: 28px; height: 28px; border-radius: 50%; object-fit: cover; flex: none; }
+    .fb-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
+    .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
+    .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -484,12 +509,73 @@
     }
     .tool.active { background: rgba(220,38,38,.08); color: var(--accent); }
 
+    /* ---- MERGED CHROME: one row when the width can hold it ---------------
+       His ruling 2026-09-09: "buat desktop, pindahin tools2nya ke atas. karena
+       spacenya kosong, cuma bikin dua baris navbar kalo spacenya ga cukup aja".
+       So the two-row layout is the FALLBACK, not the default.
+
+       ⚠️ THE BREAKPOINT IS MEASURED, NOT CHOSEN — 900px, 2026-09-09.
+       `.spacer { flex: 1 }` is the slack in this row, so its width IS the
+       headroom. Measured in Chromium: 152px of slack at 1000, 52 at 900, 12 at
+       860, and ZERO at 848. **848 is the true minimum**; 900 is that plus a
+       stated ~50px so the row never sits flush against its own ends, because a
+       row with no breathing room reads as broken even while it technically
+       fits. If a tool is added or a label reworded, RE-MEASURE — a stale
+       breakpoint shows up as a cramped row, never as an error.
+
+       ⚠️ AND THE GAUGE TOOK THREE TRIES, which is the part worth keeping.
+       Per-tool `scrollWidth` reported "fits" at every width down to 760, twice,
+       because the tools were not the element losing width. A third attempt
+       queried `#spacer` — it is a CLASS, so the query returned null and the
+       check passed on null. Only the fourth gauge, the spacer's own geometry
+       through a selector proven to match, showed a number that moved.
+       [[a-watcher-must-be-proven-to-fire]] is the sibling rule.
+
+       ⚠️ AND CHECK THE CEILING AT BOTH SIDES OF IT. design-discipline §2: a
+       band that holds three destinations at 1280 holds four at 375 without
+       anyone editing it. Here the count is unchanged either way — File, the
+       tool cluster (ONE destination, grouped), and Unduh (the one primary) —
+       which is the whole reason this merge is legitimate rather than a
+       fourth thing competing on one line. */
+    @media (min-width: 900px) {
+      :root { --chrome-h: var(--header-merged-h); }
+      header {
+        min-height: var(--header-merged-h); flex-wrap: nowrap;
+        border-bottom: 1px solid var(--line);
+      }
+      /* The flex spacer is what pushes Unduh right in the two-row layout. On
+         the merged row the TOOLBAR grows into that space instead and centres
+         its own children, so a second grower would fight it and shove the
+         tools off-centre. One grower per row. */
+      header > .spacer { display: none; }
+      header > #toolbar {
+        order: 3; flex: 1 1 auto; margin: 0;
+        height: auto; background: none; border-bottom: 0; padding: 0;
+        overflow: visible;
+      }
+      /* Undo/redo/Unduh sit AFTER the tools on the merged row. The markup has
+         the toolbar last (it was appended), so the order is stated here rather
+         than implied by the DOM. */
+      header > #btn-undo, header > #btn-redo, header > #btn-download { order: 5; }
+      /* Icon ABOVE label needs 52px of vertical room. On one shared row the
+         label moves BESIDE the icon — same target size, half the height. */
+      .tool {
+        flex-direction: row; gap: 6px;
+        min-width: 0; height: 36px; padding: 0 9px; font-size: 12.5px;
+      }
+      .tool svg { width: 17px; height: 17px; }
+      /* The BETA cap was corner-pinned so it could not widen a tight toolbar.
+         On the merged row there is room beside the word, and a corner chip on a
+         36px control overlaps its own label. */
+      .tool .beta-tag { position: static; margin-left: 1px; }
+    }
+
     /* ---- format bar: contextual, only when text is in play ---- */
     /* Contextual bars OVERLAY the canvas (founder: the document must never
        jump when a bar appears/disappears) — frosted so the page shows through. */
     #format-bar {
       display: none; align-items: center; gap: 6px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; height: 46px; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -623,61 +709,33 @@
        above was always claiming. The words survive as aria-label + title, so
        a screen reader and a desktop hover both still say "Kontak saya" — the
        label moved, it was not deleted. */
+    /* ⚠️ THE TAB SAYS WHAT IT DOES (2026-09-09, his ruling: "icon ini diganti
+       jadi kata2 aja ya 'ada masukan?'"). It was a chat glyph opening a panel
+       of five social handles; the handles are gone — "gaada yang peduli" — and
+       the glyph went with them, because an icon that has to be tapped to learn
+       its meaning fails his own element test (design-discipline §2).
+
+       AND THE PANEL IS GONE, NOT REPOINTED. Once the tab itself reads "Ada
+       masukan?", a panel whose only content was a button reading "Ada masukan?"
+       is a step that asks the same question twice. The tab opens #fb-form
+       directly. Whose product this is now lives INSIDE that dialog, where it
+       answers "who am I writing to" at the moment the question occurs.
+
+       The string is not new: it is the footer's, ratified 2026-08-22, and
+       reusing it keeps one name for one act (EXCLUDE 2 — copy is his). */
     #contact-tab-btn {
       position: fixed; left: 10px; bottom: 14px; z-index: 30;
-      width: 40px; height: 40px; border-radius: 12px;
-      display: grid; place-items: center;
+      min-height: 40px; padding: 0 14px; border-radius: 12px;
+      display: inline-flex; align-items: center;
       background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      color: var(--muted);
+      color: var(--muted); font-size: 13px; font-weight: 600;
     }
-    #contact-tab-btn svg { width: 19px; height: 19px; display: block; }
-    #contact-tab-panel {
-      position: fixed; left: 10px; bottom: 62px; z-index: 30;
-      width: max-content; max-width: min(78vw, 260px);
-      background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      border-radius: 12px; padding: 8px;
-      /* visibility (not just opacity): same reasoning as #support-card — a
-         dismissed panel must be GONE to hit-testing and screen readers. */
-      opacity: 0; visibility: hidden; pointer-events: none;
-      transform: translateY(10px); /* rests slightly low → reads as "slides up" on open */
-      transition: opacity .22s ease, transform .22s ease, visibility 0s linear .22s;
-    }
-    #contact-tab-panel.show {
-      opacity: 1; visibility: visible; pointer-events: auto;
-      transform: translateY(0); transition-delay: 0s;
-    }
-    /* One row per channel. min-height 40, not 44: this is a LIST inside an
-       already-opened panel, where rows are separated and mis-taps are cheap —
-       the 44 law guards isolated targets a finger hunts for, and the opening
-       tab is the one that has to meet it. Same reasoning text-runs.js records
-       for inflating a HIT box rather than a visual one. */
-    #contact-tab-panel a {
-      display: flex; align-items: center; gap: 10px;
-      min-height: 40px; padding: 0 10px; border-radius: 9px;
-      color: var(--ink); font-size: 13px; font-weight: 600; text-decoration: none;
-    }
-    #contact-tab-panel a:hover { background: var(--bg); }
-    /* The handle is the quiet half: the platform is what you scan for, the
-       handle is what you check once you have found it. */
-    #contact-tab-panel a b { font-weight: 600; }
-    #contact-tab-panel a span { color: var(--muted); font-weight: 500; margin-left: auto; }
-    #contact-tab-panel a svg { width: 16px; height: 16px; flex: none; color: var(--muted); }
-    /* The owner row. Deliberately NOT an <a> — it is not a sixth channel, it
-       is the answer to "whose handles are these". */
-    #contact-tab-panel .ct-owner {
-      display: flex; align-items: center; gap: 10px;
-      padding: 4px 10px 8px; margin-bottom: 4px;
-      border-bottom: 1px solid var(--line);
-    }
-    #contact-tab-panel .ct-owner img { width: 32px; height: 32px; border-radius: 50%; object-fit: cover; flex: none; }
-    #contact-tab-panel .ct-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
-    #contact-tab-panel .ct-owner span { display: block; font-size: 11px; color: var(--muted); font-weight: 500; margin-left: 0; }
-    @media (prefers-reduced-motion: reduce) { #contact-tab-panel { transition: none; } }
+    #contact-tab-btn:hover { color: var(--ink); }
 
     /* ---- the landing (= the editor's empty state; design: draf 3b) ---- */
     /* Editor chrome yields while the landing is up; it has its own header. */
     body.is-empty header, body.is-empty #toolbar, body.is-empty #zoom-ctl,
-    body.is-empty #contact-tab-btn, body.is-empty #contact-tab-panel { display: none; }
+    body.is-empty #contact-tab-btn { display: none; }
     #empty {
       position: absolute; inset: 0; overflow-y: auto; overscroll-behavior: contain;
       /* The PAGE ground is white (ruled 2026-07-29). The body underneath is
@@ -1322,7 +1380,7 @@
     /* signature context strip ("Semua Hal.") */
     #sig-bar {
       display: none; align-items: center; gap: 8px; height: 46px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -1604,8 +1662,16 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>
     </button>
     <button id="btn-download" disabled>Unduh</button>
-  </header>
-
+    <!-- ⚠️ THE TOOLBAR LIVES INSIDE <header> (2026-09-09, his ruling: "buat
+         desktop, pindahin tools2nya ke atas. karena spacenya kosong").
+         It is ONE element in TWO layouts, never two elements:
+           wide  → it sits on the header's own row, between File and Unduh
+           narrow→ header wraps and it takes its own row, exactly as before
+         A sibling cannot be pulled into a flex row by CSS, so the DOM move is
+         what makes the wide layout possible at all. Placement is by `order`,
+         so the markup order here is not the reading order — see the header
+         rules in the stylesheet, and --chrome-h, which is what everything
+         positioned BELOW the chrome measures against. -->
   <div id="toolbar" role="toolbar" aria-label="Alat">
     <!-- No "Pilih" button (founder ruling 2026-07-19): the neutral mode is a
          STATE, not a tool — nothing lit means nothing armed. Every armed tool
@@ -1635,6 +1701,8 @@
       Halaman
     </button>
   </div>
+  </header>
+
 
   <div id="format-bar" role="toolbar" aria-label="Format teks"></div>
   <div id="sig-bar" role="toolbar" aria-label="Aksi tanda tangan">
@@ -1993,44 +2061,20 @@
     <button id="z-in" aria-label="Perbesar">+</button>
     <button id="z-out" aria-label="Perkecil">−</button>
   </div>
-  <!-- Contact bookmark: quiet furniture tab, bottom-left, mirrors #zoom-ctl.
-       Two separate elements (button + panel), not one wrapper — see the CSS
-       comment for why.
+  <!-- The feedback tab: quiet furniture, bottom-left, mirrors #zoom-ctl.
+       It used to be a chat glyph opening a panel of five social handles. He
+       retired both on 2026-09-09 — "ilangin semua sosmed gue, gaada yang
+       peduli wkwk, ganti jadi feedback form aja" — so the tab now says what it
+       does and opens the general feedback dialog (#fb-form) directly.
 
-       ⚠️ THE HANDLES ARE NOT INVENTED HERE AND MUST NOT BE. They come from
-       `engine/wiki/machine/public-identity.md`, which is the machine's one
-       home for them, and each is verified against fkd/loker's own shipped
-       Kontak dialog. A handle typed from memory is a live link to someone
-       else's account. If a channel is missing from the wiki it is missing
-       here too — that is the design, not an oversight.
+       ⚠️ THE HANDLES ARE NOT COMMENTED OUT AND MUST NOT BE RESTORED FROM HERE.
+       They live in `engine/wiki/machine/public-identity.md`, which is the
+       machine's one home for them; a handle typed from memory is a live link
+       to someone else's account. This surface simply no longer carries them.
 
-       ⚠️ THREADS AND X CAME FROM HIM, NOT FROM THE MACHINE (2026-08-23). He
-       asked for "semua sosmed gue... threads x instagram, cari aja" — and
-       they were not there: not in the wiki page, not in loker's dialog, not
-       anywhere under ~/machine. The Instagram handle made threads/@ojan.lubis
-       a good guess and it turned out correct, which is exactly why it was not
-       shipped as one: a guessed handle that happens to resolve is a live link
-       to a stranger's account until someone confirms whose it is. He supplied
-       both, they are now in the wiki, and the wiki is what a future session
-       reads. -->
-  <button id="contact-tab-btn" aria-expanded="false" aria-controls="contact-tab-panel"
-          aria-label="Kontak saya" title="Kontak saya">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 11.5a8.4 8.4 0 0 1-9 8.4 9 9 0 0 1-3.9-.9L3 20.5l1.5-4.5a8.4 8.4 0 0 1-.9-3.9 8.4 8.4 0 0 1 8.4-9 8.4 8.4 0 0 1 9 8.4Z"/></svg>
-  </button>
-  <div id="contact-tab-panel">
-    <!-- WHO the channels belong to. Added 2026-08-27: this panel listed five
-         handles and never said whose they were. Not a destination — a label on
-         the list below it. -->
-    <div class="ct-owner">
-      <img src="images/ojan.jpg" alt="Foto Ojan" width="32" height="32" loading="lazy">
-      <div><b>Ojan</b><span>Fauzan Ahladzikri</span></div>
-    </div>
-    <a href="https://tiktok.com/@okeojan" target="_blank" rel="noopener"><b>TikTok</b><span>@okeojan</span></a>
-    <a href="https://instagram.com/ojan.lubis" target="_blank" rel="noopener"><b>Instagram</b><span>ojan.lubis</span></a>
-    <a href="https://www.threads.com/@ojan.lubis" target="_blank" rel="noopener"><b>Threads</b><span>ojan.lubis</span></a>
-    <a href="https://x.com/okeojan" target="_blank" rel="noopener"><b>X</b><span>@okeojan</span></a>
-    <a href="https://ojanlubis.id" target="_blank" rel="noopener"><b>Website</b><span>ojanlubis.id</span></a>
-  </div>
+       Wired by js/v2/feedback-form.js, alongside the footer's own link — one
+       dialog, one code path, two doors. -->
+  <button id="contact-tab-btn">Ada masukan?</button>
   <div id="toast" role="status" aria-live="polite"></div>
 
   <!-- The general feedback channel, opened from the footer's "Ada masukan?".
@@ -2049,6 +2093,17 @@
     <div class="sheet fb-sheet">
       <div class="fb-body">
         <h2>Gimana PDFLokal?</h2>
+        <!-- WHO IS ASKING. Moved here 2026-09-09 from the retired contact
+             panel, where it labelled a list of handles. It is a BYLINE, not a
+             destination: the dialog's one primary is Kirim, and an identity
+             block competing with it would be a second thing to decide about
+             (design-discipline §2 — the ceiling counts destinations). Small,
+             muted, directly under the question so it answers "who am I writing
+             to" exactly when that occurs to someone. -->
+        <div class="fb-owner">
+          <img src="images/ojan.jpg" alt="" width="28" height="28" loading="lazy">
+          <div><b>Ojan</b><a href="https://mesindev.com" target="_blank" rel="noopener">mesindev.com</a></div>
+        </div>
         <div class="fb-thumbs" role="group" aria-label="Penilaian">
           <button type="button" id="fb-up" aria-pressed="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/></svg>

--- a/edit-pdf.html
+++ b/edit-pdf.html
@@ -377,6 +377,20 @@
     .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
     .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
 
+    /* The pasted screenshot, shown back at a size you can actually check. */
+    #fb-shot { position: relative; margin: 10px 0 0; }
+    #fb-shot img {
+      display: block; width: 100%; max-height: 180px; object-fit: contain;
+      border: 1px solid var(--line); border-radius: 8px; background: var(--bg);
+    }
+    #fb-shot-clear {
+      position: absolute; top: 6px; right: 6px;
+      width: 28px; height: 28px; border-radius: 8px; line-height: 1;
+      display: grid; place-items: center; font-size: 17px;
+      background: var(--surface); color: var(--ink);
+      box-shadow: 0 1px 6px rgba(0,0,0,.22);
+    }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -2114,7 +2128,20 @@
             <span>Kurang</span>
           </button>
         </div>
-        <textarea id="fb-note" rows="3" placeholder="boleh minta feedbacknya di sini, supaya kita bisa improve terus pdflokal. (boleh dikosongin juga kok)"></textarea>
+        <!-- PASTE, NOT UPLOAD (his ruling 2026-09-09: "gausah ada tombolnya,
+             bilang aja diplaceholdernya"). No attach button anywhere, and
+             nothing here ever reaches into the editor for pixels — the only
+             image that can exist is one the user deliberately pasted. That is
+             the whole reason this is defensible against the product's own "no
+             uploads" claim, so a convenience button would not be a small
+             addition, it would remove the argument. -->
+        <textarea id="fb-note" rows="3" placeholder="tulis feedbacknya di sini, atau boleh paste screenshot"></textarea>
+        <!-- The pasted image, shown back before it can be sent. A screenshot
+             the sender never saw is a screenshot they did not really choose. -->
+        <div id="fb-shot" hidden>
+          <img id="fb-shot-img" alt="">
+          <button type="button" id="fb-shot-clear" aria-label="Hapus">×</button>
+        </div>
         <div class="fb-row">
           <button type="button" id="fb-cancel">Batal</button>
           <button type="button" id="fb-send" disabled>Kirim</button>

--- a/gabung-pdf.html
+++ b/gabung-pdf.html
@@ -377,6 +377,20 @@
     .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
     .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
 
+    /* The pasted screenshot, shown back at a size you can actually check. */
+    #fb-shot { position: relative; margin: 10px 0 0; }
+    #fb-shot img {
+      display: block; width: 100%; max-height: 180px; object-fit: contain;
+      border: 1px solid var(--line); border-radius: 8px; background: var(--bg);
+    }
+    #fb-shot-clear {
+      position: absolute; top: 6px; right: 6px;
+      width: 28px; height: 28px; border-radius: 8px; line-height: 1;
+      display: grid; place-items: center; font-size: 17px;
+      background: var(--surface); color: var(--ink);
+      box-shadow: 0 1px 6px rgba(0,0,0,.22);
+    }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -2121,7 +2135,20 @@
             <span>Kurang</span>
           </button>
         </div>
-        <textarea id="fb-note" rows="3" placeholder="boleh minta feedbacknya di sini, supaya kita bisa improve terus pdflokal. (boleh dikosongin juga kok)"></textarea>
+        <!-- PASTE, NOT UPLOAD (his ruling 2026-09-09: "gausah ada tombolnya,
+             bilang aja diplaceholdernya"). No attach button anywhere, and
+             nothing here ever reaches into the editor for pixels — the only
+             image that can exist is one the user deliberately pasted. That is
+             the whole reason this is defensible against the product's own "no
+             uploads" claim, so a convenience button would not be a small
+             addition, it would remove the argument. -->
+        <textarea id="fb-note" rows="3" placeholder="tulis feedbacknya di sini, atau boleh paste screenshot"></textarea>
+        <!-- The pasted image, shown back before it can be sent. A screenshot
+             the sender never saw is a screenshot they did not really choose. -->
+        <div id="fb-shot" hidden>
+          <img id="fb-shot-img" alt="">
+          <button type="button" id="fb-shot-clear" aria-label="Hapus">×</button>
+        </div>
         <div class="fb-row">
           <button type="button" id="fb-cancel">Batal</button>
           <button type="button" id="fb-send" disabled>Kirim</button>

--- a/gabung-pdf.html
+++ b/gabung-pdf.html
@@ -287,6 +287,12 @@
          its own mode and page values must not be ported into it. A toolbar at
          --sp-48 is a toolbar that wastes the document's room. */
       --header-h: 44px; --toolbar-h: 52px;
+      /* THE HEIGHT EVERYTHING BELOW THE CHROME MEASURES AGAINST. It was
+         spelled `calc(var(--header-h) + var(--toolbar-h))` at each use site,
+         which stopped being true the moment the two could share a row. One
+         name, redefined once per breakpoint. */
+      --chrome-h: calc(var(--header-h) + var(--toolbar-h));
+      --header-merged-h: 52px;   /* the single-row height (tools are 36px + padding) */
     }
     /* Self-hosted fonts (preview parity with the PDF export) */
     @font-face { font-family: 'Montserrat'; src: url('fonts/montserrat-regular.woff2') format('woff2'); font-weight: 400; font-style: normal; font-display: swap; }
@@ -336,10 +342,17 @@
 
     /* ---- header ---- */
     header {
-      height: var(--header-h); flex: 0 0 auto;
+      min-height: var(--header-h); flex: 0 0 auto;
       display: flex; align-items: center; gap: 8px; padding: 0 10px;
-      background: var(--surface); border-bottom: 1px solid var(--line);
+      background: var(--surface);
+      /* WRAPS ON PURPOSE. Below the merge breakpoint the toolbar takes a full
+         row of its own; above it, everything stays on one line. No JS, no
+         second element, no duplicated tool buttons to keep in sync. */
+      flex-wrap: wrap;
     }
+    /* Narrow: the toolbar is a row of its own and carries the bottom edge, so
+       the header must NOT also draw one — two borders read as a seam. */
+    header > #toolbar { order: 9; flex: 1 0 100%; margin: 0 -10px; }
     .brand { font-weight: 700; font-size: 15px; letter-spacing: -.01em; }
     .brand-red { color: var(--accent); }
     /* home confirm: rides the standard dialog/.sheet system (the global
@@ -352,6 +365,18 @@
      * renders as a success. This system has one meaning for red and a second
      * colour meaning "good" is not being introduced here. */
     .fb-sheet { max-width: 380px; }
+    /* The byline under the question. Muted and small on purpose: it answers
+       "who am I writing to", it is not a place to go. The domain is the only
+       link, because it is the only one that leads anywhere useful. */
+    .fb-owner {
+      display: flex; align-items: center; gap: 9px;
+      margin: -2px 0 14px;
+    }
+    .fb-owner img { width: 28px; height: 28px; border-radius: 50%; object-fit: cover; flex: none; }
+    .fb-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
+    .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
+    .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -484,12 +509,73 @@
     }
     .tool.active { background: rgba(220,38,38,.08); color: var(--accent); }
 
+    /* ---- MERGED CHROME: one row when the width can hold it ---------------
+       His ruling 2026-09-09: "buat desktop, pindahin tools2nya ke atas. karena
+       spacenya kosong, cuma bikin dua baris navbar kalo spacenya ga cukup aja".
+       So the two-row layout is the FALLBACK, not the default.
+
+       ⚠️ THE BREAKPOINT IS MEASURED, NOT CHOSEN — 900px, 2026-09-09.
+       `.spacer { flex: 1 }` is the slack in this row, so its width IS the
+       headroom. Measured in Chromium: 152px of slack at 1000, 52 at 900, 12 at
+       860, and ZERO at 848. **848 is the true minimum**; 900 is that plus a
+       stated ~50px so the row never sits flush against its own ends, because a
+       row with no breathing room reads as broken even while it technically
+       fits. If a tool is added or a label reworded, RE-MEASURE — a stale
+       breakpoint shows up as a cramped row, never as an error.
+
+       ⚠️ AND THE GAUGE TOOK THREE TRIES, which is the part worth keeping.
+       Per-tool `scrollWidth` reported "fits" at every width down to 760, twice,
+       because the tools were not the element losing width. A third attempt
+       queried `#spacer` — it is a CLASS, so the query returned null and the
+       check passed on null. Only the fourth gauge, the spacer's own geometry
+       through a selector proven to match, showed a number that moved.
+       [[a-watcher-must-be-proven-to-fire]] is the sibling rule.
+
+       ⚠️ AND CHECK THE CEILING AT BOTH SIDES OF IT. design-discipline §2: a
+       band that holds three destinations at 1280 holds four at 375 without
+       anyone editing it. Here the count is unchanged either way — File, the
+       tool cluster (ONE destination, grouped), and Unduh (the one primary) —
+       which is the whole reason this merge is legitimate rather than a
+       fourth thing competing on one line. */
+    @media (min-width: 900px) {
+      :root { --chrome-h: var(--header-merged-h); }
+      header {
+        min-height: var(--header-merged-h); flex-wrap: nowrap;
+        border-bottom: 1px solid var(--line);
+      }
+      /* The flex spacer is what pushes Unduh right in the two-row layout. On
+         the merged row the TOOLBAR grows into that space instead and centres
+         its own children, so a second grower would fight it and shove the
+         tools off-centre. One grower per row. */
+      header > .spacer { display: none; }
+      header > #toolbar {
+        order: 3; flex: 1 1 auto; margin: 0;
+        height: auto; background: none; border-bottom: 0; padding: 0;
+        overflow: visible;
+      }
+      /* Undo/redo/Unduh sit AFTER the tools on the merged row. The markup has
+         the toolbar last (it was appended), so the order is stated here rather
+         than implied by the DOM. */
+      header > #btn-undo, header > #btn-redo, header > #btn-download { order: 5; }
+      /* Icon ABOVE label needs 52px of vertical room. On one shared row the
+         label moves BESIDE the icon — same target size, half the height. */
+      .tool {
+        flex-direction: row; gap: 6px;
+        min-width: 0; height: 36px; padding: 0 9px; font-size: 12.5px;
+      }
+      .tool svg { width: 17px; height: 17px; }
+      /* The BETA cap was corner-pinned so it could not widen a tight toolbar.
+         On the merged row there is room beside the word, and a corner chip on a
+         36px control overlaps its own label. */
+      .tool .beta-tag { position: static; margin-left: 1px; }
+    }
+
     /* ---- format bar: contextual, only when text is in play ---- */
     /* Contextual bars OVERLAY the canvas (founder: the document must never
        jump when a bar appears/disappears) — frosted so the page shows through. */
     #format-bar {
       display: none; align-items: center; gap: 6px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; height: 46px; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -623,61 +709,33 @@
        above was always claiming. The words survive as aria-label + title, so
        a screen reader and a desktop hover both still say "Kontak saya" — the
        label moved, it was not deleted. */
+    /* ⚠️ THE TAB SAYS WHAT IT DOES (2026-09-09, his ruling: "icon ini diganti
+       jadi kata2 aja ya 'ada masukan?'"). It was a chat glyph opening a panel
+       of five social handles; the handles are gone — "gaada yang peduli" — and
+       the glyph went with them, because an icon that has to be tapped to learn
+       its meaning fails his own element test (design-discipline §2).
+
+       AND THE PANEL IS GONE, NOT REPOINTED. Once the tab itself reads "Ada
+       masukan?", a panel whose only content was a button reading "Ada masukan?"
+       is a step that asks the same question twice. The tab opens #fb-form
+       directly. Whose product this is now lives INSIDE that dialog, where it
+       answers "who am I writing to" at the moment the question occurs.
+
+       The string is not new: it is the footer's, ratified 2026-08-22, and
+       reusing it keeps one name for one act (EXCLUDE 2 — copy is his). */
     #contact-tab-btn {
       position: fixed; left: 10px; bottom: 14px; z-index: 30;
-      width: 40px; height: 40px; border-radius: 12px;
-      display: grid; place-items: center;
+      min-height: 40px; padding: 0 14px; border-radius: 12px;
+      display: inline-flex; align-items: center;
       background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      color: var(--muted);
+      color: var(--muted); font-size: 13px; font-weight: 600;
     }
-    #contact-tab-btn svg { width: 19px; height: 19px; display: block; }
-    #contact-tab-panel {
-      position: fixed; left: 10px; bottom: 62px; z-index: 30;
-      width: max-content; max-width: min(78vw, 260px);
-      background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      border-radius: 12px; padding: 8px;
-      /* visibility (not just opacity): same reasoning as #support-card — a
-         dismissed panel must be GONE to hit-testing and screen readers. */
-      opacity: 0; visibility: hidden; pointer-events: none;
-      transform: translateY(10px); /* rests slightly low → reads as "slides up" on open */
-      transition: opacity .22s ease, transform .22s ease, visibility 0s linear .22s;
-    }
-    #contact-tab-panel.show {
-      opacity: 1; visibility: visible; pointer-events: auto;
-      transform: translateY(0); transition-delay: 0s;
-    }
-    /* One row per channel. min-height 40, not 44: this is a LIST inside an
-       already-opened panel, where rows are separated and mis-taps are cheap —
-       the 44 law guards isolated targets a finger hunts for, and the opening
-       tab is the one that has to meet it. Same reasoning text-runs.js records
-       for inflating a HIT box rather than a visual one. */
-    #contact-tab-panel a {
-      display: flex; align-items: center; gap: 10px;
-      min-height: 40px; padding: 0 10px; border-radius: 9px;
-      color: var(--ink); font-size: 13px; font-weight: 600; text-decoration: none;
-    }
-    #contact-tab-panel a:hover { background: var(--bg); }
-    /* The handle is the quiet half: the platform is what you scan for, the
-       handle is what you check once you have found it. */
-    #contact-tab-panel a b { font-weight: 600; }
-    #contact-tab-panel a span { color: var(--muted); font-weight: 500; margin-left: auto; }
-    #contact-tab-panel a svg { width: 16px; height: 16px; flex: none; color: var(--muted); }
-    /* The owner row. Deliberately NOT an <a> — it is not a sixth channel, it
-       is the answer to "whose handles are these". */
-    #contact-tab-panel .ct-owner {
-      display: flex; align-items: center; gap: 10px;
-      padding: 4px 10px 8px; margin-bottom: 4px;
-      border-bottom: 1px solid var(--line);
-    }
-    #contact-tab-panel .ct-owner img { width: 32px; height: 32px; border-radius: 50%; object-fit: cover; flex: none; }
-    #contact-tab-panel .ct-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
-    #contact-tab-panel .ct-owner span { display: block; font-size: 11px; color: var(--muted); font-weight: 500; margin-left: 0; }
-    @media (prefers-reduced-motion: reduce) { #contact-tab-panel { transition: none; } }
+    #contact-tab-btn:hover { color: var(--ink); }
 
     /* ---- the landing (= the editor's empty state; design: draf 3b) ---- */
     /* Editor chrome yields while the landing is up; it has its own header. */
     body.is-empty header, body.is-empty #toolbar, body.is-empty #zoom-ctl,
-    body.is-empty #contact-tab-btn, body.is-empty #contact-tab-panel { display: none; }
+    body.is-empty #contact-tab-btn { display: none; }
     #empty {
       position: absolute; inset: 0; overflow-y: auto; overscroll-behavior: contain;
       /* The PAGE ground is white (ruled 2026-07-29). The body underneath is
@@ -1322,7 +1380,7 @@
     /* signature context strip ("Semua Hal.") */
     #sig-bar {
       display: none; align-items: center; gap: 8px; height: 46px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -1604,8 +1662,16 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>
     </button>
     <button id="btn-download" disabled>Unduh</button>
-  </header>
-
+    <!-- ⚠️ THE TOOLBAR LIVES INSIDE <header> (2026-09-09, his ruling: "buat
+         desktop, pindahin tools2nya ke atas. karena spacenya kosong").
+         It is ONE element in TWO layouts, never two elements:
+           wide  → it sits on the header's own row, between File and Unduh
+           narrow→ header wraps and it takes its own row, exactly as before
+         A sibling cannot be pulled into a flex row by CSS, so the DOM move is
+         what makes the wide layout possible at all. Placement is by `order`,
+         so the markup order here is not the reading order — see the header
+         rules in the stylesheet, and --chrome-h, which is what everything
+         positioned BELOW the chrome measures against. -->
   <div id="toolbar" role="toolbar" aria-label="Alat">
     <!-- No "Pilih" button (founder ruling 2026-07-19): the neutral mode is a
          STATE, not a tool — nothing lit means nothing armed. Every armed tool
@@ -1635,6 +1701,8 @@
       Halaman
     </button>
   </div>
+  </header>
+
 
   <div id="format-bar" role="toolbar" aria-label="Format teks"></div>
   <div id="sig-bar" role="toolbar" aria-label="Aksi tanda tangan">
@@ -2000,44 +2068,20 @@
     <button id="z-in" aria-label="Perbesar">+</button>
     <button id="z-out" aria-label="Perkecil">−</button>
   </div>
-  <!-- Contact bookmark: quiet furniture tab, bottom-left, mirrors #zoom-ctl.
-       Two separate elements (button + panel), not one wrapper — see the CSS
-       comment for why.
+  <!-- The feedback tab: quiet furniture, bottom-left, mirrors #zoom-ctl.
+       It used to be a chat glyph opening a panel of five social handles. He
+       retired both on 2026-09-09 — "ilangin semua sosmed gue, gaada yang
+       peduli wkwk, ganti jadi feedback form aja" — so the tab now says what it
+       does and opens the general feedback dialog (#fb-form) directly.
 
-       ⚠️ THE HANDLES ARE NOT INVENTED HERE AND MUST NOT BE. They come from
-       `engine/wiki/machine/public-identity.md`, which is the machine's one
-       home for them, and each is verified against fkd/loker's own shipped
-       Kontak dialog. A handle typed from memory is a live link to someone
-       else's account. If a channel is missing from the wiki it is missing
-       here too — that is the design, not an oversight.
+       ⚠️ THE HANDLES ARE NOT COMMENTED OUT AND MUST NOT BE RESTORED FROM HERE.
+       They live in `engine/wiki/machine/public-identity.md`, which is the
+       machine's one home for them; a handle typed from memory is a live link
+       to someone else's account. This surface simply no longer carries them.
 
-       ⚠️ THREADS AND X CAME FROM HIM, NOT FROM THE MACHINE (2026-08-23). He
-       asked for "semua sosmed gue... threads x instagram, cari aja" — and
-       they were not there: not in the wiki page, not in loker's dialog, not
-       anywhere under ~/machine. The Instagram handle made threads/@ojan.lubis
-       a good guess and it turned out correct, which is exactly why it was not
-       shipped as one: a guessed handle that happens to resolve is a live link
-       to a stranger's account until someone confirms whose it is. He supplied
-       both, they are now in the wiki, and the wiki is what a future session
-       reads. -->
-  <button id="contact-tab-btn" aria-expanded="false" aria-controls="contact-tab-panel"
-          aria-label="Kontak saya" title="Kontak saya">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 11.5a8.4 8.4 0 0 1-9 8.4 9 9 0 0 1-3.9-.9L3 20.5l1.5-4.5a8.4 8.4 0 0 1-.9-3.9 8.4 8.4 0 0 1 8.4-9 8.4 8.4 0 0 1 9 8.4Z"/></svg>
-  </button>
-  <div id="contact-tab-panel">
-    <!-- WHO the channels belong to. Added 2026-08-27: this panel listed five
-         handles and never said whose they were. Not a destination — a label on
-         the list below it. -->
-    <div class="ct-owner">
-      <img src="images/ojan.jpg" alt="Foto Ojan" width="32" height="32" loading="lazy">
-      <div><b>Ojan</b><span>Fauzan Ahladzikri</span></div>
-    </div>
-    <a href="https://tiktok.com/@okeojan" target="_blank" rel="noopener"><b>TikTok</b><span>@okeojan</span></a>
-    <a href="https://instagram.com/ojan.lubis" target="_blank" rel="noopener"><b>Instagram</b><span>ojan.lubis</span></a>
-    <a href="https://www.threads.com/@ojan.lubis" target="_blank" rel="noopener"><b>Threads</b><span>ojan.lubis</span></a>
-    <a href="https://x.com/okeojan" target="_blank" rel="noopener"><b>X</b><span>@okeojan</span></a>
-    <a href="https://ojanlubis.id" target="_blank" rel="noopener"><b>Website</b><span>ojanlubis.id</span></a>
-  </div>
+       Wired by js/v2/feedback-form.js, alongside the footer's own link — one
+       dialog, one code path, two doors. -->
+  <button id="contact-tab-btn">Ada masukan?</button>
   <div id="toast" role="status" aria-live="polite"></div>
 
   <!-- The general feedback channel, opened from the footer's "Ada masukan?".
@@ -2056,6 +2100,17 @@
     <div class="sheet fb-sheet">
       <div class="fb-body">
         <h2>Gimana PDFLokal?</h2>
+        <!-- WHO IS ASKING. Moved here 2026-09-09 from the retired contact
+             panel, where it labelled a list of handles. It is a BYLINE, not a
+             destination: the dialog's one primary is Kirim, and an identity
+             block competing with it would be a second thing to decide about
+             (design-discipline §2 — the ceiling counts destinations). Small,
+             muted, directly under the question so it answers "who am I writing
+             to" exactly when that occurs to someone. -->
+        <div class="fb-owner">
+          <img src="images/ojan.jpg" alt="" width="28" height="28" loading="lazy">
+          <div><b>Ojan</b><a href="https://mesindev.com" target="_blank" rel="noopener">mesindev.com</a></div>
+        </div>
         <div class="fb-thumbs" role="group" aria-label="Penilaian">
           <button type="button" id="fb-up" aria-pressed="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/></svg>

--- a/hapus-halaman-pdf.html
+++ b/hapus-halaman-pdf.html
@@ -287,6 +287,12 @@
          its own mode and page values must not be ported into it. A toolbar at
          --sp-48 is a toolbar that wastes the document's room. */
       --header-h: 44px; --toolbar-h: 52px;
+      /* THE HEIGHT EVERYTHING BELOW THE CHROME MEASURES AGAINST. It was
+         spelled `calc(var(--header-h) + var(--toolbar-h))` at each use site,
+         which stopped being true the moment the two could share a row. One
+         name, redefined once per breakpoint. */
+      --chrome-h: calc(var(--header-h) + var(--toolbar-h));
+      --header-merged-h: 52px;   /* the single-row height (tools are 36px + padding) */
     }
     /* Self-hosted fonts (preview parity with the PDF export) */
     @font-face { font-family: 'Montserrat'; src: url('fonts/montserrat-regular.woff2') format('woff2'); font-weight: 400; font-style: normal; font-display: swap; }
@@ -336,10 +342,17 @@
 
     /* ---- header ---- */
     header {
-      height: var(--header-h); flex: 0 0 auto;
+      min-height: var(--header-h); flex: 0 0 auto;
       display: flex; align-items: center; gap: 8px; padding: 0 10px;
-      background: var(--surface); border-bottom: 1px solid var(--line);
+      background: var(--surface);
+      /* WRAPS ON PURPOSE. Below the merge breakpoint the toolbar takes a full
+         row of its own; above it, everything stays on one line. No JS, no
+         second element, no duplicated tool buttons to keep in sync. */
+      flex-wrap: wrap;
     }
+    /* Narrow: the toolbar is a row of its own and carries the bottom edge, so
+       the header must NOT also draw one — two borders read as a seam. */
+    header > #toolbar { order: 9; flex: 1 0 100%; margin: 0 -10px; }
     .brand { font-weight: 700; font-size: 15px; letter-spacing: -.01em; }
     .brand-red { color: var(--accent); }
     /* home confirm: rides the standard dialog/.sheet system (the global
@@ -352,6 +365,18 @@
      * renders as a success. This system has one meaning for red and a second
      * colour meaning "good" is not being introduced here. */
     .fb-sheet { max-width: 380px; }
+    /* The byline under the question. Muted and small on purpose: it answers
+       "who am I writing to", it is not a place to go. The domain is the only
+       link, because it is the only one that leads anywhere useful. */
+    .fb-owner {
+      display: flex; align-items: center; gap: 9px;
+      margin: -2px 0 14px;
+    }
+    .fb-owner img { width: 28px; height: 28px; border-radius: 50%; object-fit: cover; flex: none; }
+    .fb-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
+    .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
+    .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -484,12 +509,73 @@
     }
     .tool.active { background: rgba(220,38,38,.08); color: var(--accent); }
 
+    /* ---- MERGED CHROME: one row when the width can hold it ---------------
+       His ruling 2026-09-09: "buat desktop, pindahin tools2nya ke atas. karena
+       spacenya kosong, cuma bikin dua baris navbar kalo spacenya ga cukup aja".
+       So the two-row layout is the FALLBACK, not the default.
+
+       ⚠️ THE BREAKPOINT IS MEASURED, NOT CHOSEN — 900px, 2026-09-09.
+       `.spacer { flex: 1 }` is the slack in this row, so its width IS the
+       headroom. Measured in Chromium: 152px of slack at 1000, 52 at 900, 12 at
+       860, and ZERO at 848. **848 is the true minimum**; 900 is that plus a
+       stated ~50px so the row never sits flush against its own ends, because a
+       row with no breathing room reads as broken even while it technically
+       fits. If a tool is added or a label reworded, RE-MEASURE — a stale
+       breakpoint shows up as a cramped row, never as an error.
+
+       ⚠️ AND THE GAUGE TOOK THREE TRIES, which is the part worth keeping.
+       Per-tool `scrollWidth` reported "fits" at every width down to 760, twice,
+       because the tools were not the element losing width. A third attempt
+       queried `#spacer` — it is a CLASS, so the query returned null and the
+       check passed on null. Only the fourth gauge, the spacer's own geometry
+       through a selector proven to match, showed a number that moved.
+       [[a-watcher-must-be-proven-to-fire]] is the sibling rule.
+
+       ⚠️ AND CHECK THE CEILING AT BOTH SIDES OF IT. design-discipline §2: a
+       band that holds three destinations at 1280 holds four at 375 without
+       anyone editing it. Here the count is unchanged either way — File, the
+       tool cluster (ONE destination, grouped), and Unduh (the one primary) —
+       which is the whole reason this merge is legitimate rather than a
+       fourth thing competing on one line. */
+    @media (min-width: 900px) {
+      :root { --chrome-h: var(--header-merged-h); }
+      header {
+        min-height: var(--header-merged-h); flex-wrap: nowrap;
+        border-bottom: 1px solid var(--line);
+      }
+      /* The flex spacer is what pushes Unduh right in the two-row layout. On
+         the merged row the TOOLBAR grows into that space instead and centres
+         its own children, so a second grower would fight it and shove the
+         tools off-centre. One grower per row. */
+      header > .spacer { display: none; }
+      header > #toolbar {
+        order: 3; flex: 1 1 auto; margin: 0;
+        height: auto; background: none; border-bottom: 0; padding: 0;
+        overflow: visible;
+      }
+      /* Undo/redo/Unduh sit AFTER the tools on the merged row. The markup has
+         the toolbar last (it was appended), so the order is stated here rather
+         than implied by the DOM. */
+      header > #btn-undo, header > #btn-redo, header > #btn-download { order: 5; }
+      /* Icon ABOVE label needs 52px of vertical room. On one shared row the
+         label moves BESIDE the icon — same target size, half the height. */
+      .tool {
+        flex-direction: row; gap: 6px;
+        min-width: 0; height: 36px; padding: 0 9px; font-size: 12.5px;
+      }
+      .tool svg { width: 17px; height: 17px; }
+      /* The BETA cap was corner-pinned so it could not widen a tight toolbar.
+         On the merged row there is room beside the word, and a corner chip on a
+         36px control overlaps its own label. */
+      .tool .beta-tag { position: static; margin-left: 1px; }
+    }
+
     /* ---- format bar: contextual, only when text is in play ---- */
     /* Contextual bars OVERLAY the canvas (founder: the document must never
        jump when a bar appears/disappears) — frosted so the page shows through. */
     #format-bar {
       display: none; align-items: center; gap: 6px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; height: 46px; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -623,61 +709,33 @@
        above was always claiming. The words survive as aria-label + title, so
        a screen reader and a desktop hover both still say "Kontak saya" — the
        label moved, it was not deleted. */
+    /* ⚠️ THE TAB SAYS WHAT IT DOES (2026-09-09, his ruling: "icon ini diganti
+       jadi kata2 aja ya 'ada masukan?'"). It was a chat glyph opening a panel
+       of five social handles; the handles are gone — "gaada yang peduli" — and
+       the glyph went with them, because an icon that has to be tapped to learn
+       its meaning fails his own element test (design-discipline §2).
+
+       AND THE PANEL IS GONE, NOT REPOINTED. Once the tab itself reads "Ada
+       masukan?", a panel whose only content was a button reading "Ada masukan?"
+       is a step that asks the same question twice. The tab opens #fb-form
+       directly. Whose product this is now lives INSIDE that dialog, where it
+       answers "who am I writing to" at the moment the question occurs.
+
+       The string is not new: it is the footer's, ratified 2026-08-22, and
+       reusing it keeps one name for one act (EXCLUDE 2 — copy is his). */
     #contact-tab-btn {
       position: fixed; left: 10px; bottom: 14px; z-index: 30;
-      width: 40px; height: 40px; border-radius: 12px;
-      display: grid; place-items: center;
+      min-height: 40px; padding: 0 14px; border-radius: 12px;
+      display: inline-flex; align-items: center;
       background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      color: var(--muted);
+      color: var(--muted); font-size: 13px; font-weight: 600;
     }
-    #contact-tab-btn svg { width: 19px; height: 19px; display: block; }
-    #contact-tab-panel {
-      position: fixed; left: 10px; bottom: 62px; z-index: 30;
-      width: max-content; max-width: min(78vw, 260px);
-      background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      border-radius: 12px; padding: 8px;
-      /* visibility (not just opacity): same reasoning as #support-card — a
-         dismissed panel must be GONE to hit-testing and screen readers. */
-      opacity: 0; visibility: hidden; pointer-events: none;
-      transform: translateY(10px); /* rests slightly low → reads as "slides up" on open */
-      transition: opacity .22s ease, transform .22s ease, visibility 0s linear .22s;
-    }
-    #contact-tab-panel.show {
-      opacity: 1; visibility: visible; pointer-events: auto;
-      transform: translateY(0); transition-delay: 0s;
-    }
-    /* One row per channel. min-height 40, not 44: this is a LIST inside an
-       already-opened panel, where rows are separated and mis-taps are cheap —
-       the 44 law guards isolated targets a finger hunts for, and the opening
-       tab is the one that has to meet it. Same reasoning text-runs.js records
-       for inflating a HIT box rather than a visual one. */
-    #contact-tab-panel a {
-      display: flex; align-items: center; gap: 10px;
-      min-height: 40px; padding: 0 10px; border-radius: 9px;
-      color: var(--ink); font-size: 13px; font-weight: 600; text-decoration: none;
-    }
-    #contact-tab-panel a:hover { background: var(--bg); }
-    /* The handle is the quiet half: the platform is what you scan for, the
-       handle is what you check once you have found it. */
-    #contact-tab-panel a b { font-weight: 600; }
-    #contact-tab-panel a span { color: var(--muted); font-weight: 500; margin-left: auto; }
-    #contact-tab-panel a svg { width: 16px; height: 16px; flex: none; color: var(--muted); }
-    /* The owner row. Deliberately NOT an <a> — it is not a sixth channel, it
-       is the answer to "whose handles are these". */
-    #contact-tab-panel .ct-owner {
-      display: flex; align-items: center; gap: 10px;
-      padding: 4px 10px 8px; margin-bottom: 4px;
-      border-bottom: 1px solid var(--line);
-    }
-    #contact-tab-panel .ct-owner img { width: 32px; height: 32px; border-radius: 50%; object-fit: cover; flex: none; }
-    #contact-tab-panel .ct-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
-    #contact-tab-panel .ct-owner span { display: block; font-size: 11px; color: var(--muted); font-weight: 500; margin-left: 0; }
-    @media (prefers-reduced-motion: reduce) { #contact-tab-panel { transition: none; } }
+    #contact-tab-btn:hover { color: var(--ink); }
 
     /* ---- the landing (= the editor's empty state; design: draf 3b) ---- */
     /* Editor chrome yields while the landing is up; it has its own header. */
     body.is-empty header, body.is-empty #toolbar, body.is-empty #zoom-ctl,
-    body.is-empty #contact-tab-btn, body.is-empty #contact-tab-panel { display: none; }
+    body.is-empty #contact-tab-btn { display: none; }
     #empty {
       position: absolute; inset: 0; overflow-y: auto; overscroll-behavior: contain;
       /* The PAGE ground is white (ruled 2026-07-29). The body underneath is
@@ -1322,7 +1380,7 @@
     /* signature context strip ("Semua Hal.") */
     #sig-bar {
       display: none; align-items: center; gap: 8px; height: 46px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -1604,8 +1662,16 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>
     </button>
     <button id="btn-download" disabled>Unduh</button>
-  </header>
-
+    <!-- ⚠️ THE TOOLBAR LIVES INSIDE <header> (2026-09-09, his ruling: "buat
+         desktop, pindahin tools2nya ke atas. karena spacenya kosong").
+         It is ONE element in TWO layouts, never two elements:
+           wide  → it sits on the header's own row, between File and Unduh
+           narrow→ header wraps and it takes its own row, exactly as before
+         A sibling cannot be pulled into a flex row by CSS, so the DOM move is
+         what makes the wide layout possible at all. Placement is by `order`,
+         so the markup order here is not the reading order — see the header
+         rules in the stylesheet, and --chrome-h, which is what everything
+         positioned BELOW the chrome measures against. -->
   <div id="toolbar" role="toolbar" aria-label="Alat">
     <!-- No "Pilih" button (founder ruling 2026-07-19): the neutral mode is a
          STATE, not a tool — nothing lit means nothing armed. Every armed tool
@@ -1635,6 +1701,8 @@
       Halaman
     </button>
   </div>
+  </header>
+
 
   <div id="format-bar" role="toolbar" aria-label="Format teks"></div>
   <div id="sig-bar" role="toolbar" aria-label="Aksi tanda tangan">
@@ -1997,44 +2065,20 @@
     <button id="z-in" aria-label="Perbesar">+</button>
     <button id="z-out" aria-label="Perkecil">−</button>
   </div>
-  <!-- Contact bookmark: quiet furniture tab, bottom-left, mirrors #zoom-ctl.
-       Two separate elements (button + panel), not one wrapper — see the CSS
-       comment for why.
+  <!-- The feedback tab: quiet furniture, bottom-left, mirrors #zoom-ctl.
+       It used to be a chat glyph opening a panel of five social handles. He
+       retired both on 2026-09-09 — "ilangin semua sosmed gue, gaada yang
+       peduli wkwk, ganti jadi feedback form aja" — so the tab now says what it
+       does and opens the general feedback dialog (#fb-form) directly.
 
-       ⚠️ THE HANDLES ARE NOT INVENTED HERE AND MUST NOT BE. They come from
-       `engine/wiki/machine/public-identity.md`, which is the machine's one
-       home for them, and each is verified against fkd/loker's own shipped
-       Kontak dialog. A handle typed from memory is a live link to someone
-       else's account. If a channel is missing from the wiki it is missing
-       here too — that is the design, not an oversight.
+       ⚠️ THE HANDLES ARE NOT COMMENTED OUT AND MUST NOT BE RESTORED FROM HERE.
+       They live in `engine/wiki/machine/public-identity.md`, which is the
+       machine's one home for them; a handle typed from memory is a live link
+       to someone else's account. This surface simply no longer carries them.
 
-       ⚠️ THREADS AND X CAME FROM HIM, NOT FROM THE MACHINE (2026-08-23). He
-       asked for "semua sosmed gue... threads x instagram, cari aja" — and
-       they were not there: not in the wiki page, not in loker's dialog, not
-       anywhere under ~/machine. The Instagram handle made threads/@ojan.lubis
-       a good guess and it turned out correct, which is exactly why it was not
-       shipped as one: a guessed handle that happens to resolve is a live link
-       to a stranger's account until someone confirms whose it is. He supplied
-       both, they are now in the wiki, and the wiki is what a future session
-       reads. -->
-  <button id="contact-tab-btn" aria-expanded="false" aria-controls="contact-tab-panel"
-          aria-label="Kontak saya" title="Kontak saya">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 11.5a8.4 8.4 0 0 1-9 8.4 9 9 0 0 1-3.9-.9L3 20.5l1.5-4.5a8.4 8.4 0 0 1-.9-3.9 8.4 8.4 0 0 1 8.4-9 8.4 8.4 0 0 1 9 8.4Z"/></svg>
-  </button>
-  <div id="contact-tab-panel">
-    <!-- WHO the channels belong to. Added 2026-08-27: this panel listed five
-         handles and never said whose they were. Not a destination — a label on
-         the list below it. -->
-    <div class="ct-owner">
-      <img src="images/ojan.jpg" alt="Foto Ojan" width="32" height="32" loading="lazy">
-      <div><b>Ojan</b><span>Fauzan Ahladzikri</span></div>
-    </div>
-    <a href="https://tiktok.com/@okeojan" target="_blank" rel="noopener"><b>TikTok</b><span>@okeojan</span></a>
-    <a href="https://instagram.com/ojan.lubis" target="_blank" rel="noopener"><b>Instagram</b><span>ojan.lubis</span></a>
-    <a href="https://www.threads.com/@ojan.lubis" target="_blank" rel="noopener"><b>Threads</b><span>ojan.lubis</span></a>
-    <a href="https://x.com/okeojan" target="_blank" rel="noopener"><b>X</b><span>@okeojan</span></a>
-    <a href="https://ojanlubis.id" target="_blank" rel="noopener"><b>Website</b><span>ojanlubis.id</span></a>
-  </div>
+       Wired by js/v2/feedback-form.js, alongside the footer's own link — one
+       dialog, one code path, two doors. -->
+  <button id="contact-tab-btn">Ada masukan?</button>
   <div id="toast" role="status" aria-live="polite"></div>
 
   <!-- The general feedback channel, opened from the footer's "Ada masukan?".
@@ -2053,6 +2097,17 @@
     <div class="sheet fb-sheet">
       <div class="fb-body">
         <h2>Gimana PDFLokal?</h2>
+        <!-- WHO IS ASKING. Moved here 2026-09-09 from the retired contact
+             panel, where it labelled a list of handles. It is a BYLINE, not a
+             destination: the dialog's one primary is Kirim, and an identity
+             block competing with it would be a second thing to decide about
+             (design-discipline §2 — the ceiling counts destinations). Small,
+             muted, directly under the question so it answers "who am I writing
+             to" exactly when that occurs to someone. -->
+        <div class="fb-owner">
+          <img src="images/ojan.jpg" alt="" width="28" height="28" loading="lazy">
+          <div><b>Ojan</b><a href="https://mesindev.com" target="_blank" rel="noopener">mesindev.com</a></div>
+        </div>
         <div class="fb-thumbs" role="group" aria-label="Penilaian">
           <button type="button" id="fb-up" aria-pressed="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/></svg>

--- a/hapus-halaman-pdf.html
+++ b/hapus-halaman-pdf.html
@@ -377,6 +377,20 @@
     .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
     .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
 
+    /* The pasted screenshot, shown back at a size you can actually check. */
+    #fb-shot { position: relative; margin: 10px 0 0; }
+    #fb-shot img {
+      display: block; width: 100%; max-height: 180px; object-fit: contain;
+      border: 1px solid var(--line); border-radius: 8px; background: var(--bg);
+    }
+    #fb-shot-clear {
+      position: absolute; top: 6px; right: 6px;
+      width: 28px; height: 28px; border-radius: 8px; line-height: 1;
+      display: grid; place-items: center; font-size: 17px;
+      background: var(--surface); color: var(--ink);
+      box-shadow: 0 1px 6px rgba(0,0,0,.22);
+    }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -2118,7 +2132,20 @@
             <span>Kurang</span>
           </button>
         </div>
-        <textarea id="fb-note" rows="3" placeholder="boleh minta feedbacknya di sini, supaya kita bisa improve terus pdflokal. (boleh dikosongin juga kok)"></textarea>
+        <!-- PASTE, NOT UPLOAD (his ruling 2026-09-09: "gausah ada tombolnya,
+             bilang aja diplaceholdernya"). No attach button anywhere, and
+             nothing here ever reaches into the editor for pixels — the only
+             image that can exist is one the user deliberately pasted. That is
+             the whole reason this is defensible against the product's own "no
+             uploads" claim, so a convenience button would not be a small
+             addition, it would remove the argument. -->
+        <textarea id="fb-note" rows="3" placeholder="tulis feedbacknya di sini, atau boleh paste screenshot"></textarea>
+        <!-- The pasted image, shown back before it can be sent. A screenshot
+             the sender never saw is a screenshot they did not really choose. -->
+        <div id="fb-shot" hidden>
+          <img id="fb-shot-img" alt="">
+          <button type="button" id="fb-shot-clear" aria-label="Hapus">×</button>
+        </div>
         <div class="fb-row">
           <button type="button" id="fb-cancel">Batal</button>
           <button type="button" id="fb-send" disabled>Kirim</button>

--- a/index.html
+++ b/index.html
@@ -287,6 +287,12 @@
          its own mode and page values must not be ported into it. A toolbar at
          --sp-48 is a toolbar that wastes the document's room. */
       --header-h: 44px; --toolbar-h: 52px;
+      /* THE HEIGHT EVERYTHING BELOW THE CHROME MEASURES AGAINST. It was
+         spelled `calc(var(--header-h) + var(--toolbar-h))` at each use site,
+         which stopped being true the moment the two could share a row. One
+         name, redefined once per breakpoint. */
+      --chrome-h: calc(var(--header-h) + var(--toolbar-h));
+      --header-merged-h: 52px;   /* the single-row height (tools are 36px + padding) */
     }
     /* Self-hosted fonts (preview parity with the PDF export) */
     @font-face { font-family: 'Montserrat'; src: url('fonts/montserrat-regular.woff2') format('woff2'); font-weight: 400; font-style: normal; font-display: swap; }
@@ -336,10 +342,17 @@
 
     /* ---- header ---- */
     header {
-      height: var(--header-h); flex: 0 0 auto;
+      min-height: var(--header-h); flex: 0 0 auto;
       display: flex; align-items: center; gap: 8px; padding: 0 10px;
-      background: var(--surface); border-bottom: 1px solid var(--line);
+      background: var(--surface);
+      /* WRAPS ON PURPOSE. Below the merge breakpoint the toolbar takes a full
+         row of its own; above it, everything stays on one line. No JS, no
+         second element, no duplicated tool buttons to keep in sync. */
+      flex-wrap: wrap;
     }
+    /* Narrow: the toolbar is a row of its own and carries the bottom edge, so
+       the header must NOT also draw one — two borders read as a seam. */
+    header > #toolbar { order: 9; flex: 1 0 100%; margin: 0 -10px; }
     .brand { font-weight: 700; font-size: 15px; letter-spacing: -.01em; }
     .brand-red { color: var(--accent); }
     /* home confirm: rides the standard dialog/.sheet system (the global
@@ -352,6 +365,18 @@
      * renders as a success. This system has one meaning for red and a second
      * colour meaning "good" is not being introduced here. */
     .fb-sheet { max-width: 380px; }
+    /* The byline under the question. Muted and small on purpose: it answers
+       "who am I writing to", it is not a place to go. The domain is the only
+       link, because it is the only one that leads anywhere useful. */
+    .fb-owner {
+      display: flex; align-items: center; gap: 9px;
+      margin: -2px 0 14px;
+    }
+    .fb-owner img { width: 28px; height: 28px; border-radius: 50%; object-fit: cover; flex: none; }
+    .fb-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
+    .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
+    .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -484,12 +509,73 @@
     }
     .tool.active { background: rgba(220,38,38,.08); color: var(--accent); }
 
+    /* ---- MERGED CHROME: one row when the width can hold it ---------------
+       His ruling 2026-09-09: "buat desktop, pindahin tools2nya ke atas. karena
+       spacenya kosong, cuma bikin dua baris navbar kalo spacenya ga cukup aja".
+       So the two-row layout is the FALLBACK, not the default.
+
+       ⚠️ THE BREAKPOINT IS MEASURED, NOT CHOSEN — 900px, 2026-09-09.
+       `.spacer { flex: 1 }` is the slack in this row, so its width IS the
+       headroom. Measured in Chromium: 152px of slack at 1000, 52 at 900, 12 at
+       860, and ZERO at 848. **848 is the true minimum**; 900 is that plus a
+       stated ~50px so the row never sits flush against its own ends, because a
+       row with no breathing room reads as broken even while it technically
+       fits. If a tool is added or a label reworded, RE-MEASURE — a stale
+       breakpoint shows up as a cramped row, never as an error.
+
+       ⚠️ AND THE GAUGE TOOK THREE TRIES, which is the part worth keeping.
+       Per-tool `scrollWidth` reported "fits" at every width down to 760, twice,
+       because the tools were not the element losing width. A third attempt
+       queried `#spacer` — it is a CLASS, so the query returned null and the
+       check passed on null. Only the fourth gauge, the spacer's own geometry
+       through a selector proven to match, showed a number that moved.
+       [[a-watcher-must-be-proven-to-fire]] is the sibling rule.
+
+       ⚠️ AND CHECK THE CEILING AT BOTH SIDES OF IT. design-discipline §2: a
+       band that holds three destinations at 1280 holds four at 375 without
+       anyone editing it. Here the count is unchanged either way — File, the
+       tool cluster (ONE destination, grouped), and Unduh (the one primary) —
+       which is the whole reason this merge is legitimate rather than a
+       fourth thing competing on one line. */
+    @media (min-width: 900px) {
+      :root { --chrome-h: var(--header-merged-h); }
+      header {
+        min-height: var(--header-merged-h); flex-wrap: nowrap;
+        border-bottom: 1px solid var(--line);
+      }
+      /* The flex spacer is what pushes Unduh right in the two-row layout. On
+         the merged row the TOOLBAR grows into that space instead and centres
+         its own children, so a second grower would fight it and shove the
+         tools off-centre. One grower per row. */
+      header > .spacer { display: none; }
+      header > #toolbar {
+        order: 3; flex: 1 1 auto; margin: 0;
+        height: auto; background: none; border-bottom: 0; padding: 0;
+        overflow: visible;
+      }
+      /* Undo/redo/Unduh sit AFTER the tools on the merged row. The markup has
+         the toolbar last (it was appended), so the order is stated here rather
+         than implied by the DOM. */
+      header > #btn-undo, header > #btn-redo, header > #btn-download { order: 5; }
+      /* Icon ABOVE label needs 52px of vertical room. On one shared row the
+         label moves BESIDE the icon — same target size, half the height. */
+      .tool {
+        flex-direction: row; gap: 6px;
+        min-width: 0; height: 36px; padding: 0 9px; font-size: 12.5px;
+      }
+      .tool svg { width: 17px; height: 17px; }
+      /* The BETA cap was corner-pinned so it could not widen a tight toolbar.
+         On the merged row there is room beside the word, and a corner chip on a
+         36px control overlaps its own label. */
+      .tool .beta-tag { position: static; margin-left: 1px; }
+    }
+
     /* ---- format bar: contextual, only when text is in play ---- */
     /* Contextual bars OVERLAY the canvas (founder: the document must never
        jump when a bar appears/disappears) — frosted so the page shows through. */
     #format-bar {
       display: none; align-items: center; gap: 6px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; height: 46px; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -623,61 +709,33 @@
        above was always claiming. The words survive as aria-label + title, so
        a screen reader and a desktop hover both still say "Kontak saya" — the
        label moved, it was not deleted. */
+    /* ⚠️ THE TAB SAYS WHAT IT DOES (2026-09-09, his ruling: "icon ini diganti
+       jadi kata2 aja ya 'ada masukan?'"). It was a chat glyph opening a panel
+       of five social handles; the handles are gone — "gaada yang peduli" — and
+       the glyph went with them, because an icon that has to be tapped to learn
+       its meaning fails his own element test (design-discipline §2).
+
+       AND THE PANEL IS GONE, NOT REPOINTED. Once the tab itself reads "Ada
+       masukan?", a panel whose only content was a button reading "Ada masukan?"
+       is a step that asks the same question twice. The tab opens #fb-form
+       directly. Whose product this is now lives INSIDE that dialog, where it
+       answers "who am I writing to" at the moment the question occurs.
+
+       The string is not new: it is the footer's, ratified 2026-08-22, and
+       reusing it keeps one name for one act (EXCLUDE 2 — copy is his). */
     #contact-tab-btn {
       position: fixed; left: 10px; bottom: 14px; z-index: 30;
-      width: 40px; height: 40px; border-radius: 12px;
-      display: grid; place-items: center;
+      min-height: 40px; padding: 0 14px; border-radius: 12px;
+      display: inline-flex; align-items: center;
       background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      color: var(--muted);
+      color: var(--muted); font-size: 13px; font-weight: 600;
     }
-    #contact-tab-btn svg { width: 19px; height: 19px; display: block; }
-    #contact-tab-panel {
-      position: fixed; left: 10px; bottom: 62px; z-index: 30;
-      width: max-content; max-width: min(78vw, 260px);
-      background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      border-radius: 12px; padding: 8px;
-      /* visibility (not just opacity): same reasoning as #support-card — a
-         dismissed panel must be GONE to hit-testing and screen readers. */
-      opacity: 0; visibility: hidden; pointer-events: none;
-      transform: translateY(10px); /* rests slightly low → reads as "slides up" on open */
-      transition: opacity .22s ease, transform .22s ease, visibility 0s linear .22s;
-    }
-    #contact-tab-panel.show {
-      opacity: 1; visibility: visible; pointer-events: auto;
-      transform: translateY(0); transition-delay: 0s;
-    }
-    /* One row per channel. min-height 40, not 44: this is a LIST inside an
-       already-opened panel, where rows are separated and mis-taps are cheap —
-       the 44 law guards isolated targets a finger hunts for, and the opening
-       tab is the one that has to meet it. Same reasoning text-runs.js records
-       for inflating a HIT box rather than a visual one. */
-    #contact-tab-panel a {
-      display: flex; align-items: center; gap: 10px;
-      min-height: 40px; padding: 0 10px; border-radius: 9px;
-      color: var(--ink); font-size: 13px; font-weight: 600; text-decoration: none;
-    }
-    #contact-tab-panel a:hover { background: var(--bg); }
-    /* The handle is the quiet half: the platform is what you scan for, the
-       handle is what you check once you have found it. */
-    #contact-tab-panel a b { font-weight: 600; }
-    #contact-tab-panel a span { color: var(--muted); font-weight: 500; margin-left: auto; }
-    #contact-tab-panel a svg { width: 16px; height: 16px; flex: none; color: var(--muted); }
-    /* The owner row. Deliberately NOT an <a> — it is not a sixth channel, it
-       is the answer to "whose handles are these". */
-    #contact-tab-panel .ct-owner {
-      display: flex; align-items: center; gap: 10px;
-      padding: 4px 10px 8px; margin-bottom: 4px;
-      border-bottom: 1px solid var(--line);
-    }
-    #contact-tab-panel .ct-owner img { width: 32px; height: 32px; border-radius: 50%; object-fit: cover; flex: none; }
-    #contact-tab-panel .ct-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
-    #contact-tab-panel .ct-owner span { display: block; font-size: 11px; color: var(--muted); font-weight: 500; margin-left: 0; }
-    @media (prefers-reduced-motion: reduce) { #contact-tab-panel { transition: none; } }
+    #contact-tab-btn:hover { color: var(--ink); }
 
     /* ---- the landing (= the editor's empty state; design: draf 3b) ---- */
     /* Editor chrome yields while the landing is up; it has its own header. */
     body.is-empty header, body.is-empty #toolbar, body.is-empty #zoom-ctl,
-    body.is-empty #contact-tab-btn, body.is-empty #contact-tab-panel { display: none; }
+    body.is-empty #contact-tab-btn { display: none; }
     #empty {
       position: absolute; inset: 0; overflow-y: auto; overscroll-behavior: contain;
       /* The PAGE ground is white (ruled 2026-07-29). The body underneath is
@@ -1322,7 +1380,7 @@
     /* signature context strip ("Semua Hal.") */
     #sig-bar {
       display: none; align-items: center; gap: 8px; height: 46px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -1604,8 +1662,16 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>
     </button>
     <button id="btn-download" disabled>Unduh</button>
-  </header>
-
+    <!-- ⚠️ THE TOOLBAR LIVES INSIDE <header> (2026-09-09, his ruling: "buat
+         desktop, pindahin tools2nya ke atas. karena spacenya kosong").
+         It is ONE element in TWO layouts, never two elements:
+           wide  → it sits on the header's own row, between File and Unduh
+           narrow→ header wraps and it takes its own row, exactly as before
+         A sibling cannot be pulled into a flex row by CSS, so the DOM move is
+         what makes the wide layout possible at all. Placement is by `order`,
+         so the markup order here is not the reading order — see the header
+         rules in the stylesheet, and --chrome-h, which is what everything
+         positioned BELOW the chrome measures against. -->
   <div id="toolbar" role="toolbar" aria-label="Alat">
     <!-- No "Pilih" button (founder ruling 2026-07-19): the neutral mode is a
          STATE, not a tool — nothing lit means nothing armed. Every armed tool
@@ -1635,6 +1701,8 @@
       Halaman
     </button>
   </div>
+  </header>
+
 
   <div id="format-bar" role="toolbar" aria-label="Format teks"></div>
   <div id="sig-bar" role="toolbar" aria-label="Aksi tanda tangan">
@@ -1955,44 +2023,20 @@
     <button id="z-in" aria-label="Perbesar">+</button>
     <button id="z-out" aria-label="Perkecil">−</button>
   </div>
-  <!-- Contact bookmark: quiet furniture tab, bottom-left, mirrors #zoom-ctl.
-       Two separate elements (button + panel), not one wrapper — see the CSS
-       comment for why.
+  <!-- The feedback tab: quiet furniture, bottom-left, mirrors #zoom-ctl.
+       It used to be a chat glyph opening a panel of five social handles. He
+       retired both on 2026-09-09 — "ilangin semua sosmed gue, gaada yang
+       peduli wkwk, ganti jadi feedback form aja" — so the tab now says what it
+       does and opens the general feedback dialog (#fb-form) directly.
 
-       ⚠️ THE HANDLES ARE NOT INVENTED HERE AND MUST NOT BE. They come from
-       `engine/wiki/machine/public-identity.md`, which is the machine's one
-       home for them, and each is verified against fkd/loker's own shipped
-       Kontak dialog. A handle typed from memory is a live link to someone
-       else's account. If a channel is missing from the wiki it is missing
-       here too — that is the design, not an oversight.
+       ⚠️ THE HANDLES ARE NOT COMMENTED OUT AND MUST NOT BE RESTORED FROM HERE.
+       They live in `engine/wiki/machine/public-identity.md`, which is the
+       machine's one home for them; a handle typed from memory is a live link
+       to someone else's account. This surface simply no longer carries them.
 
-       ⚠️ THREADS AND X CAME FROM HIM, NOT FROM THE MACHINE (2026-08-23). He
-       asked for "semua sosmed gue... threads x instagram, cari aja" — and
-       they were not there: not in the wiki page, not in loker's dialog, not
-       anywhere under ~/machine. The Instagram handle made threads/@ojan.lubis
-       a good guess and it turned out correct, which is exactly why it was not
-       shipped as one: a guessed handle that happens to resolve is a live link
-       to a stranger's account until someone confirms whose it is. He supplied
-       both, they are now in the wiki, and the wiki is what a future session
-       reads. -->
-  <button id="contact-tab-btn" aria-expanded="false" aria-controls="contact-tab-panel"
-          aria-label="Kontak saya" title="Kontak saya">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 11.5a8.4 8.4 0 0 1-9 8.4 9 9 0 0 1-3.9-.9L3 20.5l1.5-4.5a8.4 8.4 0 0 1-.9-3.9 8.4 8.4 0 0 1 8.4-9 8.4 8.4 0 0 1 9 8.4Z"/></svg>
-  </button>
-  <div id="contact-tab-panel">
-    <!-- WHO the channels belong to. Added 2026-08-27: this panel listed five
-         handles and never said whose they were. Not a destination — a label on
-         the list below it. -->
-    <div class="ct-owner">
-      <img src="images/ojan.jpg" alt="Foto Ojan" width="32" height="32" loading="lazy">
-      <div><b>Ojan</b><span>Fauzan Ahladzikri</span></div>
-    </div>
-    <a href="https://tiktok.com/@okeojan" target="_blank" rel="noopener"><b>TikTok</b><span>@okeojan</span></a>
-    <a href="https://instagram.com/ojan.lubis" target="_blank" rel="noopener"><b>Instagram</b><span>ojan.lubis</span></a>
-    <a href="https://www.threads.com/@ojan.lubis" target="_blank" rel="noopener"><b>Threads</b><span>ojan.lubis</span></a>
-    <a href="https://x.com/okeojan" target="_blank" rel="noopener"><b>X</b><span>@okeojan</span></a>
-    <a href="https://ojanlubis.id" target="_blank" rel="noopener"><b>Website</b><span>ojanlubis.id</span></a>
-  </div>
+       Wired by js/v2/feedback-form.js, alongside the footer's own link — one
+       dialog, one code path, two doors. -->
+  <button id="contact-tab-btn">Ada masukan?</button>
   <div id="toast" role="status" aria-live="polite"></div>
 
   <!-- The general feedback channel, opened from the footer's "Ada masukan?".
@@ -2011,6 +2055,17 @@
     <div class="sheet fb-sheet">
       <div class="fb-body">
         <h2>Gimana PDFLokal?</h2>
+        <!-- WHO IS ASKING. Moved here 2026-09-09 from the retired contact
+             panel, where it labelled a list of handles. It is a BYLINE, not a
+             destination: the dialog's one primary is Kirim, and an identity
+             block competing with it would be a second thing to decide about
+             (design-discipline §2 — the ceiling counts destinations). Small,
+             muted, directly under the question so it answers "who am I writing
+             to" exactly when that occurs to someone. -->
+        <div class="fb-owner">
+          <img src="images/ojan.jpg" alt="" width="28" height="28" loading="lazy">
+          <div><b>Ojan</b><a href="https://mesindev.com" target="_blank" rel="noopener">mesindev.com</a></div>
+        </div>
         <div class="fb-thumbs" role="group" aria-label="Penilaian">
           <button type="button" id="fb-up" aria-pressed="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/></svg>

--- a/index.html
+++ b/index.html
@@ -377,6 +377,20 @@
     .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
     .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
 
+    /* The pasted screenshot, shown back at a size you can actually check. */
+    #fb-shot { position: relative; margin: 10px 0 0; }
+    #fb-shot img {
+      display: block; width: 100%; max-height: 180px; object-fit: contain;
+      border: 1px solid var(--line); border-radius: 8px; background: var(--bg);
+    }
+    #fb-shot-clear {
+      position: absolute; top: 6px; right: 6px;
+      width: 28px; height: 28px; border-radius: 8px; line-height: 1;
+      display: grid; place-items: center; font-size: 17px;
+      background: var(--surface); color: var(--ink);
+      box-shadow: 0 1px 6px rgba(0,0,0,.22);
+    }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -2076,7 +2090,20 @@
             <span>Kurang</span>
           </button>
         </div>
-        <textarea id="fb-note" rows="3" placeholder="boleh minta feedbacknya di sini, supaya kita bisa improve terus pdflokal. (boleh dikosongin juga kok)"></textarea>
+        <!-- PASTE, NOT UPLOAD (his ruling 2026-09-09: "gausah ada tombolnya,
+             bilang aja diplaceholdernya"). No attach button anywhere, and
+             nothing here ever reaches into the editor for pixels — the only
+             image that can exist is one the user deliberately pasted. That is
+             the whole reason this is defensible against the product's own "no
+             uploads" claim, so a convenience button would not be a small
+             addition, it would remove the argument. -->
+        <textarea id="fb-note" rows="3" placeholder="tulis feedbacknya di sini, atau boleh paste screenshot"></textarea>
+        <!-- The pasted image, shown back before it can be sent. A screenshot
+             the sender never saw is a screenshot they did not really choose. -->
+        <div id="fb-shot" hidden>
+          <img id="fb-shot-img" alt="">
+          <button type="button" id="fb-shot-clear" aria-label="Hapus">×</button>
+        </div>
         <div class="fb-row">
           <button type="button" id="fb-cancel">Batal</button>
           <button type="button" id="fb-send" disabled>Kirim</button>

--- a/jpg-ke-pdf.html
+++ b/jpg-ke-pdf.html
@@ -287,6 +287,12 @@
          its own mode and page values must not be ported into it. A toolbar at
          --sp-48 is a toolbar that wastes the document's room. */
       --header-h: 44px; --toolbar-h: 52px;
+      /* THE HEIGHT EVERYTHING BELOW THE CHROME MEASURES AGAINST. It was
+         spelled `calc(var(--header-h) + var(--toolbar-h))` at each use site,
+         which stopped being true the moment the two could share a row. One
+         name, redefined once per breakpoint. */
+      --chrome-h: calc(var(--header-h) + var(--toolbar-h));
+      --header-merged-h: 52px;   /* the single-row height (tools are 36px + padding) */
     }
     /* Self-hosted fonts (preview parity with the PDF export) */
     @font-face { font-family: 'Montserrat'; src: url('fonts/montserrat-regular.woff2') format('woff2'); font-weight: 400; font-style: normal; font-display: swap; }
@@ -336,10 +342,17 @@
 
     /* ---- header ---- */
     header {
-      height: var(--header-h); flex: 0 0 auto;
+      min-height: var(--header-h); flex: 0 0 auto;
       display: flex; align-items: center; gap: 8px; padding: 0 10px;
-      background: var(--surface); border-bottom: 1px solid var(--line);
+      background: var(--surface);
+      /* WRAPS ON PURPOSE. Below the merge breakpoint the toolbar takes a full
+         row of its own; above it, everything stays on one line. No JS, no
+         second element, no duplicated tool buttons to keep in sync. */
+      flex-wrap: wrap;
     }
+    /* Narrow: the toolbar is a row of its own and carries the bottom edge, so
+       the header must NOT also draw one — two borders read as a seam. */
+    header > #toolbar { order: 9; flex: 1 0 100%; margin: 0 -10px; }
     .brand { font-weight: 700; font-size: 15px; letter-spacing: -.01em; }
     .brand-red { color: var(--accent); }
     /* home confirm: rides the standard dialog/.sheet system (the global
@@ -352,6 +365,18 @@
      * renders as a success. This system has one meaning for red and a second
      * colour meaning "good" is not being introduced here. */
     .fb-sheet { max-width: 380px; }
+    /* The byline under the question. Muted and small on purpose: it answers
+       "who am I writing to", it is not a place to go. The domain is the only
+       link, because it is the only one that leads anywhere useful. */
+    .fb-owner {
+      display: flex; align-items: center; gap: 9px;
+      margin: -2px 0 14px;
+    }
+    .fb-owner img { width: 28px; height: 28px; border-radius: 50%; object-fit: cover; flex: none; }
+    .fb-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
+    .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
+    .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -484,12 +509,73 @@
     }
     .tool.active { background: rgba(220,38,38,.08); color: var(--accent); }
 
+    /* ---- MERGED CHROME: one row when the width can hold it ---------------
+       His ruling 2026-09-09: "buat desktop, pindahin tools2nya ke atas. karena
+       spacenya kosong, cuma bikin dua baris navbar kalo spacenya ga cukup aja".
+       So the two-row layout is the FALLBACK, not the default.
+
+       ⚠️ THE BREAKPOINT IS MEASURED, NOT CHOSEN — 900px, 2026-09-09.
+       `.spacer { flex: 1 }` is the slack in this row, so its width IS the
+       headroom. Measured in Chromium: 152px of slack at 1000, 52 at 900, 12 at
+       860, and ZERO at 848. **848 is the true minimum**; 900 is that plus a
+       stated ~50px so the row never sits flush against its own ends, because a
+       row with no breathing room reads as broken even while it technically
+       fits. If a tool is added or a label reworded, RE-MEASURE — a stale
+       breakpoint shows up as a cramped row, never as an error.
+
+       ⚠️ AND THE GAUGE TOOK THREE TRIES, which is the part worth keeping.
+       Per-tool `scrollWidth` reported "fits" at every width down to 760, twice,
+       because the tools were not the element losing width. A third attempt
+       queried `#spacer` — it is a CLASS, so the query returned null and the
+       check passed on null. Only the fourth gauge, the spacer's own geometry
+       through a selector proven to match, showed a number that moved.
+       [[a-watcher-must-be-proven-to-fire]] is the sibling rule.
+
+       ⚠️ AND CHECK THE CEILING AT BOTH SIDES OF IT. design-discipline §2: a
+       band that holds three destinations at 1280 holds four at 375 without
+       anyone editing it. Here the count is unchanged either way — File, the
+       tool cluster (ONE destination, grouped), and Unduh (the one primary) —
+       which is the whole reason this merge is legitimate rather than a
+       fourth thing competing on one line. */
+    @media (min-width: 900px) {
+      :root { --chrome-h: var(--header-merged-h); }
+      header {
+        min-height: var(--header-merged-h); flex-wrap: nowrap;
+        border-bottom: 1px solid var(--line);
+      }
+      /* The flex spacer is what pushes Unduh right in the two-row layout. On
+         the merged row the TOOLBAR grows into that space instead and centres
+         its own children, so a second grower would fight it and shove the
+         tools off-centre. One grower per row. */
+      header > .spacer { display: none; }
+      header > #toolbar {
+        order: 3; flex: 1 1 auto; margin: 0;
+        height: auto; background: none; border-bottom: 0; padding: 0;
+        overflow: visible;
+      }
+      /* Undo/redo/Unduh sit AFTER the tools on the merged row. The markup has
+         the toolbar last (it was appended), so the order is stated here rather
+         than implied by the DOM. */
+      header > #btn-undo, header > #btn-redo, header > #btn-download { order: 5; }
+      /* Icon ABOVE label needs 52px of vertical room. On one shared row the
+         label moves BESIDE the icon — same target size, half the height. */
+      .tool {
+        flex-direction: row; gap: 6px;
+        min-width: 0; height: 36px; padding: 0 9px; font-size: 12.5px;
+      }
+      .tool svg { width: 17px; height: 17px; }
+      /* The BETA cap was corner-pinned so it could not widen a tight toolbar.
+         On the merged row there is room beside the word, and a corner chip on a
+         36px control overlaps its own label. */
+      .tool .beta-tag { position: static; margin-left: 1px; }
+    }
+
     /* ---- format bar: contextual, only when text is in play ---- */
     /* Contextual bars OVERLAY the canvas (founder: the document must never
        jump when a bar appears/disappears) — frosted so the page shows through. */
     #format-bar {
       display: none; align-items: center; gap: 6px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; height: 46px; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -623,61 +709,33 @@
        above was always claiming. The words survive as aria-label + title, so
        a screen reader and a desktop hover both still say "Kontak saya" — the
        label moved, it was not deleted. */
+    /* ⚠️ THE TAB SAYS WHAT IT DOES (2026-09-09, his ruling: "icon ini diganti
+       jadi kata2 aja ya 'ada masukan?'"). It was a chat glyph opening a panel
+       of five social handles; the handles are gone — "gaada yang peduli" — and
+       the glyph went with them, because an icon that has to be tapped to learn
+       its meaning fails his own element test (design-discipline §2).
+
+       AND THE PANEL IS GONE, NOT REPOINTED. Once the tab itself reads "Ada
+       masukan?", a panel whose only content was a button reading "Ada masukan?"
+       is a step that asks the same question twice. The tab opens #fb-form
+       directly. Whose product this is now lives INSIDE that dialog, where it
+       answers "who am I writing to" at the moment the question occurs.
+
+       The string is not new: it is the footer's, ratified 2026-08-22, and
+       reusing it keeps one name for one act (EXCLUDE 2 — copy is his). */
     #contact-tab-btn {
       position: fixed; left: 10px; bottom: 14px; z-index: 30;
-      width: 40px; height: 40px; border-radius: 12px;
-      display: grid; place-items: center;
+      min-height: 40px; padding: 0 14px; border-radius: 12px;
+      display: inline-flex; align-items: center;
       background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      color: var(--muted);
+      color: var(--muted); font-size: 13px; font-weight: 600;
     }
-    #contact-tab-btn svg { width: 19px; height: 19px; display: block; }
-    #contact-tab-panel {
-      position: fixed; left: 10px; bottom: 62px; z-index: 30;
-      width: max-content; max-width: min(78vw, 260px);
-      background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      border-radius: 12px; padding: 8px;
-      /* visibility (not just opacity): same reasoning as #support-card — a
-         dismissed panel must be GONE to hit-testing and screen readers. */
-      opacity: 0; visibility: hidden; pointer-events: none;
-      transform: translateY(10px); /* rests slightly low → reads as "slides up" on open */
-      transition: opacity .22s ease, transform .22s ease, visibility 0s linear .22s;
-    }
-    #contact-tab-panel.show {
-      opacity: 1; visibility: visible; pointer-events: auto;
-      transform: translateY(0); transition-delay: 0s;
-    }
-    /* One row per channel. min-height 40, not 44: this is a LIST inside an
-       already-opened panel, where rows are separated and mis-taps are cheap —
-       the 44 law guards isolated targets a finger hunts for, and the opening
-       tab is the one that has to meet it. Same reasoning text-runs.js records
-       for inflating a HIT box rather than a visual one. */
-    #contact-tab-panel a {
-      display: flex; align-items: center; gap: 10px;
-      min-height: 40px; padding: 0 10px; border-radius: 9px;
-      color: var(--ink); font-size: 13px; font-weight: 600; text-decoration: none;
-    }
-    #contact-tab-panel a:hover { background: var(--bg); }
-    /* The handle is the quiet half: the platform is what you scan for, the
-       handle is what you check once you have found it. */
-    #contact-tab-panel a b { font-weight: 600; }
-    #contact-tab-panel a span { color: var(--muted); font-weight: 500; margin-left: auto; }
-    #contact-tab-panel a svg { width: 16px; height: 16px; flex: none; color: var(--muted); }
-    /* The owner row. Deliberately NOT an <a> — it is not a sixth channel, it
-       is the answer to "whose handles are these". */
-    #contact-tab-panel .ct-owner {
-      display: flex; align-items: center; gap: 10px;
-      padding: 4px 10px 8px; margin-bottom: 4px;
-      border-bottom: 1px solid var(--line);
-    }
-    #contact-tab-panel .ct-owner img { width: 32px; height: 32px; border-radius: 50%; object-fit: cover; flex: none; }
-    #contact-tab-panel .ct-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
-    #contact-tab-panel .ct-owner span { display: block; font-size: 11px; color: var(--muted); font-weight: 500; margin-left: 0; }
-    @media (prefers-reduced-motion: reduce) { #contact-tab-panel { transition: none; } }
+    #contact-tab-btn:hover { color: var(--ink); }
 
     /* ---- the landing (= the editor's empty state; design: draf 3b) ---- */
     /* Editor chrome yields while the landing is up; it has its own header. */
     body.is-empty header, body.is-empty #toolbar, body.is-empty #zoom-ctl,
-    body.is-empty #contact-tab-btn, body.is-empty #contact-tab-panel { display: none; }
+    body.is-empty #contact-tab-btn { display: none; }
     #empty {
       position: absolute; inset: 0; overflow-y: auto; overscroll-behavior: contain;
       /* The PAGE ground is white (ruled 2026-07-29). The body underneath is
@@ -1322,7 +1380,7 @@
     /* signature context strip ("Semua Hal.") */
     #sig-bar {
       display: none; align-items: center; gap: 8px; height: 46px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -1604,8 +1662,16 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>
     </button>
     <button id="btn-download" disabled>Unduh</button>
-  </header>
-
+    <!-- ⚠️ THE TOOLBAR LIVES INSIDE <header> (2026-09-09, his ruling: "buat
+         desktop, pindahin tools2nya ke atas. karena spacenya kosong").
+         It is ONE element in TWO layouts, never two elements:
+           wide  → it sits on the header's own row, between File and Unduh
+           narrow→ header wraps and it takes its own row, exactly as before
+         A sibling cannot be pulled into a flex row by CSS, so the DOM move is
+         what makes the wide layout possible at all. Placement is by `order`,
+         so the markup order here is not the reading order — see the header
+         rules in the stylesheet, and --chrome-h, which is what everything
+         positioned BELOW the chrome measures against. -->
   <div id="toolbar" role="toolbar" aria-label="Alat">
     <!-- No "Pilih" button (founder ruling 2026-07-19): the neutral mode is a
          STATE, not a tool — nothing lit means nothing armed. Every armed tool
@@ -1635,6 +1701,8 @@
       Halaman
     </button>
   </div>
+  </header>
+
 
   <div id="format-bar" role="toolbar" aria-label="Format teks"></div>
   <div id="sig-bar" role="toolbar" aria-label="Aksi tanda tangan">
@@ -1997,44 +2065,20 @@
     <button id="z-in" aria-label="Perbesar">+</button>
     <button id="z-out" aria-label="Perkecil">−</button>
   </div>
-  <!-- Contact bookmark: quiet furniture tab, bottom-left, mirrors #zoom-ctl.
-       Two separate elements (button + panel), not one wrapper — see the CSS
-       comment for why.
+  <!-- The feedback tab: quiet furniture, bottom-left, mirrors #zoom-ctl.
+       It used to be a chat glyph opening a panel of five social handles. He
+       retired both on 2026-09-09 — "ilangin semua sosmed gue, gaada yang
+       peduli wkwk, ganti jadi feedback form aja" — so the tab now says what it
+       does and opens the general feedback dialog (#fb-form) directly.
 
-       ⚠️ THE HANDLES ARE NOT INVENTED HERE AND MUST NOT BE. They come from
-       `engine/wiki/machine/public-identity.md`, which is the machine's one
-       home for them, and each is verified against fkd/loker's own shipped
-       Kontak dialog. A handle typed from memory is a live link to someone
-       else's account. If a channel is missing from the wiki it is missing
-       here too — that is the design, not an oversight.
+       ⚠️ THE HANDLES ARE NOT COMMENTED OUT AND MUST NOT BE RESTORED FROM HERE.
+       They live in `engine/wiki/machine/public-identity.md`, which is the
+       machine's one home for them; a handle typed from memory is a live link
+       to someone else's account. This surface simply no longer carries them.
 
-       ⚠️ THREADS AND X CAME FROM HIM, NOT FROM THE MACHINE (2026-08-23). He
-       asked for "semua sosmed gue... threads x instagram, cari aja" — and
-       they were not there: not in the wiki page, not in loker's dialog, not
-       anywhere under ~/machine. The Instagram handle made threads/@ojan.lubis
-       a good guess and it turned out correct, which is exactly why it was not
-       shipped as one: a guessed handle that happens to resolve is a live link
-       to a stranger's account until someone confirms whose it is. He supplied
-       both, they are now in the wiki, and the wiki is what a future session
-       reads. -->
-  <button id="contact-tab-btn" aria-expanded="false" aria-controls="contact-tab-panel"
-          aria-label="Kontak saya" title="Kontak saya">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 11.5a8.4 8.4 0 0 1-9 8.4 9 9 0 0 1-3.9-.9L3 20.5l1.5-4.5a8.4 8.4 0 0 1-.9-3.9 8.4 8.4 0 0 1 8.4-9 8.4 8.4 0 0 1 9 8.4Z"/></svg>
-  </button>
-  <div id="contact-tab-panel">
-    <!-- WHO the channels belong to. Added 2026-08-27: this panel listed five
-         handles and never said whose they were. Not a destination — a label on
-         the list below it. -->
-    <div class="ct-owner">
-      <img src="images/ojan.jpg" alt="Foto Ojan" width="32" height="32" loading="lazy">
-      <div><b>Ojan</b><span>Fauzan Ahladzikri</span></div>
-    </div>
-    <a href="https://tiktok.com/@okeojan" target="_blank" rel="noopener"><b>TikTok</b><span>@okeojan</span></a>
-    <a href="https://instagram.com/ojan.lubis" target="_blank" rel="noopener"><b>Instagram</b><span>ojan.lubis</span></a>
-    <a href="https://www.threads.com/@ojan.lubis" target="_blank" rel="noopener"><b>Threads</b><span>ojan.lubis</span></a>
-    <a href="https://x.com/okeojan" target="_blank" rel="noopener"><b>X</b><span>@okeojan</span></a>
-    <a href="https://ojanlubis.id" target="_blank" rel="noopener"><b>Website</b><span>ojanlubis.id</span></a>
-  </div>
+       Wired by js/v2/feedback-form.js, alongside the footer's own link — one
+       dialog, one code path, two doors. -->
+  <button id="contact-tab-btn">Ada masukan?</button>
   <div id="toast" role="status" aria-live="polite"></div>
 
   <!-- The general feedback channel, opened from the footer's "Ada masukan?".
@@ -2053,6 +2097,17 @@
     <div class="sheet fb-sheet">
       <div class="fb-body">
         <h2>Gimana PDFLokal?</h2>
+        <!-- WHO IS ASKING. Moved here 2026-09-09 from the retired contact
+             panel, where it labelled a list of handles. It is a BYLINE, not a
+             destination: the dialog's one primary is Kirim, and an identity
+             block competing with it would be a second thing to decide about
+             (design-discipline §2 — the ceiling counts destinations). Small,
+             muted, directly under the question so it answers "who am I writing
+             to" exactly when that occurs to someone. -->
+        <div class="fb-owner">
+          <img src="images/ojan.jpg" alt="" width="28" height="28" loading="lazy">
+          <div><b>Ojan</b><a href="https://mesindev.com" target="_blank" rel="noopener">mesindev.com</a></div>
+        </div>
         <div class="fb-thumbs" role="group" aria-label="Penilaian">
           <button type="button" id="fb-up" aria-pressed="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/></svg>

--- a/jpg-ke-pdf.html
+++ b/jpg-ke-pdf.html
@@ -377,6 +377,20 @@
     .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
     .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
 
+    /* The pasted screenshot, shown back at a size you can actually check. */
+    #fb-shot { position: relative; margin: 10px 0 0; }
+    #fb-shot img {
+      display: block; width: 100%; max-height: 180px; object-fit: contain;
+      border: 1px solid var(--line); border-radius: 8px; background: var(--bg);
+    }
+    #fb-shot-clear {
+      position: absolute; top: 6px; right: 6px;
+      width: 28px; height: 28px; border-radius: 8px; line-height: 1;
+      display: grid; place-items: center; font-size: 17px;
+      background: var(--surface); color: var(--ink);
+      box-shadow: 0 1px 6px rgba(0,0,0,.22);
+    }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -2118,7 +2132,20 @@
             <span>Kurang</span>
           </button>
         </div>
-        <textarea id="fb-note" rows="3" placeholder="boleh minta feedbacknya di sini, supaya kita bisa improve terus pdflokal. (boleh dikosongin juga kok)"></textarea>
+        <!-- PASTE, NOT UPLOAD (his ruling 2026-09-09: "gausah ada tombolnya,
+             bilang aja diplaceholdernya"). No attach button anywhere, and
+             nothing here ever reaches into the editor for pixels — the only
+             image that can exist is one the user deliberately pasted. That is
+             the whole reason this is defensible against the product's own "no
+             uploads" claim, so a convenience button would not be a small
+             addition, it would remove the argument. -->
+        <textarea id="fb-note" rows="3" placeholder="tulis feedbacknya di sini, atau boleh paste screenshot"></textarea>
+        <!-- The pasted image, shown back before it can be sent. A screenshot
+             the sender never saw is a screenshot they did not really choose. -->
+        <div id="fb-shot" hidden>
+          <img id="fb-shot-img" alt="">
+          <button type="button" id="fb-shot-clear" aria-label="Hapus">×</button>
+        </div>
         <div class="fb-row">
           <button type="button" id="fb-cancel">Batal</button>
           <button type="button" id="fb-send" disabled>Kirim</button>

--- a/js/core/feedback-shot.js
+++ b/js/core/feedback-shot.js
@@ -1,0 +1,67 @@
+/*
+ * PDFLokal — core/feedback-shot.js  (the PASTED screenshot on general feedback)
+ * ============================================================================
+ * Pure validation for the one image a user may attach to the general feedback
+ * form by PASTING it. No DOM, no canvas, no vendor — the browser half (decode,
+ * downscale, encode) lives in js/v2/feedback-form.js, same core/adapter split
+ * as everywhere else here.
+ *
+ * ⚠️ WHY THIS IS NOT core/feedback-sample.js, and it must not be merged into it.
+ * That module validates the edit-beta's BEFORE/AFTER crop pair: a matched pair,
+ * PNG only, 40KB each, produced by our own code from a line the user edited.
+ * This is one JPEG the user chose, of whatever they chose, at a size we
+ * re-encode. Two different objects with two different invariants. Merging them
+ * would mean one validator whose rules are the union of both — which is another
+ * way of saying neither is enforced. feedback-form.js's own header already
+ * refuses to share a state machine with edit-feedback.js for the same reason.
+ *
+ * ⚠️ AND WHY IT IS THE USER'S CHOICE, EVERY TIME. The product's claim is that a
+ * document never leaves the device. A pasted screenshot is the one exception,
+ * and it is only defensible because the user performs it deliberately: there is
+ * no upload button, no "attach the current page" convenience, and nothing here
+ * ever reaches into the editor for pixels. If a future change makes an image
+ * arrive without an explicit paste, this file's reason for existing is gone.
+ *
+ * JPEG, not PNG: a screenshot is a photograph of a screen, and PNG of one is
+ * several megabytes. The crop pair upstream is PNG because it is small, flat,
+ * and its pixels are compared.
+ */
+
+export const SHOT_DATA_URL_PREFIX = 'data:image/jpeg;base64,';
+
+// The long edge we re-encode to. A screenshot is read, not inspected — 1000px
+// is enough to see which control is wrong and cheap enough to store.
+export const SHOT_MAX_DIM = 1000;
+
+// Decoded ceiling for the stored image. Deliberately generous next to the crop
+// pair's 40KB (a full screen carries far more than one edited line) and still
+// bounded, because these rows sit in the same Neon free tier the rail does.
+export const SHOT_MAX_BYTES = 200 * 1024;
+
+const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
+
+// Decoded byte length of a `data:image/jpeg;base64,...` payload, without
+// allocating it. Returns Infinity for anything malformed, so every caller's
+// size comparison fails closed rather than passing on a NaN.
+export function shotBytes(dataUrl) {
+  if (typeof dataUrl !== 'string' || !dataUrl.startsWith(SHOT_DATA_URL_PREFIX)) return Infinity;
+  const b64 = dataUrl.slice(SHOT_DATA_URL_PREFIX.length);
+  if (b64.length === 0 || b64.length % 4 !== 0 || !BASE64_RE.test(b64)) return Infinity;
+  const padding = b64.endsWith('==') ? 2 : b64.endsWith('=') ? 1 : 0;
+  return Math.floor((b64.length * 3) / 4) - padding;
+}
+
+/**
+ * The single gate a screenshot passes before it can be sent or stored.
+ * Returns the data URL unchanged, or null — never a repaired value. A caller
+ * that gets null drops the image and sends the rating and note alone, exactly
+ * as a feedback with no screenshot has always behaved.
+ *
+ * @param {string|null|undefined} dataUrl
+ * @returns {string|null}
+ */
+export function validateShot(dataUrl) {
+  const bytes = shotBytes(dataUrl);
+  if (!(bytes > 0) || bytes > SHOT_MAX_BYTES) return null;
+  return dataUrl;
+}

--- a/js/v2/app.js
+++ b/js/v2/app.js
@@ -299,24 +299,12 @@ on('z-out', 'click', () => { zoom = Math.max(zoom - 0.25, 0.3); applyZoom(); });
 // Fixing it in one module and re-introducing it in a sibling, in one sitting, is
 // why the rule is structural and not a reminder: A TOP-LEVEL LOOKUP OF AN
 // INDEX-ONLY ELEMENT IS ALWAYS GUARDED.
-const contactTabBtn = document.getElementById('contact-tab-btn');
-const contactTabPanel = document.getElementById('contact-tab-panel');
-if (contactTabBtn && contactTabPanel) {
-  const toggleContactTab = (show) => {
-    contactTabPanel.classList.toggle('show', show);
-    contactTabBtn.setAttribute('aria-expanded', String(show));
-  };
-  contactTabBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    toggleContactTab(!contactTabPanel.classList.contains('show'));
-  });
-  document.addEventListener('pointerdown', (e) => {
-    if (contactTabPanel.classList.contains('show') &&
-        !e.target.closest('#contact-tab-btn, #contact-tab-panel')) {
-      toggleContactTab(false);
-    }
-  });
-}
+// ⚠️ THE CONTACT TAB'S WIRING LIVES IN js/v2/feedback-form.js NOW (2026-09-09).
+// It used to toggle a panel of social handles from here. He retired the handles
+// and the panel with them; the tab opens the feedback dialog, so its listener
+// belongs beside the dialog it opens rather than in app.js's top-level block.
+// The guarded-lookup rule that this block used to demonstrate still stands and
+// is demonstrated by every on() call above it.
 
 // ---- camera: pinch-zoom + pan (the Google-Maps feel, founder ask) ----------------
 // One-finger pan = NATIVE container scroll (overflow auto on both axes — free,

--- a/js/v2/feedback-form.js
+++ b/js/v2/feedback-form.js
@@ -11,18 +11,33 @@
  *
  * ⚠️ WHY THIS IS A SEPARATE MODULE AND NOT A SECOND ENTRY POINT INTO
  * edit-feedback.js — read this before "simplifying" the two together.
- * edit-feedback.js carries the consent-gated image path: it can attach
- * before/after crops of an edited line, under privacy invariants its own header
- * calls non-negotiable. The seat's decisions.md names content-blindness as the
- * ONE failure class that cannot be walked back: a document string that leaves a
- * device is out, permanently. Adding a second door into that module is exactly
- * how a sample ends up on a path nobody audited — not because someone decided
- * to send content, but because two callers shared a state machine that only one
- * of them was reasoned about.
+ * edit-feedback.js carries the consent-gated crop path: it attaches before/after
+ * crops of an edited line, produced by OUR code from the user's document, under
+ * privacy invariants its own header calls non-negotiable. Adding a second door
+ * into that module is how a sample ends up on a path nobody audited — not
+ * because someone decided to send content, but because two callers shared a
+ * state machine that only one of them was reasoned about. That still stands:
+ * this module never passes a `sample`, and never will.
  *
- * So: this module NEVER passes a sample argument. It calls feedback(rating,
- * note) with two arguments, always. There is no code path here that can reach
- * an image, because there is no code here that knows images exist.
+ * ⚠️ THE OLD INVARIANT HERE WAS "no code path can reach an image, because there
+ * is no code here that knows images exist." HE RETIRED IT ON 2026-09-09 — the
+ * form now accepts ONE PASTED SCREENSHOT. It is written out rather than quietly
+ * deleted, because the replacement is narrower than it looks and the difference
+ * is the whole defence:
+ *
+ *   THE ONLY IMAGE THAT CAN EXIST HERE IS ONE THE USER PASTED, DELIBERATELY,
+ *   INTO THIS TEXTAREA. Nothing in this module reads the editor, the canvas,
+ *   the document, or the clipboard unprompted. There is no attach button by his
+ *   own ruling ("gausah ada tombolnya"), and there must never be an "attach the
+ *   current page" convenience — that would turn a deliberate act into a default
+ *   and take the product's "no uploads" claim with it.
+ *
+ * The paste is shown BACK before it can be sent (#fb-shot), because a
+ * screenshot the sender never saw is a screenshot they did not really choose.
+ * Validation is core/feedback-shot.js — its own module, deliberately not
+ * core/feedback-sample.js: a matched PNG crop pair at 40KB and one user-chosen
+ * JPEG at 200KB are different objects, and one validator holding the union of
+ * both rules enforces neither.
  *
  * ONE SCREEN, per ojan-ui-taste ("one viewport = one reading + one action"):
  * the rating and the note are shown together, not as two steps. The user got
@@ -38,11 +53,15 @@
  * are his. Any change to a user-visible word here needs him again.
  */
 import { feedback } from './telemetry.js';
+import { SHOT_MAX_DIM, SHOT_DATA_URL_PREFIX, validateShot } from '../core/feedback-shot.js';
 
 const NOTE_MAX = 500;
 
 let dlg = null;
 let rating = null;
+let shot = null;        // the pasted screenshot, as a validated data URL
+let shotEl = null;
+let shotImg = null;
 let noteEl = null;
 let sendEl = null;
 let thumbUp = null;
@@ -58,9 +77,20 @@ function setRating(next) {
   if (sendEl) sendEl.disabled = !next;
 }
 
+function clearShot() {
+  shot = null;
+  if (shotImg) shotImg.removeAttribute('src');
+  if (shotEl) shotEl.hidden = true;
+}
+
 function reset() {
   rating = null;
   if (noteEl) noteEl.value = '';
+  // THE IMAGE IS CLEARED ON EVERY OPEN, not only on send. A screenshot pasted,
+  // then dismissed with Batal, must not be sitting there attached the next time
+  // the dialog opens — the user would be re-consenting to something they had
+  // already backed out of, without being asked again.
+  clearShot();
   setRating(null);
   const body = dlg && dlg.querySelector('.fb-body');
   const done = dlg && dlg.querySelector('.fb-done');
@@ -68,10 +98,58 @@ function reset() {
   if (done) done.hidden = true;
 }
 
+// A pasted image → a small JPEG data URL, or null. Never throws: a paste that
+// cannot be decoded is simply not an attachment, and the note still sends.
+//
+// RE-ENCODED, ALWAYS, EVEN WHEN THE ORIGINAL WOULD FIT. Two reasons and both
+// matter: a screenshot pasted from a phone is often several megapixels, and a
+// canvas round-trip DROPS EVERY METADATA BLOCK the source carried — EXIF,
+// timestamps, and on some platforms the GPS a screenshot tool wrote in. We are
+// asking for a picture of our own UI, not for where the user was standing.
+async function toShot(blob) {
+  try {
+    const bitmap = await window.createImageBitmap(blob);
+    const scale = Math.min(1, SHOT_MAX_DIM / Math.max(bitmap.width, bitmap.height));
+    const w = Math.max(1, Math.round(bitmap.width * scale));
+    const h = Math.max(1, Math.round(bitmap.height * scale));
+    const canvas = document.createElement('canvas');
+    canvas.width = w; canvas.height = h;
+    canvas.getContext('2d').drawImage(bitmap, 0, 0, w, h);
+    bitmap.close?.();
+    // One retry at a lower quality, then give up. A loop chasing the cap would
+    // spend a phone's battery on an attachment nobody promised to send.
+    for (const q of [0.65, 0.45]) {
+      const url = canvas.toDataURL('image/jpeg', q);
+      if (url.startsWith(SHOT_DATA_URL_PREFIX) && validateShot(url)) return url;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function onPaste(e) {
+  const items = [...(e.clipboardData?.items || [])];
+  const item = items.find((i) => i.kind === 'file' && i.type.startsWith('image/'));
+  if (!item) return;                          // pasting TEXT stays ordinary paste
+  const blob = item.getAsFile();
+  if (!blob) return;
+  e.preventDefault();                         // stop the browser dropping a filename in the note
+  toShot(blob).then((url) => {
+    if (!url) return;                         // too big even at 0.45, or undecodable — silently no attachment
+    shot = url;
+    if (shotImg) shotImg.src = url;
+    if (shotEl) shotEl.hidden = false;
+  });
+}
+
 function send() {
   if (!rating) return;                       // guard: the button is disabled, but never trust the view
   const note = noteEl ? noteEl.value : '';
-  feedback(rating, note);                    // TWO ARGUMENTS. Never a third. See the header.
+  // `sample` is ALWAYS null from here — the crop pair belongs to
+  // edit-feedback.js and this module has never owned one. `shot` is the pasted
+  // screenshot, and it is the only image this file can produce.
+  feedback(rating, note, null, shot);
   const body = dlg.querySelector('.fb-body');
   const done = dlg.querySelector('.fb-done');
   if (body) body.hidden = true;
@@ -114,6 +192,12 @@ export function initFeedbackForm() {
   if (cancel) cancel.addEventListener('click', () => dlg.close());
 
   if (noteEl) noteEl.setAttribute('maxlength', String(NOTE_MAX));
+
+  shotEl = dlg.querySelector('#fb-shot');
+  shotImg = dlg.querySelector('#fb-shot-img');
+  const shotClear = dlg.querySelector('#fb-shot-clear');
+  if (noteEl) noteEl.addEventListener('paste', onPaste);
+  if (shotClear) shotClear.addEventListener('click', clearShot);
 
   // Clicking the backdrop closes. The global `dialog` rule IS the overlay, so
   // the backdrop is the dialog element itself and anything inside .sheet is a

--- a/js/v2/feedback-form.js
+++ b/js/v2/feedback-form.js
@@ -84,6 +84,12 @@ function send() {
 export function initFeedbackForm() {
   dlg = document.getElementById('fb-form');
   const open = document.getElementById('fb-open');
+  // TWO DOORS, ONE DIALOG (2026-09-09). The footer link and the floating tab
+  // both land here. Deliberately not two implementations: the tab was wired in
+  // app.js while it opened its own panel, and leaving it there would have meant
+  // two modules owning one surface — the exact shape this file's own header
+  // warns about for the image path.
+  const tab = document.getElementById('contact-tab-btn');
   if (!dlg || !open) return;                 // SEO pages that drop the footer simply have no channel
 
   noteEl = dlg.querySelector('#fb-note');
@@ -96,6 +102,9 @@ export function initFeedbackForm() {
     reset();
     dlg.showModal();
   });
+  // Same act, same dialog, same telemetry — so the tab reuses the link's own
+  // handler rather than getting a parallel one that can drift from it.
+  if (tab) tab.addEventListener('click', (e) => { e.preventDefault(); open.click(); });
 
   if (thumbUp) thumbUp.addEventListener('click', () => setRating('up'));
   if (thumbDown) thumbDown.addEventListener('click', () => setRating('down'));

--- a/js/v2/telemetry.js
+++ b/js/v2/telemetry.js
@@ -18,6 +18,7 @@
  */
 import { validateEvent } from '../core/telemetry-schema.js';
 import { validateSample } from '../core/feedback-sample.js';
+import { validateShot } from '../core/feedback-shot.js';
 
 const ENDPOINT = '/api/t';
 const FLUSH_AT = 10;
@@ -246,8 +247,14 @@ const FEEDBACK_NOTE_MAX = 1000;
  * @param {string} [note] user-typed, capped, optional
  * @param {{before: string, after: string}} [sample] two PNG data URLs — only
  *   ever passed when the user saw them rendered in the pill and tapped Kirim.
+ * @param {string} [shot] ONE JPEG data URL, and only ever a screenshot the user
+ *   PASTED into the general feedback form themselves (js/v2/feedback-form.js).
+ *   A FOURTH POSITIONAL ARGUMENT ON PURPOSE, rather than widening `sample`:
+ *   the two images have different producers, different validators and different
+ *   consent stories, and the day they share a parameter is the day a crop can
+ *   arrive on the screenshot's path without anyone choosing it.
  */
-export function feedback(rating, note, sample) {
+export function feedback(rating, note, sample, shot) {
   try {
     if (rating !== 'up' && rating !== 'down') return;
     const payload = { session_id: sessionId, app_version: appVersion, rating };
@@ -259,8 +266,12 @@ export function feedback(rating, note, sample) {
       payload.sample_before = validSample.before;
       payload.sample_after = validSample.after;
     }
+    const validShot = validateShot(shot);
+    if (validShot) payload.screenshot = validShot;
 
-    if (validSample && typeof fetch === 'function') {
+    // Either image makes the body too large for sendBeacon's 64KB, so the fetch
+    // path is what carries them. The condition used to name only the sample.
+    if ((validSample || validShot) && typeof fetch === 'function') {
       try {
         // Plain fetch, no keepalive — see the transport finding above. Never
         // awaited, never surfaced to app code; a failed send here just means
@@ -280,7 +291,11 @@ export function feedback(rating, note, sample) {
     }
 
     if (typeof navigator?.sendBeacon !== 'function') return; // no beacon — drop, never retry
+    // Beacon fallback: the images are exactly what made this too big, so they
+    // are what gets dropped. Rating and note still land — which is the same
+    // trade every other drop in this file makes.
     if (validSample) { delete payload.sample_before; delete payload.sample_after; }
+    if (validShot) delete payload.screenshot;
     const blob = new Blob([JSON.stringify(payload)], { type: 'application/json' });
     navigator.sendBeacon(FEEDBACK_ENDPOINT, blob);
   } catch {

--- a/kompres-pdf-100kb.html
+++ b/kompres-pdf-100kb.html
@@ -287,6 +287,12 @@
          its own mode and page values must not be ported into it. A toolbar at
          --sp-48 is a toolbar that wastes the document's room. */
       --header-h: 44px; --toolbar-h: 52px;
+      /* THE HEIGHT EVERYTHING BELOW THE CHROME MEASURES AGAINST. It was
+         spelled `calc(var(--header-h) + var(--toolbar-h))` at each use site,
+         which stopped being true the moment the two could share a row. One
+         name, redefined once per breakpoint. */
+      --chrome-h: calc(var(--header-h) + var(--toolbar-h));
+      --header-merged-h: 52px;   /* the single-row height (tools are 36px + padding) */
     }
     /* Self-hosted fonts (preview parity with the PDF export) */
     @font-face { font-family: 'Montserrat'; src: url('fonts/montserrat-regular.woff2') format('woff2'); font-weight: 400; font-style: normal; font-display: swap; }
@@ -336,10 +342,17 @@
 
     /* ---- header ---- */
     header {
-      height: var(--header-h); flex: 0 0 auto;
+      min-height: var(--header-h); flex: 0 0 auto;
       display: flex; align-items: center; gap: 8px; padding: 0 10px;
-      background: var(--surface); border-bottom: 1px solid var(--line);
+      background: var(--surface);
+      /* WRAPS ON PURPOSE. Below the merge breakpoint the toolbar takes a full
+         row of its own; above it, everything stays on one line. No JS, no
+         second element, no duplicated tool buttons to keep in sync. */
+      flex-wrap: wrap;
     }
+    /* Narrow: the toolbar is a row of its own and carries the bottom edge, so
+       the header must NOT also draw one — two borders read as a seam. */
+    header > #toolbar { order: 9; flex: 1 0 100%; margin: 0 -10px; }
     .brand { font-weight: 700; font-size: 15px; letter-spacing: -.01em; }
     .brand-red { color: var(--accent); }
     /* home confirm: rides the standard dialog/.sheet system (the global
@@ -352,6 +365,18 @@
      * renders as a success. This system has one meaning for red and a second
      * colour meaning "good" is not being introduced here. */
     .fb-sheet { max-width: 380px; }
+    /* The byline under the question. Muted and small on purpose: it answers
+       "who am I writing to", it is not a place to go. The domain is the only
+       link, because it is the only one that leads anywhere useful. */
+    .fb-owner {
+      display: flex; align-items: center; gap: 9px;
+      margin: -2px 0 14px;
+    }
+    .fb-owner img { width: 28px; height: 28px; border-radius: 50%; object-fit: cover; flex: none; }
+    .fb-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
+    .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
+    .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -484,12 +509,73 @@
     }
     .tool.active { background: rgba(220,38,38,.08); color: var(--accent); }
 
+    /* ---- MERGED CHROME: one row when the width can hold it ---------------
+       His ruling 2026-09-09: "buat desktop, pindahin tools2nya ke atas. karena
+       spacenya kosong, cuma bikin dua baris navbar kalo spacenya ga cukup aja".
+       So the two-row layout is the FALLBACK, not the default.
+
+       ⚠️ THE BREAKPOINT IS MEASURED, NOT CHOSEN — 900px, 2026-09-09.
+       `.spacer { flex: 1 }` is the slack in this row, so its width IS the
+       headroom. Measured in Chromium: 152px of slack at 1000, 52 at 900, 12 at
+       860, and ZERO at 848. **848 is the true minimum**; 900 is that plus a
+       stated ~50px so the row never sits flush against its own ends, because a
+       row with no breathing room reads as broken even while it technically
+       fits. If a tool is added or a label reworded, RE-MEASURE — a stale
+       breakpoint shows up as a cramped row, never as an error.
+
+       ⚠️ AND THE GAUGE TOOK THREE TRIES, which is the part worth keeping.
+       Per-tool `scrollWidth` reported "fits" at every width down to 760, twice,
+       because the tools were not the element losing width. A third attempt
+       queried `#spacer` — it is a CLASS, so the query returned null and the
+       check passed on null. Only the fourth gauge, the spacer's own geometry
+       through a selector proven to match, showed a number that moved.
+       [[a-watcher-must-be-proven-to-fire]] is the sibling rule.
+
+       ⚠️ AND CHECK THE CEILING AT BOTH SIDES OF IT. design-discipline §2: a
+       band that holds three destinations at 1280 holds four at 375 without
+       anyone editing it. Here the count is unchanged either way — File, the
+       tool cluster (ONE destination, grouped), and Unduh (the one primary) —
+       which is the whole reason this merge is legitimate rather than a
+       fourth thing competing on one line. */
+    @media (min-width: 900px) {
+      :root { --chrome-h: var(--header-merged-h); }
+      header {
+        min-height: var(--header-merged-h); flex-wrap: nowrap;
+        border-bottom: 1px solid var(--line);
+      }
+      /* The flex spacer is what pushes Unduh right in the two-row layout. On
+         the merged row the TOOLBAR grows into that space instead and centres
+         its own children, so a second grower would fight it and shove the
+         tools off-centre. One grower per row. */
+      header > .spacer { display: none; }
+      header > #toolbar {
+        order: 3; flex: 1 1 auto; margin: 0;
+        height: auto; background: none; border-bottom: 0; padding: 0;
+        overflow: visible;
+      }
+      /* Undo/redo/Unduh sit AFTER the tools on the merged row. The markup has
+         the toolbar last (it was appended), so the order is stated here rather
+         than implied by the DOM. */
+      header > #btn-undo, header > #btn-redo, header > #btn-download { order: 5; }
+      /* Icon ABOVE label needs 52px of vertical room. On one shared row the
+         label moves BESIDE the icon — same target size, half the height. */
+      .tool {
+        flex-direction: row; gap: 6px;
+        min-width: 0; height: 36px; padding: 0 9px; font-size: 12.5px;
+      }
+      .tool svg { width: 17px; height: 17px; }
+      /* The BETA cap was corner-pinned so it could not widen a tight toolbar.
+         On the merged row there is room beside the word, and a corner chip on a
+         36px control overlaps its own label. */
+      .tool .beta-tag { position: static; margin-left: 1px; }
+    }
+
     /* ---- format bar: contextual, only when text is in play ---- */
     /* Contextual bars OVERLAY the canvas (founder: the document must never
        jump when a bar appears/disappears) — frosted so the page shows through. */
     #format-bar {
       display: none; align-items: center; gap: 6px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; height: 46px; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -623,61 +709,33 @@
        above was always claiming. The words survive as aria-label + title, so
        a screen reader and a desktop hover both still say "Kontak saya" — the
        label moved, it was not deleted. */
+    /* ⚠️ THE TAB SAYS WHAT IT DOES (2026-09-09, his ruling: "icon ini diganti
+       jadi kata2 aja ya 'ada masukan?'"). It was a chat glyph opening a panel
+       of five social handles; the handles are gone — "gaada yang peduli" — and
+       the glyph went with them, because an icon that has to be tapped to learn
+       its meaning fails his own element test (design-discipline §2).
+
+       AND THE PANEL IS GONE, NOT REPOINTED. Once the tab itself reads "Ada
+       masukan?", a panel whose only content was a button reading "Ada masukan?"
+       is a step that asks the same question twice. The tab opens #fb-form
+       directly. Whose product this is now lives INSIDE that dialog, where it
+       answers "who am I writing to" at the moment the question occurs.
+
+       The string is not new: it is the footer's, ratified 2026-08-22, and
+       reusing it keeps one name for one act (EXCLUDE 2 — copy is his). */
     #contact-tab-btn {
       position: fixed; left: 10px; bottom: 14px; z-index: 30;
-      width: 40px; height: 40px; border-radius: 12px;
-      display: grid; place-items: center;
+      min-height: 40px; padding: 0 14px; border-radius: 12px;
+      display: inline-flex; align-items: center;
       background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      color: var(--muted);
+      color: var(--muted); font-size: 13px; font-weight: 600;
     }
-    #contact-tab-btn svg { width: 19px; height: 19px; display: block; }
-    #contact-tab-panel {
-      position: fixed; left: 10px; bottom: 62px; z-index: 30;
-      width: max-content; max-width: min(78vw, 260px);
-      background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      border-radius: 12px; padding: 8px;
-      /* visibility (not just opacity): same reasoning as #support-card — a
-         dismissed panel must be GONE to hit-testing and screen readers. */
-      opacity: 0; visibility: hidden; pointer-events: none;
-      transform: translateY(10px); /* rests slightly low → reads as "slides up" on open */
-      transition: opacity .22s ease, transform .22s ease, visibility 0s linear .22s;
-    }
-    #contact-tab-panel.show {
-      opacity: 1; visibility: visible; pointer-events: auto;
-      transform: translateY(0); transition-delay: 0s;
-    }
-    /* One row per channel. min-height 40, not 44: this is a LIST inside an
-       already-opened panel, where rows are separated and mis-taps are cheap —
-       the 44 law guards isolated targets a finger hunts for, and the opening
-       tab is the one that has to meet it. Same reasoning text-runs.js records
-       for inflating a HIT box rather than a visual one. */
-    #contact-tab-panel a {
-      display: flex; align-items: center; gap: 10px;
-      min-height: 40px; padding: 0 10px; border-radius: 9px;
-      color: var(--ink); font-size: 13px; font-weight: 600; text-decoration: none;
-    }
-    #contact-tab-panel a:hover { background: var(--bg); }
-    /* The handle is the quiet half: the platform is what you scan for, the
-       handle is what you check once you have found it. */
-    #contact-tab-panel a b { font-weight: 600; }
-    #contact-tab-panel a span { color: var(--muted); font-weight: 500; margin-left: auto; }
-    #contact-tab-panel a svg { width: 16px; height: 16px; flex: none; color: var(--muted); }
-    /* The owner row. Deliberately NOT an <a> — it is not a sixth channel, it
-       is the answer to "whose handles are these". */
-    #contact-tab-panel .ct-owner {
-      display: flex; align-items: center; gap: 10px;
-      padding: 4px 10px 8px; margin-bottom: 4px;
-      border-bottom: 1px solid var(--line);
-    }
-    #contact-tab-panel .ct-owner img { width: 32px; height: 32px; border-radius: 50%; object-fit: cover; flex: none; }
-    #contact-tab-panel .ct-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
-    #contact-tab-panel .ct-owner span { display: block; font-size: 11px; color: var(--muted); font-weight: 500; margin-left: 0; }
-    @media (prefers-reduced-motion: reduce) { #contact-tab-panel { transition: none; } }
+    #contact-tab-btn:hover { color: var(--ink); }
 
     /* ---- the landing (= the editor's empty state; design: draf 3b) ---- */
     /* Editor chrome yields while the landing is up; it has its own header. */
     body.is-empty header, body.is-empty #toolbar, body.is-empty #zoom-ctl,
-    body.is-empty #contact-tab-btn, body.is-empty #contact-tab-panel { display: none; }
+    body.is-empty #contact-tab-btn { display: none; }
     #empty {
       position: absolute; inset: 0; overflow-y: auto; overscroll-behavior: contain;
       /* The PAGE ground is white (ruled 2026-07-29). The body underneath is
@@ -1322,7 +1380,7 @@
     /* signature context strip ("Semua Hal.") */
     #sig-bar {
       display: none; align-items: center; gap: 8px; height: 46px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -1604,8 +1662,16 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>
     </button>
     <button id="btn-download" disabled>Unduh</button>
-  </header>
-
+    <!-- ⚠️ THE TOOLBAR LIVES INSIDE <header> (2026-09-09, his ruling: "buat
+         desktop, pindahin tools2nya ke atas. karena spacenya kosong").
+         It is ONE element in TWO layouts, never two elements:
+           wide  → it sits on the header's own row, between File and Unduh
+           narrow→ header wraps and it takes its own row, exactly as before
+         A sibling cannot be pulled into a flex row by CSS, so the DOM move is
+         what makes the wide layout possible at all. Placement is by `order`,
+         so the markup order here is not the reading order — see the header
+         rules in the stylesheet, and --chrome-h, which is what everything
+         positioned BELOW the chrome measures against. -->
   <div id="toolbar" role="toolbar" aria-label="Alat">
     <!-- No "Pilih" button (founder ruling 2026-07-19): the neutral mode is a
          STATE, not a tool — nothing lit means nothing armed. Every armed tool
@@ -1635,6 +1701,8 @@
       Halaman
     </button>
   </div>
+  </header>
+
 
   <div id="format-bar" role="toolbar" aria-label="Format teks"></div>
   <div id="sig-bar" role="toolbar" aria-label="Aksi tanda tangan">
@@ -1985,44 +2053,20 @@
     <button id="z-in" aria-label="Perbesar">+</button>
     <button id="z-out" aria-label="Perkecil">−</button>
   </div>
-  <!-- Contact bookmark: quiet furniture tab, bottom-left, mirrors #zoom-ctl.
-       Two separate elements (button + panel), not one wrapper — see the CSS
-       comment for why.
+  <!-- The feedback tab: quiet furniture, bottom-left, mirrors #zoom-ctl.
+       It used to be a chat glyph opening a panel of five social handles. He
+       retired both on 2026-09-09 — "ilangin semua sosmed gue, gaada yang
+       peduli wkwk, ganti jadi feedback form aja" — so the tab now says what it
+       does and opens the general feedback dialog (#fb-form) directly.
 
-       ⚠️ THE HANDLES ARE NOT INVENTED HERE AND MUST NOT BE. They come from
-       `engine/wiki/machine/public-identity.md`, which is the machine's one
-       home for them, and each is verified against fkd/loker's own shipped
-       Kontak dialog. A handle typed from memory is a live link to someone
-       else's account. If a channel is missing from the wiki it is missing
-       here too — that is the design, not an oversight.
+       ⚠️ THE HANDLES ARE NOT COMMENTED OUT AND MUST NOT BE RESTORED FROM HERE.
+       They live in `engine/wiki/machine/public-identity.md`, which is the
+       machine's one home for them; a handle typed from memory is a live link
+       to someone else's account. This surface simply no longer carries them.
 
-       ⚠️ THREADS AND X CAME FROM HIM, NOT FROM THE MACHINE (2026-08-23). He
-       asked for "semua sosmed gue... threads x instagram, cari aja" — and
-       they were not there: not in the wiki page, not in loker's dialog, not
-       anywhere under ~/machine. The Instagram handle made threads/@ojan.lubis
-       a good guess and it turned out correct, which is exactly why it was not
-       shipped as one: a guessed handle that happens to resolve is a live link
-       to a stranger's account until someone confirms whose it is. He supplied
-       both, they are now in the wiki, and the wiki is what a future session
-       reads. -->
-  <button id="contact-tab-btn" aria-expanded="false" aria-controls="contact-tab-panel"
-          aria-label="Kontak saya" title="Kontak saya">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 11.5a8.4 8.4 0 0 1-9 8.4 9 9 0 0 1-3.9-.9L3 20.5l1.5-4.5a8.4 8.4 0 0 1-.9-3.9 8.4 8.4 0 0 1 8.4-9 8.4 8.4 0 0 1 9 8.4Z"/></svg>
-  </button>
-  <div id="contact-tab-panel">
-    <!-- WHO the channels belong to. Added 2026-08-27: this panel listed five
-         handles and never said whose they were. Not a destination — a label on
-         the list below it. -->
-    <div class="ct-owner">
-      <img src="images/ojan.jpg" alt="Foto Ojan" width="32" height="32" loading="lazy">
-      <div><b>Ojan</b><span>Fauzan Ahladzikri</span></div>
-    </div>
-    <a href="https://tiktok.com/@okeojan" target="_blank" rel="noopener"><b>TikTok</b><span>@okeojan</span></a>
-    <a href="https://instagram.com/ojan.lubis" target="_blank" rel="noopener"><b>Instagram</b><span>ojan.lubis</span></a>
-    <a href="https://www.threads.com/@ojan.lubis" target="_blank" rel="noopener"><b>Threads</b><span>ojan.lubis</span></a>
-    <a href="https://x.com/okeojan" target="_blank" rel="noopener"><b>X</b><span>@okeojan</span></a>
-    <a href="https://ojanlubis.id" target="_blank" rel="noopener"><b>Website</b><span>ojanlubis.id</span></a>
-  </div>
+       Wired by js/v2/feedback-form.js, alongside the footer's own link — one
+       dialog, one code path, two doors. -->
+  <button id="contact-tab-btn">Ada masukan?</button>
   <div id="toast" role="status" aria-live="polite"></div>
 
   <!-- The general feedback channel, opened from the footer's "Ada masukan?".
@@ -2041,6 +2085,17 @@
     <div class="sheet fb-sheet">
       <div class="fb-body">
         <h2>Gimana PDFLokal?</h2>
+        <!-- WHO IS ASKING. Moved here 2026-09-09 from the retired contact
+             panel, where it labelled a list of handles. It is a BYLINE, not a
+             destination: the dialog's one primary is Kirim, and an identity
+             block competing with it would be a second thing to decide about
+             (design-discipline §2 — the ceiling counts destinations). Small,
+             muted, directly under the question so it answers "who am I writing
+             to" exactly when that occurs to someone. -->
+        <div class="fb-owner">
+          <img src="images/ojan.jpg" alt="" width="28" height="28" loading="lazy">
+          <div><b>Ojan</b><a href="https://mesindev.com" target="_blank" rel="noopener">mesindev.com</a></div>
+        </div>
         <div class="fb-thumbs" role="group" aria-label="Penilaian">
           <button type="button" id="fb-up" aria-pressed="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/></svg>

--- a/kompres-pdf-100kb.html
+++ b/kompres-pdf-100kb.html
@@ -377,6 +377,20 @@
     .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
     .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
 
+    /* The pasted screenshot, shown back at a size you can actually check. */
+    #fb-shot { position: relative; margin: 10px 0 0; }
+    #fb-shot img {
+      display: block; width: 100%; max-height: 180px; object-fit: contain;
+      border: 1px solid var(--line); border-radius: 8px; background: var(--bg);
+    }
+    #fb-shot-clear {
+      position: absolute; top: 6px; right: 6px;
+      width: 28px; height: 28px; border-radius: 8px; line-height: 1;
+      display: grid; place-items: center; font-size: 17px;
+      background: var(--surface); color: var(--ink);
+      box-shadow: 0 1px 6px rgba(0,0,0,.22);
+    }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -2106,7 +2120,20 @@
             <span>Kurang</span>
           </button>
         </div>
-        <textarea id="fb-note" rows="3" placeholder="boleh minta feedbacknya di sini, supaya kita bisa improve terus pdflokal. (boleh dikosongin juga kok)"></textarea>
+        <!-- PASTE, NOT UPLOAD (his ruling 2026-09-09: "gausah ada tombolnya,
+             bilang aja diplaceholdernya"). No attach button anywhere, and
+             nothing here ever reaches into the editor for pixels — the only
+             image that can exist is one the user deliberately pasted. That is
+             the whole reason this is defensible against the product's own "no
+             uploads" claim, so a convenience button would not be a small
+             addition, it would remove the argument. -->
+        <textarea id="fb-note" rows="3" placeholder="tulis feedbacknya di sini, atau boleh paste screenshot"></textarea>
+        <!-- The pasted image, shown back before it can be sent. A screenshot
+             the sender never saw is a screenshot they did not really choose. -->
+        <div id="fb-shot" hidden>
+          <img id="fb-shot-img" alt="">
+          <button type="button" id="fb-shot-clear" aria-label="Hapus">×</button>
+        </div>
         <div class="fb-row">
           <button type="button" id="fb-cancel">Batal</button>
           <button type="button" id="fb-send" disabled>Kirim</button>

--- a/kompres-pdf-1mb.html
+++ b/kompres-pdf-1mb.html
@@ -287,6 +287,12 @@
          its own mode and page values must not be ported into it. A toolbar at
          --sp-48 is a toolbar that wastes the document's room. */
       --header-h: 44px; --toolbar-h: 52px;
+      /* THE HEIGHT EVERYTHING BELOW THE CHROME MEASURES AGAINST. It was
+         spelled `calc(var(--header-h) + var(--toolbar-h))` at each use site,
+         which stopped being true the moment the two could share a row. One
+         name, redefined once per breakpoint. */
+      --chrome-h: calc(var(--header-h) + var(--toolbar-h));
+      --header-merged-h: 52px;   /* the single-row height (tools are 36px + padding) */
     }
     /* Self-hosted fonts (preview parity with the PDF export) */
     @font-face { font-family: 'Montserrat'; src: url('fonts/montserrat-regular.woff2') format('woff2'); font-weight: 400; font-style: normal; font-display: swap; }
@@ -336,10 +342,17 @@
 
     /* ---- header ---- */
     header {
-      height: var(--header-h); flex: 0 0 auto;
+      min-height: var(--header-h); flex: 0 0 auto;
       display: flex; align-items: center; gap: 8px; padding: 0 10px;
-      background: var(--surface); border-bottom: 1px solid var(--line);
+      background: var(--surface);
+      /* WRAPS ON PURPOSE. Below the merge breakpoint the toolbar takes a full
+         row of its own; above it, everything stays on one line. No JS, no
+         second element, no duplicated tool buttons to keep in sync. */
+      flex-wrap: wrap;
     }
+    /* Narrow: the toolbar is a row of its own and carries the bottom edge, so
+       the header must NOT also draw one — two borders read as a seam. */
+    header > #toolbar { order: 9; flex: 1 0 100%; margin: 0 -10px; }
     .brand { font-weight: 700; font-size: 15px; letter-spacing: -.01em; }
     .brand-red { color: var(--accent); }
     /* home confirm: rides the standard dialog/.sheet system (the global
@@ -352,6 +365,18 @@
      * renders as a success. This system has one meaning for red and a second
      * colour meaning "good" is not being introduced here. */
     .fb-sheet { max-width: 380px; }
+    /* The byline under the question. Muted and small on purpose: it answers
+       "who am I writing to", it is not a place to go. The domain is the only
+       link, because it is the only one that leads anywhere useful. */
+    .fb-owner {
+      display: flex; align-items: center; gap: 9px;
+      margin: -2px 0 14px;
+    }
+    .fb-owner img { width: 28px; height: 28px; border-radius: 50%; object-fit: cover; flex: none; }
+    .fb-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
+    .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
+    .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -484,12 +509,73 @@
     }
     .tool.active { background: rgba(220,38,38,.08); color: var(--accent); }
 
+    /* ---- MERGED CHROME: one row when the width can hold it ---------------
+       His ruling 2026-09-09: "buat desktop, pindahin tools2nya ke atas. karena
+       spacenya kosong, cuma bikin dua baris navbar kalo spacenya ga cukup aja".
+       So the two-row layout is the FALLBACK, not the default.
+
+       ⚠️ THE BREAKPOINT IS MEASURED, NOT CHOSEN — 900px, 2026-09-09.
+       `.spacer { flex: 1 }` is the slack in this row, so its width IS the
+       headroom. Measured in Chromium: 152px of slack at 1000, 52 at 900, 12 at
+       860, and ZERO at 848. **848 is the true minimum**; 900 is that plus a
+       stated ~50px so the row never sits flush against its own ends, because a
+       row with no breathing room reads as broken even while it technically
+       fits. If a tool is added or a label reworded, RE-MEASURE — a stale
+       breakpoint shows up as a cramped row, never as an error.
+
+       ⚠️ AND THE GAUGE TOOK THREE TRIES, which is the part worth keeping.
+       Per-tool `scrollWidth` reported "fits" at every width down to 760, twice,
+       because the tools were not the element losing width. A third attempt
+       queried `#spacer` — it is a CLASS, so the query returned null and the
+       check passed on null. Only the fourth gauge, the spacer's own geometry
+       through a selector proven to match, showed a number that moved.
+       [[a-watcher-must-be-proven-to-fire]] is the sibling rule.
+
+       ⚠️ AND CHECK THE CEILING AT BOTH SIDES OF IT. design-discipline §2: a
+       band that holds three destinations at 1280 holds four at 375 without
+       anyone editing it. Here the count is unchanged either way — File, the
+       tool cluster (ONE destination, grouped), and Unduh (the one primary) —
+       which is the whole reason this merge is legitimate rather than a
+       fourth thing competing on one line. */
+    @media (min-width: 900px) {
+      :root { --chrome-h: var(--header-merged-h); }
+      header {
+        min-height: var(--header-merged-h); flex-wrap: nowrap;
+        border-bottom: 1px solid var(--line);
+      }
+      /* The flex spacer is what pushes Unduh right in the two-row layout. On
+         the merged row the TOOLBAR grows into that space instead and centres
+         its own children, so a second grower would fight it and shove the
+         tools off-centre. One grower per row. */
+      header > .spacer { display: none; }
+      header > #toolbar {
+        order: 3; flex: 1 1 auto; margin: 0;
+        height: auto; background: none; border-bottom: 0; padding: 0;
+        overflow: visible;
+      }
+      /* Undo/redo/Unduh sit AFTER the tools on the merged row. The markup has
+         the toolbar last (it was appended), so the order is stated here rather
+         than implied by the DOM. */
+      header > #btn-undo, header > #btn-redo, header > #btn-download { order: 5; }
+      /* Icon ABOVE label needs 52px of vertical room. On one shared row the
+         label moves BESIDE the icon — same target size, half the height. */
+      .tool {
+        flex-direction: row; gap: 6px;
+        min-width: 0; height: 36px; padding: 0 9px; font-size: 12.5px;
+      }
+      .tool svg { width: 17px; height: 17px; }
+      /* The BETA cap was corner-pinned so it could not widen a tight toolbar.
+         On the merged row there is room beside the word, and a corner chip on a
+         36px control overlaps its own label. */
+      .tool .beta-tag { position: static; margin-left: 1px; }
+    }
+
     /* ---- format bar: contextual, only when text is in play ---- */
     /* Contextual bars OVERLAY the canvas (founder: the document must never
        jump when a bar appears/disappears) — frosted so the page shows through. */
     #format-bar {
       display: none; align-items: center; gap: 6px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; height: 46px; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -623,61 +709,33 @@
        above was always claiming. The words survive as aria-label + title, so
        a screen reader and a desktop hover both still say "Kontak saya" — the
        label moved, it was not deleted. */
+    /* ⚠️ THE TAB SAYS WHAT IT DOES (2026-09-09, his ruling: "icon ini diganti
+       jadi kata2 aja ya 'ada masukan?'"). It was a chat glyph opening a panel
+       of five social handles; the handles are gone — "gaada yang peduli" — and
+       the glyph went with them, because an icon that has to be tapped to learn
+       its meaning fails his own element test (design-discipline §2).
+
+       AND THE PANEL IS GONE, NOT REPOINTED. Once the tab itself reads "Ada
+       masukan?", a panel whose only content was a button reading "Ada masukan?"
+       is a step that asks the same question twice. The tab opens #fb-form
+       directly. Whose product this is now lives INSIDE that dialog, where it
+       answers "who am I writing to" at the moment the question occurs.
+
+       The string is not new: it is the footer's, ratified 2026-08-22, and
+       reusing it keeps one name for one act (EXCLUDE 2 — copy is his). */
     #contact-tab-btn {
       position: fixed; left: 10px; bottom: 14px; z-index: 30;
-      width: 40px; height: 40px; border-radius: 12px;
-      display: grid; place-items: center;
+      min-height: 40px; padding: 0 14px; border-radius: 12px;
+      display: inline-flex; align-items: center;
       background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      color: var(--muted);
+      color: var(--muted); font-size: 13px; font-weight: 600;
     }
-    #contact-tab-btn svg { width: 19px; height: 19px; display: block; }
-    #contact-tab-panel {
-      position: fixed; left: 10px; bottom: 62px; z-index: 30;
-      width: max-content; max-width: min(78vw, 260px);
-      background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      border-radius: 12px; padding: 8px;
-      /* visibility (not just opacity): same reasoning as #support-card — a
-         dismissed panel must be GONE to hit-testing and screen readers. */
-      opacity: 0; visibility: hidden; pointer-events: none;
-      transform: translateY(10px); /* rests slightly low → reads as "slides up" on open */
-      transition: opacity .22s ease, transform .22s ease, visibility 0s linear .22s;
-    }
-    #contact-tab-panel.show {
-      opacity: 1; visibility: visible; pointer-events: auto;
-      transform: translateY(0); transition-delay: 0s;
-    }
-    /* One row per channel. min-height 40, not 44: this is a LIST inside an
-       already-opened panel, where rows are separated and mis-taps are cheap —
-       the 44 law guards isolated targets a finger hunts for, and the opening
-       tab is the one that has to meet it. Same reasoning text-runs.js records
-       for inflating a HIT box rather than a visual one. */
-    #contact-tab-panel a {
-      display: flex; align-items: center; gap: 10px;
-      min-height: 40px; padding: 0 10px; border-radius: 9px;
-      color: var(--ink); font-size: 13px; font-weight: 600; text-decoration: none;
-    }
-    #contact-tab-panel a:hover { background: var(--bg); }
-    /* The handle is the quiet half: the platform is what you scan for, the
-       handle is what you check once you have found it. */
-    #contact-tab-panel a b { font-weight: 600; }
-    #contact-tab-panel a span { color: var(--muted); font-weight: 500; margin-left: auto; }
-    #contact-tab-panel a svg { width: 16px; height: 16px; flex: none; color: var(--muted); }
-    /* The owner row. Deliberately NOT an <a> — it is not a sixth channel, it
-       is the answer to "whose handles are these". */
-    #contact-tab-panel .ct-owner {
-      display: flex; align-items: center; gap: 10px;
-      padding: 4px 10px 8px; margin-bottom: 4px;
-      border-bottom: 1px solid var(--line);
-    }
-    #contact-tab-panel .ct-owner img { width: 32px; height: 32px; border-radius: 50%; object-fit: cover; flex: none; }
-    #contact-tab-panel .ct-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
-    #contact-tab-panel .ct-owner span { display: block; font-size: 11px; color: var(--muted); font-weight: 500; margin-left: 0; }
-    @media (prefers-reduced-motion: reduce) { #contact-tab-panel { transition: none; } }
+    #contact-tab-btn:hover { color: var(--ink); }
 
     /* ---- the landing (= the editor's empty state; design: draf 3b) ---- */
     /* Editor chrome yields while the landing is up; it has its own header. */
     body.is-empty header, body.is-empty #toolbar, body.is-empty #zoom-ctl,
-    body.is-empty #contact-tab-btn, body.is-empty #contact-tab-panel { display: none; }
+    body.is-empty #contact-tab-btn { display: none; }
     #empty {
       position: absolute; inset: 0; overflow-y: auto; overscroll-behavior: contain;
       /* The PAGE ground is white (ruled 2026-07-29). The body underneath is
@@ -1322,7 +1380,7 @@
     /* signature context strip ("Semua Hal.") */
     #sig-bar {
       display: none; align-items: center; gap: 8px; height: 46px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -1604,8 +1662,16 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>
     </button>
     <button id="btn-download" disabled>Unduh</button>
-  </header>
-
+    <!-- ⚠️ THE TOOLBAR LIVES INSIDE <header> (2026-09-09, his ruling: "buat
+         desktop, pindahin tools2nya ke atas. karena spacenya kosong").
+         It is ONE element in TWO layouts, never two elements:
+           wide  → it sits on the header's own row, between File and Unduh
+           narrow→ header wraps and it takes its own row, exactly as before
+         A sibling cannot be pulled into a flex row by CSS, so the DOM move is
+         what makes the wide layout possible at all. Placement is by `order`,
+         so the markup order here is not the reading order — see the header
+         rules in the stylesheet, and --chrome-h, which is what everything
+         positioned BELOW the chrome measures against. -->
   <div id="toolbar" role="toolbar" aria-label="Alat">
     <!-- No "Pilih" button (founder ruling 2026-07-19): the neutral mode is a
          STATE, not a tool — nothing lit means nothing armed. Every armed tool
@@ -1635,6 +1701,8 @@
       Halaman
     </button>
   </div>
+  </header>
+
 
   <div id="format-bar" role="toolbar" aria-label="Format teks"></div>
   <div id="sig-bar" role="toolbar" aria-label="Aksi tanda tangan">
@@ -1988,44 +2056,20 @@
     <button id="z-in" aria-label="Perbesar">+</button>
     <button id="z-out" aria-label="Perkecil">−</button>
   </div>
-  <!-- Contact bookmark: quiet furniture tab, bottom-left, mirrors #zoom-ctl.
-       Two separate elements (button + panel), not one wrapper — see the CSS
-       comment for why.
+  <!-- The feedback tab: quiet furniture, bottom-left, mirrors #zoom-ctl.
+       It used to be a chat glyph opening a panel of five social handles. He
+       retired both on 2026-09-09 — "ilangin semua sosmed gue, gaada yang
+       peduli wkwk, ganti jadi feedback form aja" — so the tab now says what it
+       does and opens the general feedback dialog (#fb-form) directly.
 
-       ⚠️ THE HANDLES ARE NOT INVENTED HERE AND MUST NOT BE. They come from
-       `engine/wiki/machine/public-identity.md`, which is the machine's one
-       home for them, and each is verified against fkd/loker's own shipped
-       Kontak dialog. A handle typed from memory is a live link to someone
-       else's account. If a channel is missing from the wiki it is missing
-       here too — that is the design, not an oversight.
+       ⚠️ THE HANDLES ARE NOT COMMENTED OUT AND MUST NOT BE RESTORED FROM HERE.
+       They live in `engine/wiki/machine/public-identity.md`, which is the
+       machine's one home for them; a handle typed from memory is a live link
+       to someone else's account. This surface simply no longer carries them.
 
-       ⚠️ THREADS AND X CAME FROM HIM, NOT FROM THE MACHINE (2026-08-23). He
-       asked for "semua sosmed gue... threads x instagram, cari aja" — and
-       they were not there: not in the wiki page, not in loker's dialog, not
-       anywhere under ~/machine. The Instagram handle made threads/@ojan.lubis
-       a good guess and it turned out correct, which is exactly why it was not
-       shipped as one: a guessed handle that happens to resolve is a live link
-       to a stranger's account until someone confirms whose it is. He supplied
-       both, they are now in the wiki, and the wiki is what a future session
-       reads. -->
-  <button id="contact-tab-btn" aria-expanded="false" aria-controls="contact-tab-panel"
-          aria-label="Kontak saya" title="Kontak saya">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 11.5a8.4 8.4 0 0 1-9 8.4 9 9 0 0 1-3.9-.9L3 20.5l1.5-4.5a8.4 8.4 0 0 1-.9-3.9 8.4 8.4 0 0 1 8.4-9 8.4 8.4 0 0 1 9 8.4Z"/></svg>
-  </button>
-  <div id="contact-tab-panel">
-    <!-- WHO the channels belong to. Added 2026-08-27: this panel listed five
-         handles and never said whose they were. Not a destination — a label on
-         the list below it. -->
-    <div class="ct-owner">
-      <img src="images/ojan.jpg" alt="Foto Ojan" width="32" height="32" loading="lazy">
-      <div><b>Ojan</b><span>Fauzan Ahladzikri</span></div>
-    </div>
-    <a href="https://tiktok.com/@okeojan" target="_blank" rel="noopener"><b>TikTok</b><span>@okeojan</span></a>
-    <a href="https://instagram.com/ojan.lubis" target="_blank" rel="noopener"><b>Instagram</b><span>ojan.lubis</span></a>
-    <a href="https://www.threads.com/@ojan.lubis" target="_blank" rel="noopener"><b>Threads</b><span>ojan.lubis</span></a>
-    <a href="https://x.com/okeojan" target="_blank" rel="noopener"><b>X</b><span>@okeojan</span></a>
-    <a href="https://ojanlubis.id" target="_blank" rel="noopener"><b>Website</b><span>ojanlubis.id</span></a>
-  </div>
+       Wired by js/v2/feedback-form.js, alongside the footer's own link — one
+       dialog, one code path, two doors. -->
+  <button id="contact-tab-btn">Ada masukan?</button>
   <div id="toast" role="status" aria-live="polite"></div>
 
   <!-- The general feedback channel, opened from the footer's "Ada masukan?".
@@ -2044,6 +2088,17 @@
     <div class="sheet fb-sheet">
       <div class="fb-body">
         <h2>Gimana PDFLokal?</h2>
+        <!-- WHO IS ASKING. Moved here 2026-09-09 from the retired contact
+             panel, where it labelled a list of handles. It is a BYLINE, not a
+             destination: the dialog's one primary is Kirim, and an identity
+             block competing with it would be a second thing to decide about
+             (design-discipline §2 — the ceiling counts destinations). Small,
+             muted, directly under the question so it answers "who am I writing
+             to" exactly when that occurs to someone. -->
+        <div class="fb-owner">
+          <img src="images/ojan.jpg" alt="" width="28" height="28" loading="lazy">
+          <div><b>Ojan</b><a href="https://mesindev.com" target="_blank" rel="noopener">mesindev.com</a></div>
+        </div>
         <div class="fb-thumbs" role="group" aria-label="Penilaian">
           <button type="button" id="fb-up" aria-pressed="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/></svg>

--- a/kompres-pdf-1mb.html
+++ b/kompres-pdf-1mb.html
@@ -377,6 +377,20 @@
     .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
     .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
 
+    /* The pasted screenshot, shown back at a size you can actually check. */
+    #fb-shot { position: relative; margin: 10px 0 0; }
+    #fb-shot img {
+      display: block; width: 100%; max-height: 180px; object-fit: contain;
+      border: 1px solid var(--line); border-radius: 8px; background: var(--bg);
+    }
+    #fb-shot-clear {
+      position: absolute; top: 6px; right: 6px;
+      width: 28px; height: 28px; border-radius: 8px; line-height: 1;
+      display: grid; place-items: center; font-size: 17px;
+      background: var(--surface); color: var(--ink);
+      box-shadow: 0 1px 6px rgba(0,0,0,.22);
+    }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -2109,7 +2123,20 @@
             <span>Kurang</span>
           </button>
         </div>
-        <textarea id="fb-note" rows="3" placeholder="boleh minta feedbacknya di sini, supaya kita bisa improve terus pdflokal. (boleh dikosongin juga kok)"></textarea>
+        <!-- PASTE, NOT UPLOAD (his ruling 2026-09-09: "gausah ada tombolnya,
+             bilang aja diplaceholdernya"). No attach button anywhere, and
+             nothing here ever reaches into the editor for pixels — the only
+             image that can exist is one the user deliberately pasted. That is
+             the whole reason this is defensible against the product's own "no
+             uploads" claim, so a convenience button would not be a small
+             addition, it would remove the argument. -->
+        <textarea id="fb-note" rows="3" placeholder="tulis feedbacknya di sini, atau boleh paste screenshot"></textarea>
+        <!-- The pasted image, shown back before it can be sent. A screenshot
+             the sender never saw is a screenshot they did not really choose. -->
+        <div id="fb-shot" hidden>
+          <img id="fb-shot-img" alt="">
+          <button type="button" id="fb-shot-clear" aria-label="Hapus">×</button>
+        </div>
         <div class="fb-row">
           <button type="button" id="fb-cancel">Batal</button>
           <button type="button" id="fb-send" disabled>Kirim</button>

--- a/kompres-pdf-200kb.html
+++ b/kompres-pdf-200kb.html
@@ -287,6 +287,12 @@
          its own mode and page values must not be ported into it. A toolbar at
          --sp-48 is a toolbar that wastes the document's room. */
       --header-h: 44px; --toolbar-h: 52px;
+      /* THE HEIGHT EVERYTHING BELOW THE CHROME MEASURES AGAINST. It was
+         spelled `calc(var(--header-h) + var(--toolbar-h))` at each use site,
+         which stopped being true the moment the two could share a row. One
+         name, redefined once per breakpoint. */
+      --chrome-h: calc(var(--header-h) + var(--toolbar-h));
+      --header-merged-h: 52px;   /* the single-row height (tools are 36px + padding) */
     }
     /* Self-hosted fonts (preview parity with the PDF export) */
     @font-face { font-family: 'Montserrat'; src: url('fonts/montserrat-regular.woff2') format('woff2'); font-weight: 400; font-style: normal; font-display: swap; }
@@ -336,10 +342,17 @@
 
     /* ---- header ---- */
     header {
-      height: var(--header-h); flex: 0 0 auto;
+      min-height: var(--header-h); flex: 0 0 auto;
       display: flex; align-items: center; gap: 8px; padding: 0 10px;
-      background: var(--surface); border-bottom: 1px solid var(--line);
+      background: var(--surface);
+      /* WRAPS ON PURPOSE. Below the merge breakpoint the toolbar takes a full
+         row of its own; above it, everything stays on one line. No JS, no
+         second element, no duplicated tool buttons to keep in sync. */
+      flex-wrap: wrap;
     }
+    /* Narrow: the toolbar is a row of its own and carries the bottom edge, so
+       the header must NOT also draw one — two borders read as a seam. */
+    header > #toolbar { order: 9; flex: 1 0 100%; margin: 0 -10px; }
     .brand { font-weight: 700; font-size: 15px; letter-spacing: -.01em; }
     .brand-red { color: var(--accent); }
     /* home confirm: rides the standard dialog/.sheet system (the global
@@ -352,6 +365,18 @@
      * renders as a success. This system has one meaning for red and a second
      * colour meaning "good" is not being introduced here. */
     .fb-sheet { max-width: 380px; }
+    /* The byline under the question. Muted and small on purpose: it answers
+       "who am I writing to", it is not a place to go. The domain is the only
+       link, because it is the only one that leads anywhere useful. */
+    .fb-owner {
+      display: flex; align-items: center; gap: 9px;
+      margin: -2px 0 14px;
+    }
+    .fb-owner img { width: 28px; height: 28px; border-radius: 50%; object-fit: cover; flex: none; }
+    .fb-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
+    .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
+    .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -484,12 +509,73 @@
     }
     .tool.active { background: rgba(220,38,38,.08); color: var(--accent); }
 
+    /* ---- MERGED CHROME: one row when the width can hold it ---------------
+       His ruling 2026-09-09: "buat desktop, pindahin tools2nya ke atas. karena
+       spacenya kosong, cuma bikin dua baris navbar kalo spacenya ga cukup aja".
+       So the two-row layout is the FALLBACK, not the default.
+
+       ⚠️ THE BREAKPOINT IS MEASURED, NOT CHOSEN — 900px, 2026-09-09.
+       `.spacer { flex: 1 }` is the slack in this row, so its width IS the
+       headroom. Measured in Chromium: 152px of slack at 1000, 52 at 900, 12 at
+       860, and ZERO at 848. **848 is the true minimum**; 900 is that plus a
+       stated ~50px so the row never sits flush against its own ends, because a
+       row with no breathing room reads as broken even while it technically
+       fits. If a tool is added or a label reworded, RE-MEASURE — a stale
+       breakpoint shows up as a cramped row, never as an error.
+
+       ⚠️ AND THE GAUGE TOOK THREE TRIES, which is the part worth keeping.
+       Per-tool `scrollWidth` reported "fits" at every width down to 760, twice,
+       because the tools were not the element losing width. A third attempt
+       queried `#spacer` — it is a CLASS, so the query returned null and the
+       check passed on null. Only the fourth gauge, the spacer's own geometry
+       through a selector proven to match, showed a number that moved.
+       [[a-watcher-must-be-proven-to-fire]] is the sibling rule.
+
+       ⚠️ AND CHECK THE CEILING AT BOTH SIDES OF IT. design-discipline §2: a
+       band that holds three destinations at 1280 holds four at 375 without
+       anyone editing it. Here the count is unchanged either way — File, the
+       tool cluster (ONE destination, grouped), and Unduh (the one primary) —
+       which is the whole reason this merge is legitimate rather than a
+       fourth thing competing on one line. */
+    @media (min-width: 900px) {
+      :root { --chrome-h: var(--header-merged-h); }
+      header {
+        min-height: var(--header-merged-h); flex-wrap: nowrap;
+        border-bottom: 1px solid var(--line);
+      }
+      /* The flex spacer is what pushes Unduh right in the two-row layout. On
+         the merged row the TOOLBAR grows into that space instead and centres
+         its own children, so a second grower would fight it and shove the
+         tools off-centre. One grower per row. */
+      header > .spacer { display: none; }
+      header > #toolbar {
+        order: 3; flex: 1 1 auto; margin: 0;
+        height: auto; background: none; border-bottom: 0; padding: 0;
+        overflow: visible;
+      }
+      /* Undo/redo/Unduh sit AFTER the tools on the merged row. The markup has
+         the toolbar last (it was appended), so the order is stated here rather
+         than implied by the DOM. */
+      header > #btn-undo, header > #btn-redo, header > #btn-download { order: 5; }
+      /* Icon ABOVE label needs 52px of vertical room. On one shared row the
+         label moves BESIDE the icon — same target size, half the height. */
+      .tool {
+        flex-direction: row; gap: 6px;
+        min-width: 0; height: 36px; padding: 0 9px; font-size: 12.5px;
+      }
+      .tool svg { width: 17px; height: 17px; }
+      /* The BETA cap was corner-pinned so it could not widen a tight toolbar.
+         On the merged row there is room beside the word, and a corner chip on a
+         36px control overlaps its own label. */
+      .tool .beta-tag { position: static; margin-left: 1px; }
+    }
+
     /* ---- format bar: contextual, only when text is in play ---- */
     /* Contextual bars OVERLAY the canvas (founder: the document must never
        jump when a bar appears/disappears) — frosted so the page shows through. */
     #format-bar {
       display: none; align-items: center; gap: 6px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; height: 46px; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -623,61 +709,33 @@
        above was always claiming. The words survive as aria-label + title, so
        a screen reader and a desktop hover both still say "Kontak saya" — the
        label moved, it was not deleted. */
+    /* ⚠️ THE TAB SAYS WHAT IT DOES (2026-09-09, his ruling: "icon ini diganti
+       jadi kata2 aja ya 'ada masukan?'"). It was a chat glyph opening a panel
+       of five social handles; the handles are gone — "gaada yang peduli" — and
+       the glyph went with them, because an icon that has to be tapped to learn
+       its meaning fails his own element test (design-discipline §2).
+
+       AND THE PANEL IS GONE, NOT REPOINTED. Once the tab itself reads "Ada
+       masukan?", a panel whose only content was a button reading "Ada masukan?"
+       is a step that asks the same question twice. The tab opens #fb-form
+       directly. Whose product this is now lives INSIDE that dialog, where it
+       answers "who am I writing to" at the moment the question occurs.
+
+       The string is not new: it is the footer's, ratified 2026-08-22, and
+       reusing it keeps one name for one act (EXCLUDE 2 — copy is his). */
     #contact-tab-btn {
       position: fixed; left: 10px; bottom: 14px; z-index: 30;
-      width: 40px; height: 40px; border-radius: 12px;
-      display: grid; place-items: center;
+      min-height: 40px; padding: 0 14px; border-radius: 12px;
+      display: inline-flex; align-items: center;
       background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      color: var(--muted);
+      color: var(--muted); font-size: 13px; font-weight: 600;
     }
-    #contact-tab-btn svg { width: 19px; height: 19px; display: block; }
-    #contact-tab-panel {
-      position: fixed; left: 10px; bottom: 62px; z-index: 30;
-      width: max-content; max-width: min(78vw, 260px);
-      background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      border-radius: 12px; padding: 8px;
-      /* visibility (not just opacity): same reasoning as #support-card — a
-         dismissed panel must be GONE to hit-testing and screen readers. */
-      opacity: 0; visibility: hidden; pointer-events: none;
-      transform: translateY(10px); /* rests slightly low → reads as "slides up" on open */
-      transition: opacity .22s ease, transform .22s ease, visibility 0s linear .22s;
-    }
-    #contact-tab-panel.show {
-      opacity: 1; visibility: visible; pointer-events: auto;
-      transform: translateY(0); transition-delay: 0s;
-    }
-    /* One row per channel. min-height 40, not 44: this is a LIST inside an
-       already-opened panel, where rows are separated and mis-taps are cheap —
-       the 44 law guards isolated targets a finger hunts for, and the opening
-       tab is the one that has to meet it. Same reasoning text-runs.js records
-       for inflating a HIT box rather than a visual one. */
-    #contact-tab-panel a {
-      display: flex; align-items: center; gap: 10px;
-      min-height: 40px; padding: 0 10px; border-radius: 9px;
-      color: var(--ink); font-size: 13px; font-weight: 600; text-decoration: none;
-    }
-    #contact-tab-panel a:hover { background: var(--bg); }
-    /* The handle is the quiet half: the platform is what you scan for, the
-       handle is what you check once you have found it. */
-    #contact-tab-panel a b { font-weight: 600; }
-    #contact-tab-panel a span { color: var(--muted); font-weight: 500; margin-left: auto; }
-    #contact-tab-panel a svg { width: 16px; height: 16px; flex: none; color: var(--muted); }
-    /* The owner row. Deliberately NOT an <a> — it is not a sixth channel, it
-       is the answer to "whose handles are these". */
-    #contact-tab-panel .ct-owner {
-      display: flex; align-items: center; gap: 10px;
-      padding: 4px 10px 8px; margin-bottom: 4px;
-      border-bottom: 1px solid var(--line);
-    }
-    #contact-tab-panel .ct-owner img { width: 32px; height: 32px; border-radius: 50%; object-fit: cover; flex: none; }
-    #contact-tab-panel .ct-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
-    #contact-tab-panel .ct-owner span { display: block; font-size: 11px; color: var(--muted); font-weight: 500; margin-left: 0; }
-    @media (prefers-reduced-motion: reduce) { #contact-tab-panel { transition: none; } }
+    #contact-tab-btn:hover { color: var(--ink); }
 
     /* ---- the landing (= the editor's empty state; design: draf 3b) ---- */
     /* Editor chrome yields while the landing is up; it has its own header. */
     body.is-empty header, body.is-empty #toolbar, body.is-empty #zoom-ctl,
-    body.is-empty #contact-tab-btn, body.is-empty #contact-tab-panel { display: none; }
+    body.is-empty #contact-tab-btn { display: none; }
     #empty {
       position: absolute; inset: 0; overflow-y: auto; overscroll-behavior: contain;
       /* The PAGE ground is white (ruled 2026-07-29). The body underneath is
@@ -1322,7 +1380,7 @@
     /* signature context strip ("Semua Hal.") */
     #sig-bar {
       display: none; align-items: center; gap: 8px; height: 46px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -1604,8 +1662,16 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>
     </button>
     <button id="btn-download" disabled>Unduh</button>
-  </header>
-
+    <!-- ⚠️ THE TOOLBAR LIVES INSIDE <header> (2026-09-09, his ruling: "buat
+         desktop, pindahin tools2nya ke atas. karena spacenya kosong").
+         It is ONE element in TWO layouts, never two elements:
+           wide  → it sits on the header's own row, between File and Unduh
+           narrow→ header wraps and it takes its own row, exactly as before
+         A sibling cannot be pulled into a flex row by CSS, so the DOM move is
+         what makes the wide layout possible at all. Placement is by `order`,
+         so the markup order here is not the reading order — see the header
+         rules in the stylesheet, and --chrome-h, which is what everything
+         positioned BELOW the chrome measures against. -->
   <div id="toolbar" role="toolbar" aria-label="Alat">
     <!-- No "Pilih" button (founder ruling 2026-07-19): the neutral mode is a
          STATE, not a tool — nothing lit means nothing armed. Every armed tool
@@ -1635,6 +1701,8 @@
       Halaman
     </button>
   </div>
+  </header>
+
 
   <div id="format-bar" role="toolbar" aria-label="Format teks"></div>
   <div id="sig-bar" role="toolbar" aria-label="Aksi tanda tangan">
@@ -1985,44 +2053,20 @@
     <button id="z-in" aria-label="Perbesar">+</button>
     <button id="z-out" aria-label="Perkecil">−</button>
   </div>
-  <!-- Contact bookmark: quiet furniture tab, bottom-left, mirrors #zoom-ctl.
-       Two separate elements (button + panel), not one wrapper — see the CSS
-       comment for why.
+  <!-- The feedback tab: quiet furniture, bottom-left, mirrors #zoom-ctl.
+       It used to be a chat glyph opening a panel of five social handles. He
+       retired both on 2026-09-09 — "ilangin semua sosmed gue, gaada yang
+       peduli wkwk, ganti jadi feedback form aja" — so the tab now says what it
+       does and opens the general feedback dialog (#fb-form) directly.
 
-       ⚠️ THE HANDLES ARE NOT INVENTED HERE AND MUST NOT BE. They come from
-       `engine/wiki/machine/public-identity.md`, which is the machine's one
-       home for them, and each is verified against fkd/loker's own shipped
-       Kontak dialog. A handle typed from memory is a live link to someone
-       else's account. If a channel is missing from the wiki it is missing
-       here too — that is the design, not an oversight.
+       ⚠️ THE HANDLES ARE NOT COMMENTED OUT AND MUST NOT BE RESTORED FROM HERE.
+       They live in `engine/wiki/machine/public-identity.md`, which is the
+       machine's one home for them; a handle typed from memory is a live link
+       to someone else's account. This surface simply no longer carries them.
 
-       ⚠️ THREADS AND X CAME FROM HIM, NOT FROM THE MACHINE (2026-08-23). He
-       asked for "semua sosmed gue... threads x instagram, cari aja" — and
-       they were not there: not in the wiki page, not in loker's dialog, not
-       anywhere under ~/machine. The Instagram handle made threads/@ojan.lubis
-       a good guess and it turned out correct, which is exactly why it was not
-       shipped as one: a guessed handle that happens to resolve is a live link
-       to a stranger's account until someone confirms whose it is. He supplied
-       both, they are now in the wiki, and the wiki is what a future session
-       reads. -->
-  <button id="contact-tab-btn" aria-expanded="false" aria-controls="contact-tab-panel"
-          aria-label="Kontak saya" title="Kontak saya">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 11.5a8.4 8.4 0 0 1-9 8.4 9 9 0 0 1-3.9-.9L3 20.5l1.5-4.5a8.4 8.4 0 0 1-.9-3.9 8.4 8.4 0 0 1 8.4-9 8.4 8.4 0 0 1 9 8.4Z"/></svg>
-  </button>
-  <div id="contact-tab-panel">
-    <!-- WHO the channels belong to. Added 2026-08-27: this panel listed five
-         handles and never said whose they were. Not a destination — a label on
-         the list below it. -->
-    <div class="ct-owner">
-      <img src="images/ojan.jpg" alt="Foto Ojan" width="32" height="32" loading="lazy">
-      <div><b>Ojan</b><span>Fauzan Ahladzikri</span></div>
-    </div>
-    <a href="https://tiktok.com/@okeojan" target="_blank" rel="noopener"><b>TikTok</b><span>@okeojan</span></a>
-    <a href="https://instagram.com/ojan.lubis" target="_blank" rel="noopener"><b>Instagram</b><span>ojan.lubis</span></a>
-    <a href="https://www.threads.com/@ojan.lubis" target="_blank" rel="noopener"><b>Threads</b><span>ojan.lubis</span></a>
-    <a href="https://x.com/okeojan" target="_blank" rel="noopener"><b>X</b><span>@okeojan</span></a>
-    <a href="https://ojanlubis.id" target="_blank" rel="noopener"><b>Website</b><span>ojanlubis.id</span></a>
-  </div>
+       Wired by js/v2/feedback-form.js, alongside the footer's own link — one
+       dialog, one code path, two doors. -->
+  <button id="contact-tab-btn">Ada masukan?</button>
   <div id="toast" role="status" aria-live="polite"></div>
 
   <!-- The general feedback channel, opened from the footer's "Ada masukan?".
@@ -2041,6 +2085,17 @@
     <div class="sheet fb-sheet">
       <div class="fb-body">
         <h2>Gimana PDFLokal?</h2>
+        <!-- WHO IS ASKING. Moved here 2026-09-09 from the retired contact
+             panel, where it labelled a list of handles. It is a BYLINE, not a
+             destination: the dialog's one primary is Kirim, and an identity
+             block competing with it would be a second thing to decide about
+             (design-discipline §2 — the ceiling counts destinations). Small,
+             muted, directly under the question so it answers "who am I writing
+             to" exactly when that occurs to someone. -->
+        <div class="fb-owner">
+          <img src="images/ojan.jpg" alt="" width="28" height="28" loading="lazy">
+          <div><b>Ojan</b><a href="https://mesindev.com" target="_blank" rel="noopener">mesindev.com</a></div>
+        </div>
         <div class="fb-thumbs" role="group" aria-label="Penilaian">
           <button type="button" id="fb-up" aria-pressed="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/></svg>

--- a/kompres-pdf-200kb.html
+++ b/kompres-pdf-200kb.html
@@ -377,6 +377,20 @@
     .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
     .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
 
+    /* The pasted screenshot, shown back at a size you can actually check. */
+    #fb-shot { position: relative; margin: 10px 0 0; }
+    #fb-shot img {
+      display: block; width: 100%; max-height: 180px; object-fit: contain;
+      border: 1px solid var(--line); border-radius: 8px; background: var(--bg);
+    }
+    #fb-shot-clear {
+      position: absolute; top: 6px; right: 6px;
+      width: 28px; height: 28px; border-radius: 8px; line-height: 1;
+      display: grid; place-items: center; font-size: 17px;
+      background: var(--surface); color: var(--ink);
+      box-shadow: 0 1px 6px rgba(0,0,0,.22);
+    }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -2106,7 +2120,20 @@
             <span>Kurang</span>
           </button>
         </div>
-        <textarea id="fb-note" rows="3" placeholder="boleh minta feedbacknya di sini, supaya kita bisa improve terus pdflokal. (boleh dikosongin juga kok)"></textarea>
+        <!-- PASTE, NOT UPLOAD (his ruling 2026-09-09: "gausah ada tombolnya,
+             bilang aja diplaceholdernya"). No attach button anywhere, and
+             nothing here ever reaches into the editor for pixels — the only
+             image that can exist is one the user deliberately pasted. That is
+             the whole reason this is defensible against the product's own "no
+             uploads" claim, so a convenience button would not be a small
+             addition, it would remove the argument. -->
+        <textarea id="fb-note" rows="3" placeholder="tulis feedbacknya di sini, atau boleh paste screenshot"></textarea>
+        <!-- The pasted image, shown back before it can be sent. A screenshot
+             the sender never saw is a screenshot they did not really choose. -->
+        <div id="fb-shot" hidden>
+          <img id="fb-shot-img" alt="">
+          <button type="button" id="fb-shot-clear" aria-label="Hapus">×</button>
+        </div>
         <div class="fb-row">
           <button type="button" id="fb-cancel">Batal</button>
           <button type="button" id="fb-send" disabled>Kirim</button>

--- a/kompres-pdf-500kb.html
+++ b/kompres-pdf-500kb.html
@@ -377,6 +377,20 @@
     .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
     .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
 
+    /* The pasted screenshot, shown back at a size you can actually check. */
+    #fb-shot { position: relative; margin: 10px 0 0; }
+    #fb-shot img {
+      display: block; width: 100%; max-height: 180px; object-fit: contain;
+      border: 1px solid var(--line); border-radius: 8px; background: var(--bg);
+    }
+    #fb-shot-clear {
+      position: absolute; top: 6px; right: 6px;
+      width: 28px; height: 28px; border-radius: 8px; line-height: 1;
+      display: grid; place-items: center; font-size: 17px;
+      background: var(--surface); color: var(--ink);
+      box-shadow: 0 1px 6px rgba(0,0,0,.22);
+    }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -2101,7 +2115,20 @@
             <span>Kurang</span>
           </button>
         </div>
-        <textarea id="fb-note" rows="3" placeholder="boleh minta feedbacknya di sini, supaya kita bisa improve terus pdflokal. (boleh dikosongin juga kok)"></textarea>
+        <!-- PASTE, NOT UPLOAD (his ruling 2026-09-09: "gausah ada tombolnya,
+             bilang aja diplaceholdernya"). No attach button anywhere, and
+             nothing here ever reaches into the editor for pixels — the only
+             image that can exist is one the user deliberately pasted. That is
+             the whole reason this is defensible against the product's own "no
+             uploads" claim, so a convenience button would not be a small
+             addition, it would remove the argument. -->
+        <textarea id="fb-note" rows="3" placeholder="tulis feedbacknya di sini, atau boleh paste screenshot"></textarea>
+        <!-- The pasted image, shown back before it can be sent. A screenshot
+             the sender never saw is a screenshot they did not really choose. -->
+        <div id="fb-shot" hidden>
+          <img id="fb-shot-img" alt="">
+          <button type="button" id="fb-shot-clear" aria-label="Hapus">×</button>
+        </div>
         <div class="fb-row">
           <button type="button" id="fb-cancel">Batal</button>
           <button type="button" id="fb-send" disabled>Kirim</button>

--- a/kompres-pdf-500kb.html
+++ b/kompres-pdf-500kb.html
@@ -287,6 +287,12 @@
          its own mode and page values must not be ported into it. A toolbar at
          --sp-48 is a toolbar that wastes the document's room. */
       --header-h: 44px; --toolbar-h: 52px;
+      /* THE HEIGHT EVERYTHING BELOW THE CHROME MEASURES AGAINST. It was
+         spelled `calc(var(--header-h) + var(--toolbar-h))` at each use site,
+         which stopped being true the moment the two could share a row. One
+         name, redefined once per breakpoint. */
+      --chrome-h: calc(var(--header-h) + var(--toolbar-h));
+      --header-merged-h: 52px;   /* the single-row height (tools are 36px + padding) */
     }
     /* Self-hosted fonts (preview parity with the PDF export) */
     @font-face { font-family: 'Montserrat'; src: url('fonts/montserrat-regular.woff2') format('woff2'); font-weight: 400; font-style: normal; font-display: swap; }
@@ -336,10 +342,17 @@
 
     /* ---- header ---- */
     header {
-      height: var(--header-h); flex: 0 0 auto;
+      min-height: var(--header-h); flex: 0 0 auto;
       display: flex; align-items: center; gap: 8px; padding: 0 10px;
-      background: var(--surface); border-bottom: 1px solid var(--line);
+      background: var(--surface);
+      /* WRAPS ON PURPOSE. Below the merge breakpoint the toolbar takes a full
+         row of its own; above it, everything stays on one line. No JS, no
+         second element, no duplicated tool buttons to keep in sync. */
+      flex-wrap: wrap;
     }
+    /* Narrow: the toolbar is a row of its own and carries the bottom edge, so
+       the header must NOT also draw one — two borders read as a seam. */
+    header > #toolbar { order: 9; flex: 1 0 100%; margin: 0 -10px; }
     .brand { font-weight: 700; font-size: 15px; letter-spacing: -.01em; }
     .brand-red { color: var(--accent); }
     /* home confirm: rides the standard dialog/.sheet system (the global
@@ -352,6 +365,18 @@
      * renders as a success. This system has one meaning for red and a second
      * colour meaning "good" is not being introduced here. */
     .fb-sheet { max-width: 380px; }
+    /* The byline under the question. Muted and small on purpose: it answers
+       "who am I writing to", it is not a place to go. The domain is the only
+       link, because it is the only one that leads anywhere useful. */
+    .fb-owner {
+      display: flex; align-items: center; gap: 9px;
+      margin: -2px 0 14px;
+    }
+    .fb-owner img { width: 28px; height: 28px; border-radius: 50%; object-fit: cover; flex: none; }
+    .fb-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
+    .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
+    .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -484,12 +509,73 @@
     }
     .tool.active { background: rgba(220,38,38,.08); color: var(--accent); }
 
+    /* ---- MERGED CHROME: one row when the width can hold it ---------------
+       His ruling 2026-09-09: "buat desktop, pindahin tools2nya ke atas. karena
+       spacenya kosong, cuma bikin dua baris navbar kalo spacenya ga cukup aja".
+       So the two-row layout is the FALLBACK, not the default.
+
+       ⚠️ THE BREAKPOINT IS MEASURED, NOT CHOSEN — 900px, 2026-09-09.
+       `.spacer { flex: 1 }` is the slack in this row, so its width IS the
+       headroom. Measured in Chromium: 152px of slack at 1000, 52 at 900, 12 at
+       860, and ZERO at 848. **848 is the true minimum**; 900 is that plus a
+       stated ~50px so the row never sits flush against its own ends, because a
+       row with no breathing room reads as broken even while it technically
+       fits. If a tool is added or a label reworded, RE-MEASURE — a stale
+       breakpoint shows up as a cramped row, never as an error.
+
+       ⚠️ AND THE GAUGE TOOK THREE TRIES, which is the part worth keeping.
+       Per-tool `scrollWidth` reported "fits" at every width down to 760, twice,
+       because the tools were not the element losing width. A third attempt
+       queried `#spacer` — it is a CLASS, so the query returned null and the
+       check passed on null. Only the fourth gauge, the spacer's own geometry
+       through a selector proven to match, showed a number that moved.
+       [[a-watcher-must-be-proven-to-fire]] is the sibling rule.
+
+       ⚠️ AND CHECK THE CEILING AT BOTH SIDES OF IT. design-discipline §2: a
+       band that holds three destinations at 1280 holds four at 375 without
+       anyone editing it. Here the count is unchanged either way — File, the
+       tool cluster (ONE destination, grouped), and Unduh (the one primary) —
+       which is the whole reason this merge is legitimate rather than a
+       fourth thing competing on one line. */
+    @media (min-width: 900px) {
+      :root { --chrome-h: var(--header-merged-h); }
+      header {
+        min-height: var(--header-merged-h); flex-wrap: nowrap;
+        border-bottom: 1px solid var(--line);
+      }
+      /* The flex spacer is what pushes Unduh right in the two-row layout. On
+         the merged row the TOOLBAR grows into that space instead and centres
+         its own children, so a second grower would fight it and shove the
+         tools off-centre. One grower per row. */
+      header > .spacer { display: none; }
+      header > #toolbar {
+        order: 3; flex: 1 1 auto; margin: 0;
+        height: auto; background: none; border-bottom: 0; padding: 0;
+        overflow: visible;
+      }
+      /* Undo/redo/Unduh sit AFTER the tools on the merged row. The markup has
+         the toolbar last (it was appended), so the order is stated here rather
+         than implied by the DOM. */
+      header > #btn-undo, header > #btn-redo, header > #btn-download { order: 5; }
+      /* Icon ABOVE label needs 52px of vertical room. On one shared row the
+         label moves BESIDE the icon — same target size, half the height. */
+      .tool {
+        flex-direction: row; gap: 6px;
+        min-width: 0; height: 36px; padding: 0 9px; font-size: 12.5px;
+      }
+      .tool svg { width: 17px; height: 17px; }
+      /* The BETA cap was corner-pinned so it could not widen a tight toolbar.
+         On the merged row there is room beside the word, and a corner chip on a
+         36px control overlaps its own label. */
+      .tool .beta-tag { position: static; margin-left: 1px; }
+    }
+
     /* ---- format bar: contextual, only when text is in play ---- */
     /* Contextual bars OVERLAY the canvas (founder: the document must never
        jump when a bar appears/disappears) — frosted so the page shows through. */
     #format-bar {
       display: none; align-items: center; gap: 6px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; height: 46px; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -623,61 +709,33 @@
        above was always claiming. The words survive as aria-label + title, so
        a screen reader and a desktop hover both still say "Kontak saya" — the
        label moved, it was not deleted. */
+    /* ⚠️ THE TAB SAYS WHAT IT DOES (2026-09-09, his ruling: "icon ini diganti
+       jadi kata2 aja ya 'ada masukan?'"). It was a chat glyph opening a panel
+       of five social handles; the handles are gone — "gaada yang peduli" — and
+       the glyph went with them, because an icon that has to be tapped to learn
+       its meaning fails his own element test (design-discipline §2).
+
+       AND THE PANEL IS GONE, NOT REPOINTED. Once the tab itself reads "Ada
+       masukan?", a panel whose only content was a button reading "Ada masukan?"
+       is a step that asks the same question twice. The tab opens #fb-form
+       directly. Whose product this is now lives INSIDE that dialog, where it
+       answers "who am I writing to" at the moment the question occurs.
+
+       The string is not new: it is the footer's, ratified 2026-08-22, and
+       reusing it keeps one name for one act (EXCLUDE 2 — copy is his). */
     #contact-tab-btn {
       position: fixed; left: 10px; bottom: 14px; z-index: 30;
-      width: 40px; height: 40px; border-radius: 12px;
-      display: grid; place-items: center;
+      min-height: 40px; padding: 0 14px; border-radius: 12px;
+      display: inline-flex; align-items: center;
       background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      color: var(--muted);
+      color: var(--muted); font-size: 13px; font-weight: 600;
     }
-    #contact-tab-btn svg { width: 19px; height: 19px; display: block; }
-    #contact-tab-panel {
-      position: fixed; left: 10px; bottom: 62px; z-index: 30;
-      width: max-content; max-width: min(78vw, 260px);
-      background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      border-radius: 12px; padding: 8px;
-      /* visibility (not just opacity): same reasoning as #support-card — a
-         dismissed panel must be GONE to hit-testing and screen readers. */
-      opacity: 0; visibility: hidden; pointer-events: none;
-      transform: translateY(10px); /* rests slightly low → reads as "slides up" on open */
-      transition: opacity .22s ease, transform .22s ease, visibility 0s linear .22s;
-    }
-    #contact-tab-panel.show {
-      opacity: 1; visibility: visible; pointer-events: auto;
-      transform: translateY(0); transition-delay: 0s;
-    }
-    /* One row per channel. min-height 40, not 44: this is a LIST inside an
-       already-opened panel, where rows are separated and mis-taps are cheap —
-       the 44 law guards isolated targets a finger hunts for, and the opening
-       tab is the one that has to meet it. Same reasoning text-runs.js records
-       for inflating a HIT box rather than a visual one. */
-    #contact-tab-panel a {
-      display: flex; align-items: center; gap: 10px;
-      min-height: 40px; padding: 0 10px; border-radius: 9px;
-      color: var(--ink); font-size: 13px; font-weight: 600; text-decoration: none;
-    }
-    #contact-tab-panel a:hover { background: var(--bg); }
-    /* The handle is the quiet half: the platform is what you scan for, the
-       handle is what you check once you have found it. */
-    #contact-tab-panel a b { font-weight: 600; }
-    #contact-tab-panel a span { color: var(--muted); font-weight: 500; margin-left: auto; }
-    #contact-tab-panel a svg { width: 16px; height: 16px; flex: none; color: var(--muted); }
-    /* The owner row. Deliberately NOT an <a> — it is not a sixth channel, it
-       is the answer to "whose handles are these". */
-    #contact-tab-panel .ct-owner {
-      display: flex; align-items: center; gap: 10px;
-      padding: 4px 10px 8px; margin-bottom: 4px;
-      border-bottom: 1px solid var(--line);
-    }
-    #contact-tab-panel .ct-owner img { width: 32px; height: 32px; border-radius: 50%; object-fit: cover; flex: none; }
-    #contact-tab-panel .ct-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
-    #contact-tab-panel .ct-owner span { display: block; font-size: 11px; color: var(--muted); font-weight: 500; margin-left: 0; }
-    @media (prefers-reduced-motion: reduce) { #contact-tab-panel { transition: none; } }
+    #contact-tab-btn:hover { color: var(--ink); }
 
     /* ---- the landing (= the editor's empty state; design: draf 3b) ---- */
     /* Editor chrome yields while the landing is up; it has its own header. */
     body.is-empty header, body.is-empty #toolbar, body.is-empty #zoom-ctl,
-    body.is-empty #contact-tab-btn, body.is-empty #contact-tab-panel { display: none; }
+    body.is-empty #contact-tab-btn { display: none; }
     #empty {
       position: absolute; inset: 0; overflow-y: auto; overscroll-behavior: contain;
       /* The PAGE ground is white (ruled 2026-07-29). The body underneath is
@@ -1322,7 +1380,7 @@
     /* signature context strip ("Semua Hal.") */
     #sig-bar {
       display: none; align-items: center; gap: 8px; height: 46px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -1604,8 +1662,16 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>
     </button>
     <button id="btn-download" disabled>Unduh</button>
-  </header>
-
+    <!-- ⚠️ THE TOOLBAR LIVES INSIDE <header> (2026-09-09, his ruling: "buat
+         desktop, pindahin tools2nya ke atas. karena spacenya kosong").
+         It is ONE element in TWO layouts, never two elements:
+           wide  → it sits on the header's own row, between File and Unduh
+           narrow→ header wraps and it takes its own row, exactly as before
+         A sibling cannot be pulled into a flex row by CSS, so the DOM move is
+         what makes the wide layout possible at all. Placement is by `order`,
+         so the markup order here is not the reading order — see the header
+         rules in the stylesheet, and --chrome-h, which is what everything
+         positioned BELOW the chrome measures against. -->
   <div id="toolbar" role="toolbar" aria-label="Alat">
     <!-- No "Pilih" button (founder ruling 2026-07-19): the neutral mode is a
          STATE, not a tool — nothing lit means nothing armed. Every armed tool
@@ -1635,6 +1701,8 @@
       Halaman
     </button>
   </div>
+  </header>
+
 
   <div id="format-bar" role="toolbar" aria-label="Format teks"></div>
   <div id="sig-bar" role="toolbar" aria-label="Aksi tanda tangan">
@@ -1980,44 +2048,20 @@
     <button id="z-in" aria-label="Perbesar">+</button>
     <button id="z-out" aria-label="Perkecil">−</button>
   </div>
-  <!-- Contact bookmark: quiet furniture tab, bottom-left, mirrors #zoom-ctl.
-       Two separate elements (button + panel), not one wrapper — see the CSS
-       comment for why.
+  <!-- The feedback tab: quiet furniture, bottom-left, mirrors #zoom-ctl.
+       It used to be a chat glyph opening a panel of five social handles. He
+       retired both on 2026-09-09 — "ilangin semua sosmed gue, gaada yang
+       peduli wkwk, ganti jadi feedback form aja" — so the tab now says what it
+       does and opens the general feedback dialog (#fb-form) directly.
 
-       ⚠️ THE HANDLES ARE NOT INVENTED HERE AND MUST NOT BE. They come from
-       `engine/wiki/machine/public-identity.md`, which is the machine's one
-       home for them, and each is verified against fkd/loker's own shipped
-       Kontak dialog. A handle typed from memory is a live link to someone
-       else's account. If a channel is missing from the wiki it is missing
-       here too — that is the design, not an oversight.
+       ⚠️ THE HANDLES ARE NOT COMMENTED OUT AND MUST NOT BE RESTORED FROM HERE.
+       They live in `engine/wiki/machine/public-identity.md`, which is the
+       machine's one home for them; a handle typed from memory is a live link
+       to someone else's account. This surface simply no longer carries them.
 
-       ⚠️ THREADS AND X CAME FROM HIM, NOT FROM THE MACHINE (2026-08-23). He
-       asked for "semua sosmed gue... threads x instagram, cari aja" — and
-       they were not there: not in the wiki page, not in loker's dialog, not
-       anywhere under ~/machine. The Instagram handle made threads/@ojan.lubis
-       a good guess and it turned out correct, which is exactly why it was not
-       shipped as one: a guessed handle that happens to resolve is a live link
-       to a stranger's account until someone confirms whose it is. He supplied
-       both, they are now in the wiki, and the wiki is what a future session
-       reads. -->
-  <button id="contact-tab-btn" aria-expanded="false" aria-controls="contact-tab-panel"
-          aria-label="Kontak saya" title="Kontak saya">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 11.5a8.4 8.4 0 0 1-9 8.4 9 9 0 0 1-3.9-.9L3 20.5l1.5-4.5a8.4 8.4 0 0 1-.9-3.9 8.4 8.4 0 0 1 8.4-9 8.4 8.4 0 0 1 9 8.4Z"/></svg>
-  </button>
-  <div id="contact-tab-panel">
-    <!-- WHO the channels belong to. Added 2026-08-27: this panel listed five
-         handles and never said whose they were. Not a destination — a label on
-         the list below it. -->
-    <div class="ct-owner">
-      <img src="images/ojan.jpg" alt="Foto Ojan" width="32" height="32" loading="lazy">
-      <div><b>Ojan</b><span>Fauzan Ahladzikri</span></div>
-    </div>
-    <a href="https://tiktok.com/@okeojan" target="_blank" rel="noopener"><b>TikTok</b><span>@okeojan</span></a>
-    <a href="https://instagram.com/ojan.lubis" target="_blank" rel="noopener"><b>Instagram</b><span>ojan.lubis</span></a>
-    <a href="https://www.threads.com/@ojan.lubis" target="_blank" rel="noopener"><b>Threads</b><span>ojan.lubis</span></a>
-    <a href="https://x.com/okeojan" target="_blank" rel="noopener"><b>X</b><span>@okeojan</span></a>
-    <a href="https://ojanlubis.id" target="_blank" rel="noopener"><b>Website</b><span>ojanlubis.id</span></a>
-  </div>
+       Wired by js/v2/feedback-form.js, alongside the footer's own link — one
+       dialog, one code path, two doors. -->
+  <button id="contact-tab-btn">Ada masukan?</button>
   <div id="toast" role="status" aria-live="polite"></div>
 
   <!-- The general feedback channel, opened from the footer's "Ada masukan?".
@@ -2036,6 +2080,17 @@
     <div class="sheet fb-sheet">
       <div class="fb-body">
         <h2>Gimana PDFLokal?</h2>
+        <!-- WHO IS ASKING. Moved here 2026-09-09 from the retired contact
+             panel, where it labelled a list of handles. It is a BYLINE, not a
+             destination: the dialog's one primary is Kirim, and an identity
+             block competing with it would be a second thing to decide about
+             (design-discipline §2 — the ceiling counts destinations). Small,
+             muted, directly under the question so it answers "who am I writing
+             to" exactly when that occurs to someone. -->
+        <div class="fb-owner">
+          <img src="images/ojan.jpg" alt="" width="28" height="28" loading="lazy">
+          <div><b>Ojan</b><a href="https://mesindev.com" target="_blank" rel="noopener">mesindev.com</a></div>
+        </div>
         <div class="fb-thumbs" role="group" aria-label="Penilaian">
           <button type="button" id="fb-up" aria-pressed="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/></svg>

--- a/kompres-pdf.html
+++ b/kompres-pdf.html
@@ -377,6 +377,20 @@
     .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
     .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
 
+    /* The pasted screenshot, shown back at a size you can actually check. */
+    #fb-shot { position: relative; margin: 10px 0 0; }
+    #fb-shot img {
+      display: block; width: 100%; max-height: 180px; object-fit: contain;
+      border: 1px solid var(--line); border-radius: 8px; background: var(--bg);
+    }
+    #fb-shot-clear {
+      position: absolute; top: 6px; right: 6px;
+      width: 28px; height: 28px; border-radius: 8px; line-height: 1;
+      display: grid; place-items: center; font-size: 17px;
+      background: var(--surface); color: var(--ink);
+      box-shadow: 0 1px 6px rgba(0,0,0,.22);
+    }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -2122,7 +2136,20 @@
             <span>Kurang</span>
           </button>
         </div>
-        <textarea id="fb-note" rows="3" placeholder="boleh minta feedbacknya di sini, supaya kita bisa improve terus pdflokal. (boleh dikosongin juga kok)"></textarea>
+        <!-- PASTE, NOT UPLOAD (his ruling 2026-09-09: "gausah ada tombolnya,
+             bilang aja diplaceholdernya"). No attach button anywhere, and
+             nothing here ever reaches into the editor for pixels — the only
+             image that can exist is one the user deliberately pasted. That is
+             the whole reason this is defensible against the product's own "no
+             uploads" claim, so a convenience button would not be a small
+             addition, it would remove the argument. -->
+        <textarea id="fb-note" rows="3" placeholder="tulis feedbacknya di sini, atau boleh paste screenshot"></textarea>
+        <!-- The pasted image, shown back before it can be sent. A screenshot
+             the sender never saw is a screenshot they did not really choose. -->
+        <div id="fb-shot" hidden>
+          <img id="fb-shot-img" alt="">
+          <button type="button" id="fb-shot-clear" aria-label="Hapus">×</button>
+        </div>
         <div class="fb-row">
           <button type="button" id="fb-cancel">Batal</button>
           <button type="button" id="fb-send" disabled>Kirim</button>

--- a/kompres-pdf.html
+++ b/kompres-pdf.html
@@ -287,6 +287,12 @@
          its own mode and page values must not be ported into it. A toolbar at
          --sp-48 is a toolbar that wastes the document's room. */
       --header-h: 44px; --toolbar-h: 52px;
+      /* THE HEIGHT EVERYTHING BELOW THE CHROME MEASURES AGAINST. It was
+         spelled `calc(var(--header-h) + var(--toolbar-h))` at each use site,
+         which stopped being true the moment the two could share a row. One
+         name, redefined once per breakpoint. */
+      --chrome-h: calc(var(--header-h) + var(--toolbar-h));
+      --header-merged-h: 52px;   /* the single-row height (tools are 36px + padding) */
     }
     /* Self-hosted fonts (preview parity with the PDF export) */
     @font-face { font-family: 'Montserrat'; src: url('fonts/montserrat-regular.woff2') format('woff2'); font-weight: 400; font-style: normal; font-display: swap; }
@@ -336,10 +342,17 @@
 
     /* ---- header ---- */
     header {
-      height: var(--header-h); flex: 0 0 auto;
+      min-height: var(--header-h); flex: 0 0 auto;
       display: flex; align-items: center; gap: 8px; padding: 0 10px;
-      background: var(--surface); border-bottom: 1px solid var(--line);
+      background: var(--surface);
+      /* WRAPS ON PURPOSE. Below the merge breakpoint the toolbar takes a full
+         row of its own; above it, everything stays on one line. No JS, no
+         second element, no duplicated tool buttons to keep in sync. */
+      flex-wrap: wrap;
     }
+    /* Narrow: the toolbar is a row of its own and carries the bottom edge, so
+       the header must NOT also draw one — two borders read as a seam. */
+    header > #toolbar { order: 9; flex: 1 0 100%; margin: 0 -10px; }
     .brand { font-weight: 700; font-size: 15px; letter-spacing: -.01em; }
     .brand-red { color: var(--accent); }
     /* home confirm: rides the standard dialog/.sheet system (the global
@@ -352,6 +365,18 @@
      * renders as a success. This system has one meaning for red and a second
      * colour meaning "good" is not being introduced here. */
     .fb-sheet { max-width: 380px; }
+    /* The byline under the question. Muted and small on purpose: it answers
+       "who am I writing to", it is not a place to go. The domain is the only
+       link, because it is the only one that leads anywhere useful. */
+    .fb-owner {
+      display: flex; align-items: center; gap: 9px;
+      margin: -2px 0 14px;
+    }
+    .fb-owner img { width: 28px; height: 28px; border-radius: 50%; object-fit: cover; flex: none; }
+    .fb-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
+    .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
+    .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -484,12 +509,73 @@
     }
     .tool.active { background: rgba(220,38,38,.08); color: var(--accent); }
 
+    /* ---- MERGED CHROME: one row when the width can hold it ---------------
+       His ruling 2026-09-09: "buat desktop, pindahin tools2nya ke atas. karena
+       spacenya kosong, cuma bikin dua baris navbar kalo spacenya ga cukup aja".
+       So the two-row layout is the FALLBACK, not the default.
+
+       ⚠️ THE BREAKPOINT IS MEASURED, NOT CHOSEN — 900px, 2026-09-09.
+       `.spacer { flex: 1 }` is the slack in this row, so its width IS the
+       headroom. Measured in Chromium: 152px of slack at 1000, 52 at 900, 12 at
+       860, and ZERO at 848. **848 is the true minimum**; 900 is that plus a
+       stated ~50px so the row never sits flush against its own ends, because a
+       row with no breathing room reads as broken even while it technically
+       fits. If a tool is added or a label reworded, RE-MEASURE — a stale
+       breakpoint shows up as a cramped row, never as an error.
+
+       ⚠️ AND THE GAUGE TOOK THREE TRIES, which is the part worth keeping.
+       Per-tool `scrollWidth` reported "fits" at every width down to 760, twice,
+       because the tools were not the element losing width. A third attempt
+       queried `#spacer` — it is a CLASS, so the query returned null and the
+       check passed on null. Only the fourth gauge, the spacer's own geometry
+       through a selector proven to match, showed a number that moved.
+       [[a-watcher-must-be-proven-to-fire]] is the sibling rule.
+
+       ⚠️ AND CHECK THE CEILING AT BOTH SIDES OF IT. design-discipline §2: a
+       band that holds three destinations at 1280 holds four at 375 without
+       anyone editing it. Here the count is unchanged either way — File, the
+       tool cluster (ONE destination, grouped), and Unduh (the one primary) —
+       which is the whole reason this merge is legitimate rather than a
+       fourth thing competing on one line. */
+    @media (min-width: 900px) {
+      :root { --chrome-h: var(--header-merged-h); }
+      header {
+        min-height: var(--header-merged-h); flex-wrap: nowrap;
+        border-bottom: 1px solid var(--line);
+      }
+      /* The flex spacer is what pushes Unduh right in the two-row layout. On
+         the merged row the TOOLBAR grows into that space instead and centres
+         its own children, so a second grower would fight it and shove the
+         tools off-centre. One grower per row. */
+      header > .spacer { display: none; }
+      header > #toolbar {
+        order: 3; flex: 1 1 auto; margin: 0;
+        height: auto; background: none; border-bottom: 0; padding: 0;
+        overflow: visible;
+      }
+      /* Undo/redo/Unduh sit AFTER the tools on the merged row. The markup has
+         the toolbar last (it was appended), so the order is stated here rather
+         than implied by the DOM. */
+      header > #btn-undo, header > #btn-redo, header > #btn-download { order: 5; }
+      /* Icon ABOVE label needs 52px of vertical room. On one shared row the
+         label moves BESIDE the icon — same target size, half the height. */
+      .tool {
+        flex-direction: row; gap: 6px;
+        min-width: 0; height: 36px; padding: 0 9px; font-size: 12.5px;
+      }
+      .tool svg { width: 17px; height: 17px; }
+      /* The BETA cap was corner-pinned so it could not widen a tight toolbar.
+         On the merged row there is room beside the word, and a corner chip on a
+         36px control overlaps its own label. */
+      .tool .beta-tag { position: static; margin-left: 1px; }
+    }
+
     /* ---- format bar: contextual, only when text is in play ---- */
     /* Contextual bars OVERLAY the canvas (founder: the document must never
        jump when a bar appears/disappears) — frosted so the page shows through. */
     #format-bar {
       display: none; align-items: center; gap: 6px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; height: 46px; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -623,61 +709,33 @@
        above was always claiming. The words survive as aria-label + title, so
        a screen reader and a desktop hover both still say "Kontak saya" — the
        label moved, it was not deleted. */
+    /* ⚠️ THE TAB SAYS WHAT IT DOES (2026-09-09, his ruling: "icon ini diganti
+       jadi kata2 aja ya 'ada masukan?'"). It was a chat glyph opening a panel
+       of five social handles; the handles are gone — "gaada yang peduli" — and
+       the glyph went with them, because an icon that has to be tapped to learn
+       its meaning fails his own element test (design-discipline §2).
+
+       AND THE PANEL IS GONE, NOT REPOINTED. Once the tab itself reads "Ada
+       masukan?", a panel whose only content was a button reading "Ada masukan?"
+       is a step that asks the same question twice. The tab opens #fb-form
+       directly. Whose product this is now lives INSIDE that dialog, where it
+       answers "who am I writing to" at the moment the question occurs.
+
+       The string is not new: it is the footer's, ratified 2026-08-22, and
+       reusing it keeps one name for one act (EXCLUDE 2 — copy is his). */
     #contact-tab-btn {
       position: fixed; left: 10px; bottom: 14px; z-index: 30;
-      width: 40px; height: 40px; border-radius: 12px;
-      display: grid; place-items: center;
+      min-height: 40px; padding: 0 14px; border-radius: 12px;
+      display: inline-flex; align-items: center;
       background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      color: var(--muted);
+      color: var(--muted); font-size: 13px; font-weight: 600;
     }
-    #contact-tab-btn svg { width: 19px; height: 19px; display: block; }
-    #contact-tab-panel {
-      position: fixed; left: 10px; bottom: 62px; z-index: 30;
-      width: max-content; max-width: min(78vw, 260px);
-      background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      border-radius: 12px; padding: 8px;
-      /* visibility (not just opacity): same reasoning as #support-card — a
-         dismissed panel must be GONE to hit-testing and screen readers. */
-      opacity: 0; visibility: hidden; pointer-events: none;
-      transform: translateY(10px); /* rests slightly low → reads as "slides up" on open */
-      transition: opacity .22s ease, transform .22s ease, visibility 0s linear .22s;
-    }
-    #contact-tab-panel.show {
-      opacity: 1; visibility: visible; pointer-events: auto;
-      transform: translateY(0); transition-delay: 0s;
-    }
-    /* One row per channel. min-height 40, not 44: this is a LIST inside an
-       already-opened panel, where rows are separated and mis-taps are cheap —
-       the 44 law guards isolated targets a finger hunts for, and the opening
-       tab is the one that has to meet it. Same reasoning text-runs.js records
-       for inflating a HIT box rather than a visual one. */
-    #contact-tab-panel a {
-      display: flex; align-items: center; gap: 10px;
-      min-height: 40px; padding: 0 10px; border-radius: 9px;
-      color: var(--ink); font-size: 13px; font-weight: 600; text-decoration: none;
-    }
-    #contact-tab-panel a:hover { background: var(--bg); }
-    /* The handle is the quiet half: the platform is what you scan for, the
-       handle is what you check once you have found it. */
-    #contact-tab-panel a b { font-weight: 600; }
-    #contact-tab-panel a span { color: var(--muted); font-weight: 500; margin-left: auto; }
-    #contact-tab-panel a svg { width: 16px; height: 16px; flex: none; color: var(--muted); }
-    /* The owner row. Deliberately NOT an <a> — it is not a sixth channel, it
-       is the answer to "whose handles are these". */
-    #contact-tab-panel .ct-owner {
-      display: flex; align-items: center; gap: 10px;
-      padding: 4px 10px 8px; margin-bottom: 4px;
-      border-bottom: 1px solid var(--line);
-    }
-    #contact-tab-panel .ct-owner img { width: 32px; height: 32px; border-radius: 50%; object-fit: cover; flex: none; }
-    #contact-tab-panel .ct-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
-    #contact-tab-panel .ct-owner span { display: block; font-size: 11px; color: var(--muted); font-weight: 500; margin-left: 0; }
-    @media (prefers-reduced-motion: reduce) { #contact-tab-panel { transition: none; } }
+    #contact-tab-btn:hover { color: var(--ink); }
 
     /* ---- the landing (= the editor's empty state; design: draf 3b) ---- */
     /* Editor chrome yields while the landing is up; it has its own header. */
     body.is-empty header, body.is-empty #toolbar, body.is-empty #zoom-ctl,
-    body.is-empty #contact-tab-btn, body.is-empty #contact-tab-panel { display: none; }
+    body.is-empty #contact-tab-btn { display: none; }
     #empty {
       position: absolute; inset: 0; overflow-y: auto; overscroll-behavior: contain;
       /* The PAGE ground is white (ruled 2026-07-29). The body underneath is
@@ -1322,7 +1380,7 @@
     /* signature context strip ("Semua Hal.") */
     #sig-bar {
       display: none; align-items: center; gap: 8px; height: 46px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -1604,8 +1662,16 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>
     </button>
     <button id="btn-download" disabled>Unduh</button>
-  </header>
-
+    <!-- ⚠️ THE TOOLBAR LIVES INSIDE <header> (2026-09-09, his ruling: "buat
+         desktop, pindahin tools2nya ke atas. karena spacenya kosong").
+         It is ONE element in TWO layouts, never two elements:
+           wide  → it sits on the header's own row, between File and Unduh
+           narrow→ header wraps and it takes its own row, exactly as before
+         A sibling cannot be pulled into a flex row by CSS, so the DOM move is
+         what makes the wide layout possible at all. Placement is by `order`,
+         so the markup order here is not the reading order — see the header
+         rules in the stylesheet, and --chrome-h, which is what everything
+         positioned BELOW the chrome measures against. -->
   <div id="toolbar" role="toolbar" aria-label="Alat">
     <!-- No "Pilih" button (founder ruling 2026-07-19): the neutral mode is a
          STATE, not a tool — nothing lit means nothing armed. Every armed tool
@@ -1635,6 +1701,8 @@
       Halaman
     </button>
   </div>
+  </header>
+
 
   <div id="format-bar" role="toolbar" aria-label="Format teks"></div>
   <div id="sig-bar" role="toolbar" aria-label="Aksi tanda tangan">
@@ -2001,44 +2069,20 @@
     <button id="z-in" aria-label="Perbesar">+</button>
     <button id="z-out" aria-label="Perkecil">−</button>
   </div>
-  <!-- Contact bookmark: quiet furniture tab, bottom-left, mirrors #zoom-ctl.
-       Two separate elements (button + panel), not one wrapper — see the CSS
-       comment for why.
+  <!-- The feedback tab: quiet furniture, bottom-left, mirrors #zoom-ctl.
+       It used to be a chat glyph opening a panel of five social handles. He
+       retired both on 2026-09-09 — "ilangin semua sosmed gue, gaada yang
+       peduli wkwk, ganti jadi feedback form aja" — so the tab now says what it
+       does and opens the general feedback dialog (#fb-form) directly.
 
-       ⚠️ THE HANDLES ARE NOT INVENTED HERE AND MUST NOT BE. They come from
-       `engine/wiki/machine/public-identity.md`, which is the machine's one
-       home for them, and each is verified against fkd/loker's own shipped
-       Kontak dialog. A handle typed from memory is a live link to someone
-       else's account. If a channel is missing from the wiki it is missing
-       here too — that is the design, not an oversight.
+       ⚠️ THE HANDLES ARE NOT COMMENTED OUT AND MUST NOT BE RESTORED FROM HERE.
+       They live in `engine/wiki/machine/public-identity.md`, which is the
+       machine's one home for them; a handle typed from memory is a live link
+       to someone else's account. This surface simply no longer carries them.
 
-       ⚠️ THREADS AND X CAME FROM HIM, NOT FROM THE MACHINE (2026-08-23). He
-       asked for "semua sosmed gue... threads x instagram, cari aja" — and
-       they were not there: not in the wiki page, not in loker's dialog, not
-       anywhere under ~/machine. The Instagram handle made threads/@ojan.lubis
-       a good guess and it turned out correct, which is exactly why it was not
-       shipped as one: a guessed handle that happens to resolve is a live link
-       to a stranger's account until someone confirms whose it is. He supplied
-       both, they are now in the wiki, and the wiki is what a future session
-       reads. -->
-  <button id="contact-tab-btn" aria-expanded="false" aria-controls="contact-tab-panel"
-          aria-label="Kontak saya" title="Kontak saya">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 11.5a8.4 8.4 0 0 1-9 8.4 9 9 0 0 1-3.9-.9L3 20.5l1.5-4.5a8.4 8.4 0 0 1-.9-3.9 8.4 8.4 0 0 1 8.4-9 8.4 8.4 0 0 1 9 8.4Z"/></svg>
-  </button>
-  <div id="contact-tab-panel">
-    <!-- WHO the channels belong to. Added 2026-08-27: this panel listed five
-         handles and never said whose they were. Not a destination — a label on
-         the list below it. -->
-    <div class="ct-owner">
-      <img src="images/ojan.jpg" alt="Foto Ojan" width="32" height="32" loading="lazy">
-      <div><b>Ojan</b><span>Fauzan Ahladzikri</span></div>
-    </div>
-    <a href="https://tiktok.com/@okeojan" target="_blank" rel="noopener"><b>TikTok</b><span>@okeojan</span></a>
-    <a href="https://instagram.com/ojan.lubis" target="_blank" rel="noopener"><b>Instagram</b><span>ojan.lubis</span></a>
-    <a href="https://www.threads.com/@ojan.lubis" target="_blank" rel="noopener"><b>Threads</b><span>ojan.lubis</span></a>
-    <a href="https://x.com/okeojan" target="_blank" rel="noopener"><b>X</b><span>@okeojan</span></a>
-    <a href="https://ojanlubis.id" target="_blank" rel="noopener"><b>Website</b><span>ojanlubis.id</span></a>
-  </div>
+       Wired by js/v2/feedback-form.js, alongside the footer's own link — one
+       dialog, one code path, two doors. -->
+  <button id="contact-tab-btn">Ada masukan?</button>
   <div id="toast" role="status" aria-live="polite"></div>
 
   <!-- The general feedback channel, opened from the footer's "Ada masukan?".
@@ -2057,6 +2101,17 @@
     <div class="sheet fb-sheet">
       <div class="fb-body">
         <h2>Gimana PDFLokal?</h2>
+        <!-- WHO IS ASKING. Moved here 2026-09-09 from the retired contact
+             panel, where it labelled a list of handles. It is a BYLINE, not a
+             destination: the dialog's one primary is Kirim, and an identity
+             block competing with it would be a second thing to decide about
+             (design-discipline §2 — the ceiling counts destinations). Small,
+             muted, directly under the question so it answers "who am I writing
+             to" exactly when that occurs to someone. -->
+        <div class="fb-owner">
+          <img src="images/ojan.jpg" alt="" width="28" height="28" loading="lazy">
+          <div><b>Ojan</b><a href="https://mesindev.com" target="_blank" rel="noopener">mesindev.com</a></div>
+        </div>
         <div class="fb-thumbs" role="group" aria-label="Penilaian">
           <button type="button" id="fb-up" aria-pressed="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/></svg>

--- a/pdf-ke-jpg.html
+++ b/pdf-ke-jpg.html
@@ -287,6 +287,12 @@
          its own mode and page values must not be ported into it. A toolbar at
          --sp-48 is a toolbar that wastes the document's room. */
       --header-h: 44px; --toolbar-h: 52px;
+      /* THE HEIGHT EVERYTHING BELOW THE CHROME MEASURES AGAINST. It was
+         spelled `calc(var(--header-h) + var(--toolbar-h))` at each use site,
+         which stopped being true the moment the two could share a row. One
+         name, redefined once per breakpoint. */
+      --chrome-h: calc(var(--header-h) + var(--toolbar-h));
+      --header-merged-h: 52px;   /* the single-row height (tools are 36px + padding) */
     }
     /* Self-hosted fonts (preview parity with the PDF export) */
     @font-face { font-family: 'Montserrat'; src: url('fonts/montserrat-regular.woff2') format('woff2'); font-weight: 400; font-style: normal; font-display: swap; }
@@ -336,10 +342,17 @@
 
     /* ---- header ---- */
     header {
-      height: var(--header-h); flex: 0 0 auto;
+      min-height: var(--header-h); flex: 0 0 auto;
       display: flex; align-items: center; gap: 8px; padding: 0 10px;
-      background: var(--surface); border-bottom: 1px solid var(--line);
+      background: var(--surface);
+      /* WRAPS ON PURPOSE. Below the merge breakpoint the toolbar takes a full
+         row of its own; above it, everything stays on one line. No JS, no
+         second element, no duplicated tool buttons to keep in sync. */
+      flex-wrap: wrap;
     }
+    /* Narrow: the toolbar is a row of its own and carries the bottom edge, so
+       the header must NOT also draw one — two borders read as a seam. */
+    header > #toolbar { order: 9; flex: 1 0 100%; margin: 0 -10px; }
     .brand { font-weight: 700; font-size: 15px; letter-spacing: -.01em; }
     .brand-red { color: var(--accent); }
     /* home confirm: rides the standard dialog/.sheet system (the global
@@ -352,6 +365,18 @@
      * renders as a success. This system has one meaning for red and a second
      * colour meaning "good" is not being introduced here. */
     .fb-sheet { max-width: 380px; }
+    /* The byline under the question. Muted and small on purpose: it answers
+       "who am I writing to", it is not a place to go. The domain is the only
+       link, because it is the only one that leads anywhere useful. */
+    .fb-owner {
+      display: flex; align-items: center; gap: 9px;
+      margin: -2px 0 14px;
+    }
+    .fb-owner img { width: 28px; height: 28px; border-radius: 50%; object-fit: cover; flex: none; }
+    .fb-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
+    .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
+    .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -484,12 +509,73 @@
     }
     .tool.active { background: rgba(220,38,38,.08); color: var(--accent); }
 
+    /* ---- MERGED CHROME: one row when the width can hold it ---------------
+       His ruling 2026-09-09: "buat desktop, pindahin tools2nya ke atas. karena
+       spacenya kosong, cuma bikin dua baris navbar kalo spacenya ga cukup aja".
+       So the two-row layout is the FALLBACK, not the default.
+
+       ⚠️ THE BREAKPOINT IS MEASURED, NOT CHOSEN — 900px, 2026-09-09.
+       `.spacer { flex: 1 }` is the slack in this row, so its width IS the
+       headroom. Measured in Chromium: 152px of slack at 1000, 52 at 900, 12 at
+       860, and ZERO at 848. **848 is the true minimum**; 900 is that plus a
+       stated ~50px so the row never sits flush against its own ends, because a
+       row with no breathing room reads as broken even while it technically
+       fits. If a tool is added or a label reworded, RE-MEASURE — a stale
+       breakpoint shows up as a cramped row, never as an error.
+
+       ⚠️ AND THE GAUGE TOOK THREE TRIES, which is the part worth keeping.
+       Per-tool `scrollWidth` reported "fits" at every width down to 760, twice,
+       because the tools were not the element losing width. A third attempt
+       queried `#spacer` — it is a CLASS, so the query returned null and the
+       check passed on null. Only the fourth gauge, the spacer's own geometry
+       through a selector proven to match, showed a number that moved.
+       [[a-watcher-must-be-proven-to-fire]] is the sibling rule.
+
+       ⚠️ AND CHECK THE CEILING AT BOTH SIDES OF IT. design-discipline §2: a
+       band that holds three destinations at 1280 holds four at 375 without
+       anyone editing it. Here the count is unchanged either way — File, the
+       tool cluster (ONE destination, grouped), and Unduh (the one primary) —
+       which is the whole reason this merge is legitimate rather than a
+       fourth thing competing on one line. */
+    @media (min-width: 900px) {
+      :root { --chrome-h: var(--header-merged-h); }
+      header {
+        min-height: var(--header-merged-h); flex-wrap: nowrap;
+        border-bottom: 1px solid var(--line);
+      }
+      /* The flex spacer is what pushes Unduh right in the two-row layout. On
+         the merged row the TOOLBAR grows into that space instead and centres
+         its own children, so a second grower would fight it and shove the
+         tools off-centre. One grower per row. */
+      header > .spacer { display: none; }
+      header > #toolbar {
+        order: 3; flex: 1 1 auto; margin: 0;
+        height: auto; background: none; border-bottom: 0; padding: 0;
+        overflow: visible;
+      }
+      /* Undo/redo/Unduh sit AFTER the tools on the merged row. The markup has
+         the toolbar last (it was appended), so the order is stated here rather
+         than implied by the DOM. */
+      header > #btn-undo, header > #btn-redo, header > #btn-download { order: 5; }
+      /* Icon ABOVE label needs 52px of vertical room. On one shared row the
+         label moves BESIDE the icon — same target size, half the height. */
+      .tool {
+        flex-direction: row; gap: 6px;
+        min-width: 0; height: 36px; padding: 0 9px; font-size: 12.5px;
+      }
+      .tool svg { width: 17px; height: 17px; }
+      /* The BETA cap was corner-pinned so it could not widen a tight toolbar.
+         On the merged row there is room beside the word, and a corner chip on a
+         36px control overlaps its own label. */
+      .tool .beta-tag { position: static; margin-left: 1px; }
+    }
+
     /* ---- format bar: contextual, only when text is in play ---- */
     /* Contextual bars OVERLAY the canvas (founder: the document must never
        jump when a bar appears/disappears) — frosted so the page shows through. */
     #format-bar {
       display: none; align-items: center; gap: 6px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; height: 46px; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -623,61 +709,33 @@
        above was always claiming. The words survive as aria-label + title, so
        a screen reader and a desktop hover both still say "Kontak saya" — the
        label moved, it was not deleted. */
+    /* ⚠️ THE TAB SAYS WHAT IT DOES (2026-09-09, his ruling: "icon ini diganti
+       jadi kata2 aja ya 'ada masukan?'"). It was a chat glyph opening a panel
+       of five social handles; the handles are gone — "gaada yang peduli" — and
+       the glyph went with them, because an icon that has to be tapped to learn
+       its meaning fails his own element test (design-discipline §2).
+
+       AND THE PANEL IS GONE, NOT REPOINTED. Once the tab itself reads "Ada
+       masukan?", a panel whose only content was a button reading "Ada masukan?"
+       is a step that asks the same question twice. The tab opens #fb-form
+       directly. Whose product this is now lives INSIDE that dialog, where it
+       answers "who am I writing to" at the moment the question occurs.
+
+       The string is not new: it is the footer's, ratified 2026-08-22, and
+       reusing it keeps one name for one act (EXCLUDE 2 — copy is his). */
     #contact-tab-btn {
       position: fixed; left: 10px; bottom: 14px; z-index: 30;
-      width: 40px; height: 40px; border-radius: 12px;
-      display: grid; place-items: center;
+      min-height: 40px; padding: 0 14px; border-radius: 12px;
+      display: inline-flex; align-items: center;
       background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      color: var(--muted);
+      color: var(--muted); font-size: 13px; font-weight: 600;
     }
-    #contact-tab-btn svg { width: 19px; height: 19px; display: block; }
-    #contact-tab-panel {
-      position: fixed; left: 10px; bottom: 62px; z-index: 30;
-      width: max-content; max-width: min(78vw, 260px);
-      background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      border-radius: 12px; padding: 8px;
-      /* visibility (not just opacity): same reasoning as #support-card — a
-         dismissed panel must be GONE to hit-testing and screen readers. */
-      opacity: 0; visibility: hidden; pointer-events: none;
-      transform: translateY(10px); /* rests slightly low → reads as "slides up" on open */
-      transition: opacity .22s ease, transform .22s ease, visibility 0s linear .22s;
-    }
-    #contact-tab-panel.show {
-      opacity: 1; visibility: visible; pointer-events: auto;
-      transform: translateY(0); transition-delay: 0s;
-    }
-    /* One row per channel. min-height 40, not 44: this is a LIST inside an
-       already-opened panel, where rows are separated and mis-taps are cheap —
-       the 44 law guards isolated targets a finger hunts for, and the opening
-       tab is the one that has to meet it. Same reasoning text-runs.js records
-       for inflating a HIT box rather than a visual one. */
-    #contact-tab-panel a {
-      display: flex; align-items: center; gap: 10px;
-      min-height: 40px; padding: 0 10px; border-radius: 9px;
-      color: var(--ink); font-size: 13px; font-weight: 600; text-decoration: none;
-    }
-    #contact-tab-panel a:hover { background: var(--bg); }
-    /* The handle is the quiet half: the platform is what you scan for, the
-       handle is what you check once you have found it. */
-    #contact-tab-panel a b { font-weight: 600; }
-    #contact-tab-panel a span { color: var(--muted); font-weight: 500; margin-left: auto; }
-    #contact-tab-panel a svg { width: 16px; height: 16px; flex: none; color: var(--muted); }
-    /* The owner row. Deliberately NOT an <a> — it is not a sixth channel, it
-       is the answer to "whose handles are these". */
-    #contact-tab-panel .ct-owner {
-      display: flex; align-items: center; gap: 10px;
-      padding: 4px 10px 8px; margin-bottom: 4px;
-      border-bottom: 1px solid var(--line);
-    }
-    #contact-tab-panel .ct-owner img { width: 32px; height: 32px; border-radius: 50%; object-fit: cover; flex: none; }
-    #contact-tab-panel .ct-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
-    #contact-tab-panel .ct-owner span { display: block; font-size: 11px; color: var(--muted); font-weight: 500; margin-left: 0; }
-    @media (prefers-reduced-motion: reduce) { #contact-tab-panel { transition: none; } }
+    #contact-tab-btn:hover { color: var(--ink); }
 
     /* ---- the landing (= the editor's empty state; design: draf 3b) ---- */
     /* Editor chrome yields while the landing is up; it has its own header. */
     body.is-empty header, body.is-empty #toolbar, body.is-empty #zoom-ctl,
-    body.is-empty #contact-tab-btn, body.is-empty #contact-tab-panel { display: none; }
+    body.is-empty #contact-tab-btn { display: none; }
     #empty {
       position: absolute; inset: 0; overflow-y: auto; overscroll-behavior: contain;
       /* The PAGE ground is white (ruled 2026-07-29). The body underneath is
@@ -1322,7 +1380,7 @@
     /* signature context strip ("Semua Hal.") */
     #sig-bar {
       display: none; align-items: center; gap: 8px; height: 46px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -1604,8 +1662,16 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>
     </button>
     <button id="btn-download" disabled>Unduh</button>
-  </header>
-
+    <!-- ⚠️ THE TOOLBAR LIVES INSIDE <header> (2026-09-09, his ruling: "buat
+         desktop, pindahin tools2nya ke atas. karena spacenya kosong").
+         It is ONE element in TWO layouts, never two elements:
+           wide  → it sits on the header's own row, between File and Unduh
+           narrow→ header wraps and it takes its own row, exactly as before
+         A sibling cannot be pulled into a flex row by CSS, so the DOM move is
+         what makes the wide layout possible at all. Placement is by `order`,
+         so the markup order here is not the reading order — see the header
+         rules in the stylesheet, and --chrome-h, which is what everything
+         positioned BELOW the chrome measures against. -->
   <div id="toolbar" role="toolbar" aria-label="Alat">
     <!-- No "Pilih" button (founder ruling 2026-07-19): the neutral mode is a
          STATE, not a tool — nothing lit means nothing armed. Every armed tool
@@ -1635,6 +1701,8 @@
       Halaman
     </button>
   </div>
+  </header>
+
 
   <div id="format-bar" role="toolbar" aria-label="Format teks"></div>
   <div id="sig-bar" role="toolbar" aria-label="Aksi tanda tangan">
@@ -1993,44 +2061,20 @@
     <button id="z-in" aria-label="Perbesar">+</button>
     <button id="z-out" aria-label="Perkecil">−</button>
   </div>
-  <!-- Contact bookmark: quiet furniture tab, bottom-left, mirrors #zoom-ctl.
-       Two separate elements (button + panel), not one wrapper — see the CSS
-       comment for why.
+  <!-- The feedback tab: quiet furniture, bottom-left, mirrors #zoom-ctl.
+       It used to be a chat glyph opening a panel of five social handles. He
+       retired both on 2026-09-09 — "ilangin semua sosmed gue, gaada yang
+       peduli wkwk, ganti jadi feedback form aja" — so the tab now says what it
+       does and opens the general feedback dialog (#fb-form) directly.
 
-       ⚠️ THE HANDLES ARE NOT INVENTED HERE AND MUST NOT BE. They come from
-       `engine/wiki/machine/public-identity.md`, which is the machine's one
-       home for them, and each is verified against fkd/loker's own shipped
-       Kontak dialog. A handle typed from memory is a live link to someone
-       else's account. If a channel is missing from the wiki it is missing
-       here too — that is the design, not an oversight.
+       ⚠️ THE HANDLES ARE NOT COMMENTED OUT AND MUST NOT BE RESTORED FROM HERE.
+       They live in `engine/wiki/machine/public-identity.md`, which is the
+       machine's one home for them; a handle typed from memory is a live link
+       to someone else's account. This surface simply no longer carries them.
 
-       ⚠️ THREADS AND X CAME FROM HIM, NOT FROM THE MACHINE (2026-08-23). He
-       asked for "semua sosmed gue... threads x instagram, cari aja" — and
-       they were not there: not in the wiki page, not in loker's dialog, not
-       anywhere under ~/machine. The Instagram handle made threads/@ojan.lubis
-       a good guess and it turned out correct, which is exactly why it was not
-       shipped as one: a guessed handle that happens to resolve is a live link
-       to a stranger's account until someone confirms whose it is. He supplied
-       both, they are now in the wiki, and the wiki is what a future session
-       reads. -->
-  <button id="contact-tab-btn" aria-expanded="false" aria-controls="contact-tab-panel"
-          aria-label="Kontak saya" title="Kontak saya">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 11.5a8.4 8.4 0 0 1-9 8.4 9 9 0 0 1-3.9-.9L3 20.5l1.5-4.5a8.4 8.4 0 0 1-.9-3.9 8.4 8.4 0 0 1 8.4-9 8.4 8.4 0 0 1 9 8.4Z"/></svg>
-  </button>
-  <div id="contact-tab-panel">
-    <!-- WHO the channels belong to. Added 2026-08-27: this panel listed five
-         handles and never said whose they were. Not a destination — a label on
-         the list below it. -->
-    <div class="ct-owner">
-      <img src="images/ojan.jpg" alt="Foto Ojan" width="32" height="32" loading="lazy">
-      <div><b>Ojan</b><span>Fauzan Ahladzikri</span></div>
-    </div>
-    <a href="https://tiktok.com/@okeojan" target="_blank" rel="noopener"><b>TikTok</b><span>@okeojan</span></a>
-    <a href="https://instagram.com/ojan.lubis" target="_blank" rel="noopener"><b>Instagram</b><span>ojan.lubis</span></a>
-    <a href="https://www.threads.com/@ojan.lubis" target="_blank" rel="noopener"><b>Threads</b><span>ojan.lubis</span></a>
-    <a href="https://x.com/okeojan" target="_blank" rel="noopener"><b>X</b><span>@okeojan</span></a>
-    <a href="https://ojanlubis.id" target="_blank" rel="noopener"><b>Website</b><span>ojanlubis.id</span></a>
-  </div>
+       Wired by js/v2/feedback-form.js, alongside the footer's own link — one
+       dialog, one code path, two doors. -->
+  <button id="contact-tab-btn">Ada masukan?</button>
   <div id="toast" role="status" aria-live="polite"></div>
 
   <!-- The general feedback channel, opened from the footer's "Ada masukan?".
@@ -2049,6 +2093,17 @@
     <div class="sheet fb-sheet">
       <div class="fb-body">
         <h2>Gimana PDFLokal?</h2>
+        <!-- WHO IS ASKING. Moved here 2026-09-09 from the retired contact
+             panel, where it labelled a list of handles. It is a BYLINE, not a
+             destination: the dialog's one primary is Kirim, and an identity
+             block competing with it would be a second thing to decide about
+             (design-discipline §2 — the ceiling counts destinations). Small,
+             muted, directly under the question so it answers "who am I writing
+             to" exactly when that occurs to someone. -->
+        <div class="fb-owner">
+          <img src="images/ojan.jpg" alt="" width="28" height="28" loading="lazy">
+          <div><b>Ojan</b><a href="https://mesindev.com" target="_blank" rel="noopener">mesindev.com</a></div>
+        </div>
         <div class="fb-thumbs" role="group" aria-label="Penilaian">
           <button type="button" id="fb-up" aria-pressed="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/></svg>

--- a/pdf-ke-jpg.html
+++ b/pdf-ke-jpg.html
@@ -377,6 +377,20 @@
     .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
     .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
 
+    /* The pasted screenshot, shown back at a size you can actually check. */
+    #fb-shot { position: relative; margin: 10px 0 0; }
+    #fb-shot img {
+      display: block; width: 100%; max-height: 180px; object-fit: contain;
+      border: 1px solid var(--line); border-radius: 8px; background: var(--bg);
+    }
+    #fb-shot-clear {
+      position: absolute; top: 6px; right: 6px;
+      width: 28px; height: 28px; border-radius: 8px; line-height: 1;
+      display: grid; place-items: center; font-size: 17px;
+      background: var(--surface); color: var(--ink);
+      box-shadow: 0 1px 6px rgba(0,0,0,.22);
+    }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -2114,7 +2128,20 @@
             <span>Kurang</span>
           </button>
         </div>
-        <textarea id="fb-note" rows="3" placeholder="boleh minta feedbacknya di sini, supaya kita bisa improve terus pdflokal. (boleh dikosongin juga kok)"></textarea>
+        <!-- PASTE, NOT UPLOAD (his ruling 2026-09-09: "gausah ada tombolnya,
+             bilang aja diplaceholdernya"). No attach button anywhere, and
+             nothing here ever reaches into the editor for pixels — the only
+             image that can exist is one the user deliberately pasted. That is
+             the whole reason this is defensible against the product's own "no
+             uploads" claim, so a convenience button would not be a small
+             addition, it would remove the argument. -->
+        <textarea id="fb-note" rows="3" placeholder="tulis feedbacknya di sini, atau boleh paste screenshot"></textarea>
+        <!-- The pasted image, shown back before it can be sent. A screenshot
+             the sender never saw is a screenshot they did not really choose. -->
+        <div id="fb-shot" hidden>
+          <img id="fb-shot-img" alt="">
+          <button type="button" id="fb-shot-clear" aria-label="Hapus">×</button>
+        </div>
         <div class="fb-row">
           <button type="button" id="fb-cancel">Batal</button>
           <button type="button" id="fb-send" disabled>Kirim</button>

--- a/pisah-pdf.html
+++ b/pisah-pdf.html
@@ -287,6 +287,12 @@
          its own mode and page values must not be ported into it. A toolbar at
          --sp-48 is a toolbar that wastes the document's room. */
       --header-h: 44px; --toolbar-h: 52px;
+      /* THE HEIGHT EVERYTHING BELOW THE CHROME MEASURES AGAINST. It was
+         spelled `calc(var(--header-h) + var(--toolbar-h))` at each use site,
+         which stopped being true the moment the two could share a row. One
+         name, redefined once per breakpoint. */
+      --chrome-h: calc(var(--header-h) + var(--toolbar-h));
+      --header-merged-h: 52px;   /* the single-row height (tools are 36px + padding) */
     }
     /* Self-hosted fonts (preview parity with the PDF export) */
     @font-face { font-family: 'Montserrat'; src: url('fonts/montserrat-regular.woff2') format('woff2'); font-weight: 400; font-style: normal; font-display: swap; }
@@ -336,10 +342,17 @@
 
     /* ---- header ---- */
     header {
-      height: var(--header-h); flex: 0 0 auto;
+      min-height: var(--header-h); flex: 0 0 auto;
       display: flex; align-items: center; gap: 8px; padding: 0 10px;
-      background: var(--surface); border-bottom: 1px solid var(--line);
+      background: var(--surface);
+      /* WRAPS ON PURPOSE. Below the merge breakpoint the toolbar takes a full
+         row of its own; above it, everything stays on one line. No JS, no
+         second element, no duplicated tool buttons to keep in sync. */
+      flex-wrap: wrap;
     }
+    /* Narrow: the toolbar is a row of its own and carries the bottom edge, so
+       the header must NOT also draw one — two borders read as a seam. */
+    header > #toolbar { order: 9; flex: 1 0 100%; margin: 0 -10px; }
     .brand { font-weight: 700; font-size: 15px; letter-spacing: -.01em; }
     .brand-red { color: var(--accent); }
     /* home confirm: rides the standard dialog/.sheet system (the global
@@ -352,6 +365,18 @@
      * renders as a success. This system has one meaning for red and a second
      * colour meaning "good" is not being introduced here. */
     .fb-sheet { max-width: 380px; }
+    /* The byline under the question. Muted and small on purpose: it answers
+       "who am I writing to", it is not a place to go. The domain is the only
+       link, because it is the only one that leads anywhere useful. */
+    .fb-owner {
+      display: flex; align-items: center; gap: 9px;
+      margin: -2px 0 14px;
+    }
+    .fb-owner img { width: 28px; height: 28px; border-radius: 50%; object-fit: cover; flex: none; }
+    .fb-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
+    .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
+    .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -484,12 +509,73 @@
     }
     .tool.active { background: rgba(220,38,38,.08); color: var(--accent); }
 
+    /* ---- MERGED CHROME: one row when the width can hold it ---------------
+       His ruling 2026-09-09: "buat desktop, pindahin tools2nya ke atas. karena
+       spacenya kosong, cuma bikin dua baris navbar kalo spacenya ga cukup aja".
+       So the two-row layout is the FALLBACK, not the default.
+
+       ⚠️ THE BREAKPOINT IS MEASURED, NOT CHOSEN — 900px, 2026-09-09.
+       `.spacer { flex: 1 }` is the slack in this row, so its width IS the
+       headroom. Measured in Chromium: 152px of slack at 1000, 52 at 900, 12 at
+       860, and ZERO at 848. **848 is the true minimum**; 900 is that plus a
+       stated ~50px so the row never sits flush against its own ends, because a
+       row with no breathing room reads as broken even while it technically
+       fits. If a tool is added or a label reworded, RE-MEASURE — a stale
+       breakpoint shows up as a cramped row, never as an error.
+
+       ⚠️ AND THE GAUGE TOOK THREE TRIES, which is the part worth keeping.
+       Per-tool `scrollWidth` reported "fits" at every width down to 760, twice,
+       because the tools were not the element losing width. A third attempt
+       queried `#spacer` — it is a CLASS, so the query returned null and the
+       check passed on null. Only the fourth gauge, the spacer's own geometry
+       through a selector proven to match, showed a number that moved.
+       [[a-watcher-must-be-proven-to-fire]] is the sibling rule.
+
+       ⚠️ AND CHECK THE CEILING AT BOTH SIDES OF IT. design-discipline §2: a
+       band that holds three destinations at 1280 holds four at 375 without
+       anyone editing it. Here the count is unchanged either way — File, the
+       tool cluster (ONE destination, grouped), and Unduh (the one primary) —
+       which is the whole reason this merge is legitimate rather than a
+       fourth thing competing on one line. */
+    @media (min-width: 900px) {
+      :root { --chrome-h: var(--header-merged-h); }
+      header {
+        min-height: var(--header-merged-h); flex-wrap: nowrap;
+        border-bottom: 1px solid var(--line);
+      }
+      /* The flex spacer is what pushes Unduh right in the two-row layout. On
+         the merged row the TOOLBAR grows into that space instead and centres
+         its own children, so a second grower would fight it and shove the
+         tools off-centre. One grower per row. */
+      header > .spacer { display: none; }
+      header > #toolbar {
+        order: 3; flex: 1 1 auto; margin: 0;
+        height: auto; background: none; border-bottom: 0; padding: 0;
+        overflow: visible;
+      }
+      /* Undo/redo/Unduh sit AFTER the tools on the merged row. The markup has
+         the toolbar last (it was appended), so the order is stated here rather
+         than implied by the DOM. */
+      header > #btn-undo, header > #btn-redo, header > #btn-download { order: 5; }
+      /* Icon ABOVE label needs 52px of vertical room. On one shared row the
+         label moves BESIDE the icon — same target size, half the height. */
+      .tool {
+        flex-direction: row; gap: 6px;
+        min-width: 0; height: 36px; padding: 0 9px; font-size: 12.5px;
+      }
+      .tool svg { width: 17px; height: 17px; }
+      /* The BETA cap was corner-pinned so it could not widen a tight toolbar.
+         On the merged row there is room beside the word, and a corner chip on a
+         36px control overlaps its own label. */
+      .tool .beta-tag { position: static; margin-left: 1px; }
+    }
+
     /* ---- format bar: contextual, only when text is in play ---- */
     /* Contextual bars OVERLAY the canvas (founder: the document must never
        jump when a bar appears/disappears) — frosted so the page shows through. */
     #format-bar {
       display: none; align-items: center; gap: 6px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; height: 46px; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -623,61 +709,33 @@
        above was always claiming. The words survive as aria-label + title, so
        a screen reader and a desktop hover both still say "Kontak saya" — the
        label moved, it was not deleted. */
+    /* ⚠️ THE TAB SAYS WHAT IT DOES (2026-09-09, his ruling: "icon ini diganti
+       jadi kata2 aja ya 'ada masukan?'"). It was a chat glyph opening a panel
+       of five social handles; the handles are gone — "gaada yang peduli" — and
+       the glyph went with them, because an icon that has to be tapped to learn
+       its meaning fails his own element test (design-discipline §2).
+
+       AND THE PANEL IS GONE, NOT REPOINTED. Once the tab itself reads "Ada
+       masukan?", a panel whose only content was a button reading "Ada masukan?"
+       is a step that asks the same question twice. The tab opens #fb-form
+       directly. Whose product this is now lives INSIDE that dialog, where it
+       answers "who am I writing to" at the moment the question occurs.
+
+       The string is not new: it is the footer's, ratified 2026-08-22, and
+       reusing it keeps one name for one act (EXCLUDE 2 — copy is his). */
     #contact-tab-btn {
       position: fixed; left: 10px; bottom: 14px; z-index: 30;
-      width: 40px; height: 40px; border-radius: 12px;
-      display: grid; place-items: center;
+      min-height: 40px; padding: 0 14px; border-radius: 12px;
+      display: inline-flex; align-items: center;
       background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      color: var(--muted);
+      color: var(--muted); font-size: 13px; font-weight: 600;
     }
-    #contact-tab-btn svg { width: 19px; height: 19px; display: block; }
-    #contact-tab-panel {
-      position: fixed; left: 10px; bottom: 62px; z-index: 30;
-      width: max-content; max-width: min(78vw, 260px);
-      background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      border-radius: 12px; padding: 8px;
-      /* visibility (not just opacity): same reasoning as #support-card — a
-         dismissed panel must be GONE to hit-testing and screen readers. */
-      opacity: 0; visibility: hidden; pointer-events: none;
-      transform: translateY(10px); /* rests slightly low → reads as "slides up" on open */
-      transition: opacity .22s ease, transform .22s ease, visibility 0s linear .22s;
-    }
-    #contact-tab-panel.show {
-      opacity: 1; visibility: visible; pointer-events: auto;
-      transform: translateY(0); transition-delay: 0s;
-    }
-    /* One row per channel. min-height 40, not 44: this is a LIST inside an
-       already-opened panel, where rows are separated and mis-taps are cheap —
-       the 44 law guards isolated targets a finger hunts for, and the opening
-       tab is the one that has to meet it. Same reasoning text-runs.js records
-       for inflating a HIT box rather than a visual one. */
-    #contact-tab-panel a {
-      display: flex; align-items: center; gap: 10px;
-      min-height: 40px; padding: 0 10px; border-radius: 9px;
-      color: var(--ink); font-size: 13px; font-weight: 600; text-decoration: none;
-    }
-    #contact-tab-panel a:hover { background: var(--bg); }
-    /* The handle is the quiet half: the platform is what you scan for, the
-       handle is what you check once you have found it. */
-    #contact-tab-panel a b { font-weight: 600; }
-    #contact-tab-panel a span { color: var(--muted); font-weight: 500; margin-left: auto; }
-    #contact-tab-panel a svg { width: 16px; height: 16px; flex: none; color: var(--muted); }
-    /* The owner row. Deliberately NOT an <a> — it is not a sixth channel, it
-       is the answer to "whose handles are these". */
-    #contact-tab-panel .ct-owner {
-      display: flex; align-items: center; gap: 10px;
-      padding: 4px 10px 8px; margin-bottom: 4px;
-      border-bottom: 1px solid var(--line);
-    }
-    #contact-tab-panel .ct-owner img { width: 32px; height: 32px; border-radius: 50%; object-fit: cover; flex: none; }
-    #contact-tab-panel .ct-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
-    #contact-tab-panel .ct-owner span { display: block; font-size: 11px; color: var(--muted); font-weight: 500; margin-left: 0; }
-    @media (prefers-reduced-motion: reduce) { #contact-tab-panel { transition: none; } }
+    #contact-tab-btn:hover { color: var(--ink); }
 
     /* ---- the landing (= the editor's empty state; design: draf 3b) ---- */
     /* Editor chrome yields while the landing is up; it has its own header. */
     body.is-empty header, body.is-empty #toolbar, body.is-empty #zoom-ctl,
-    body.is-empty #contact-tab-btn, body.is-empty #contact-tab-panel { display: none; }
+    body.is-empty #contact-tab-btn { display: none; }
     #empty {
       position: absolute; inset: 0; overflow-y: auto; overscroll-behavior: contain;
       /* The PAGE ground is white (ruled 2026-07-29). The body underneath is
@@ -1322,7 +1380,7 @@
     /* signature context strip ("Semua Hal.") */
     #sig-bar {
       display: none; align-items: center; gap: 8px; height: 46px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -1604,8 +1662,16 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>
     </button>
     <button id="btn-download" disabled>Unduh</button>
-  </header>
-
+    <!-- ⚠️ THE TOOLBAR LIVES INSIDE <header> (2026-09-09, his ruling: "buat
+         desktop, pindahin tools2nya ke atas. karena spacenya kosong").
+         It is ONE element in TWO layouts, never two elements:
+           wide  → it sits on the header's own row, between File and Unduh
+           narrow→ header wraps and it takes its own row, exactly as before
+         A sibling cannot be pulled into a flex row by CSS, so the DOM move is
+         what makes the wide layout possible at all. Placement is by `order`,
+         so the markup order here is not the reading order — see the header
+         rules in the stylesheet, and --chrome-h, which is what everything
+         positioned BELOW the chrome measures against. -->
   <div id="toolbar" role="toolbar" aria-label="Alat">
     <!-- No "Pilih" button (founder ruling 2026-07-19): the neutral mode is a
          STATE, not a tool — nothing lit means nothing armed. Every armed tool
@@ -1635,6 +1701,8 @@
       Halaman
     </button>
   </div>
+  </header>
+
 
   <div id="format-bar" role="toolbar" aria-label="Format teks"></div>
   <div id="sig-bar" role="toolbar" aria-label="Aksi tanda tangan">
@@ -1996,44 +2064,20 @@
     <button id="z-in" aria-label="Perbesar">+</button>
     <button id="z-out" aria-label="Perkecil">−</button>
   </div>
-  <!-- Contact bookmark: quiet furniture tab, bottom-left, mirrors #zoom-ctl.
-       Two separate elements (button + panel), not one wrapper — see the CSS
-       comment for why.
+  <!-- The feedback tab: quiet furniture, bottom-left, mirrors #zoom-ctl.
+       It used to be a chat glyph opening a panel of five social handles. He
+       retired both on 2026-09-09 — "ilangin semua sosmed gue, gaada yang
+       peduli wkwk, ganti jadi feedback form aja" — so the tab now says what it
+       does and opens the general feedback dialog (#fb-form) directly.
 
-       ⚠️ THE HANDLES ARE NOT INVENTED HERE AND MUST NOT BE. They come from
-       `engine/wiki/machine/public-identity.md`, which is the machine's one
-       home for them, and each is verified against fkd/loker's own shipped
-       Kontak dialog. A handle typed from memory is a live link to someone
-       else's account. If a channel is missing from the wiki it is missing
-       here too — that is the design, not an oversight.
+       ⚠️ THE HANDLES ARE NOT COMMENTED OUT AND MUST NOT BE RESTORED FROM HERE.
+       They live in `engine/wiki/machine/public-identity.md`, which is the
+       machine's one home for them; a handle typed from memory is a live link
+       to someone else's account. This surface simply no longer carries them.
 
-       ⚠️ THREADS AND X CAME FROM HIM, NOT FROM THE MACHINE (2026-08-23). He
-       asked for "semua sosmed gue... threads x instagram, cari aja" — and
-       they were not there: not in the wiki page, not in loker's dialog, not
-       anywhere under ~/machine. The Instagram handle made threads/@ojan.lubis
-       a good guess and it turned out correct, which is exactly why it was not
-       shipped as one: a guessed handle that happens to resolve is a live link
-       to a stranger's account until someone confirms whose it is. He supplied
-       both, they are now in the wiki, and the wiki is what a future session
-       reads. -->
-  <button id="contact-tab-btn" aria-expanded="false" aria-controls="contact-tab-panel"
-          aria-label="Kontak saya" title="Kontak saya">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 11.5a8.4 8.4 0 0 1-9 8.4 9 9 0 0 1-3.9-.9L3 20.5l1.5-4.5a8.4 8.4 0 0 1-.9-3.9 8.4 8.4 0 0 1 8.4-9 8.4 8.4 0 0 1 9 8.4Z"/></svg>
-  </button>
-  <div id="contact-tab-panel">
-    <!-- WHO the channels belong to. Added 2026-08-27: this panel listed five
-         handles and never said whose they were. Not a destination — a label on
-         the list below it. -->
-    <div class="ct-owner">
-      <img src="images/ojan.jpg" alt="Foto Ojan" width="32" height="32" loading="lazy">
-      <div><b>Ojan</b><span>Fauzan Ahladzikri</span></div>
-    </div>
-    <a href="https://tiktok.com/@okeojan" target="_blank" rel="noopener"><b>TikTok</b><span>@okeojan</span></a>
-    <a href="https://instagram.com/ojan.lubis" target="_blank" rel="noopener"><b>Instagram</b><span>ojan.lubis</span></a>
-    <a href="https://www.threads.com/@ojan.lubis" target="_blank" rel="noopener"><b>Threads</b><span>ojan.lubis</span></a>
-    <a href="https://x.com/okeojan" target="_blank" rel="noopener"><b>X</b><span>@okeojan</span></a>
-    <a href="https://ojanlubis.id" target="_blank" rel="noopener"><b>Website</b><span>ojanlubis.id</span></a>
-  </div>
+       Wired by js/v2/feedback-form.js, alongside the footer's own link — one
+       dialog, one code path, two doors. -->
+  <button id="contact-tab-btn">Ada masukan?</button>
   <div id="toast" role="status" aria-live="polite"></div>
 
   <!-- The general feedback channel, opened from the footer's "Ada masukan?".
@@ -2052,6 +2096,17 @@
     <div class="sheet fb-sheet">
       <div class="fb-body">
         <h2>Gimana PDFLokal?</h2>
+        <!-- WHO IS ASKING. Moved here 2026-09-09 from the retired contact
+             panel, where it labelled a list of handles. It is a BYLINE, not a
+             destination: the dialog's one primary is Kirim, and an identity
+             block competing with it would be a second thing to decide about
+             (design-discipline §2 — the ceiling counts destinations). Small,
+             muted, directly under the question so it answers "who am I writing
+             to" exactly when that occurs to someone. -->
+        <div class="fb-owner">
+          <img src="images/ojan.jpg" alt="" width="28" height="28" loading="lazy">
+          <div><b>Ojan</b><a href="https://mesindev.com" target="_blank" rel="noopener">mesindev.com</a></div>
+        </div>
         <div class="fb-thumbs" role="group" aria-label="Penilaian">
           <button type="button" id="fb-up" aria-pressed="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/></svg>

--- a/pisah-pdf.html
+++ b/pisah-pdf.html
@@ -377,6 +377,20 @@
     .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
     .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
 
+    /* The pasted screenshot, shown back at a size you can actually check. */
+    #fb-shot { position: relative; margin: 10px 0 0; }
+    #fb-shot img {
+      display: block; width: 100%; max-height: 180px; object-fit: contain;
+      border: 1px solid var(--line); border-radius: 8px; background: var(--bg);
+    }
+    #fb-shot-clear {
+      position: absolute; top: 6px; right: 6px;
+      width: 28px; height: 28px; border-radius: 8px; line-height: 1;
+      display: grid; place-items: center; font-size: 17px;
+      background: var(--surface); color: var(--ink);
+      box-shadow: 0 1px 6px rgba(0,0,0,.22);
+    }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -2117,7 +2131,20 @@
             <span>Kurang</span>
           </button>
         </div>
-        <textarea id="fb-note" rows="3" placeholder="boleh minta feedbacknya di sini, supaya kita bisa improve terus pdflokal. (boleh dikosongin juga kok)"></textarea>
+        <!-- PASTE, NOT UPLOAD (his ruling 2026-09-09: "gausah ada tombolnya,
+             bilang aja diplaceholdernya"). No attach button anywhere, and
+             nothing here ever reaches into the editor for pixels — the only
+             image that can exist is one the user deliberately pasted. That is
+             the whole reason this is defensible against the product's own "no
+             uploads" claim, so a convenience button would not be a small
+             addition, it would remove the argument. -->
+        <textarea id="fb-note" rows="3" placeholder="tulis feedbacknya di sini, atau boleh paste screenshot"></textarea>
+        <!-- The pasted image, shown back before it can be sent. A screenshot
+             the sender never saw is a screenshot they did not really choose. -->
+        <div id="fb-shot" hidden>
+          <img id="fb-shot-img" alt="">
+          <button type="button" id="fb-shot-clear" aria-label="Hapus">×</button>
+        </div>
         <div class="fb-row">
           <button type="button" id="fb-cancel">Batal</button>
           <button type="button" id="fb-send" disabled>Kirim</button>

--- a/privasi.html
+++ b/privasi.html
@@ -391,19 +391,10 @@
           bukan dokumen, dan tentu bukan file kamu.
         </p>
         <p style="color: var(--muted); line-height: 1.6; margin-top: var(--sp-16);">
-          Di form masukan (yang kebuka dari tombol "Ada masukan?"), kamu boleh nge-paste screenshot
-          kalau itu lebih gampang daripada ngetik. Nggak ada tombol upload di situ, dan nggak ada yang
-          otomatis: satu-satunya cara sebuah gambar bisa ikut terkirim adalah kalau kamu sendiri yang
-          nge-paste-nya. Habis di-paste, gambarnya langsung muncul di form supaya kamu lihat dulu apa
-          yang bakal terkirim, dan ada tombol × buat ngebatalin. Gambarnya juga saya kecilin dan
-          kompres ulang di browser kamu dulu, jadi data tersembunyi yang biasanya nempel di file
-          gambar (waktu, lokasi, tipe perangkat) ikut hilang sebelum apa pun dikirim.
-        </p>
-        <p style="color: var(--muted); line-height: 1.6; margin-top: var(--sp-16);">
-          Satu hal yang harus saya bilang terus terang: kalau screenshot yang kamu paste kebetulan
-          menampilkan isi dokumenmu, ya isi itu ikut terkirim, karena kamu yang milih gambarnya.
-          Prinsip "filenya tidak pernah diunggah" tetap berlaku, file PDF kamu sendiri nggak pernah
-          saya kirim ke mana-mana. Yang terkirim cuma gambar yang kamu sendiri pilih untuk dikirim.
+          Di form masukan kamu boleh paste screenshot. Nggak ada tombol upload, nggak ada yang
+          otomatis, dan gambarnya muncul dulu biar kamu lihat sebelum dikirim. Terus terang: kalau
+          screenshot itu nampilin isi dokumenmu, isi itu ikut terkirim, karena kamu yang milih
+          gambarnya. File PDF-mu sendiri tetap nggak pernah saya kirim ke mana-mana.
         </p>
       </div>
 

--- a/privasi.html
+++ b/privasi.html
@@ -390,6 +390,21 @@
           yang mungkin terkirim cuma potongan satu baris yang KAMU pilih untuk dikirim, bukan halaman,
           bukan dokumen, dan tentu bukan file kamu.
         </p>
+        <p style="color: var(--muted); line-height: 1.6; margin-top: var(--sp-16);">
+          Di form masukan (yang kebuka dari tombol "Ada masukan?"), kamu boleh nge-paste screenshot
+          kalau itu lebih gampang daripada ngetik. Nggak ada tombol upload di situ, dan nggak ada yang
+          otomatis: satu-satunya cara sebuah gambar bisa ikut terkirim adalah kalau kamu sendiri yang
+          nge-paste-nya. Habis di-paste, gambarnya langsung muncul di form supaya kamu lihat dulu apa
+          yang bakal terkirim, dan ada tombol × buat ngebatalin. Gambarnya juga saya kecilin dan
+          kompres ulang di browser kamu dulu, jadi data tersembunyi yang biasanya nempel di file
+          gambar (waktu, lokasi, tipe perangkat) ikut hilang sebelum apa pun dikirim.
+        </p>
+        <p style="color: var(--muted); line-height: 1.6; margin-top: var(--sp-16);">
+          Satu hal yang harus saya bilang terus terang: kalau screenshot yang kamu paste kebetulan
+          menampilkan isi dokumenmu, ya isi itu ikut terkirim, karena kamu yang milih gambarnya.
+          Prinsip "filenya tidak pernah diunggah" tetap berlaku, file PDF kamu sendiri nggak pernah
+          saya kirim ke mana-mana. Yang terkirim cuma gambar yang kamu sendiri pilih untuk dikirim.
+        </p>
       </div>
 
       <!-- Local Storage -->

--- a/tanda-tangan-pdf.html
+++ b/tanda-tangan-pdf.html
@@ -287,6 +287,12 @@
          its own mode and page values must not be ported into it. A toolbar at
          --sp-48 is a toolbar that wastes the document's room. */
       --header-h: 44px; --toolbar-h: 52px;
+      /* THE HEIGHT EVERYTHING BELOW THE CHROME MEASURES AGAINST. It was
+         spelled `calc(var(--header-h) + var(--toolbar-h))` at each use site,
+         which stopped being true the moment the two could share a row. One
+         name, redefined once per breakpoint. */
+      --chrome-h: calc(var(--header-h) + var(--toolbar-h));
+      --header-merged-h: 52px;   /* the single-row height (tools are 36px + padding) */
     }
     /* Self-hosted fonts (preview parity with the PDF export) */
     @font-face { font-family: 'Montserrat'; src: url('fonts/montserrat-regular.woff2') format('woff2'); font-weight: 400; font-style: normal; font-display: swap; }
@@ -336,10 +342,17 @@
 
     /* ---- header ---- */
     header {
-      height: var(--header-h); flex: 0 0 auto;
+      min-height: var(--header-h); flex: 0 0 auto;
       display: flex; align-items: center; gap: 8px; padding: 0 10px;
-      background: var(--surface); border-bottom: 1px solid var(--line);
+      background: var(--surface);
+      /* WRAPS ON PURPOSE. Below the merge breakpoint the toolbar takes a full
+         row of its own; above it, everything stays on one line. No JS, no
+         second element, no duplicated tool buttons to keep in sync. */
+      flex-wrap: wrap;
     }
+    /* Narrow: the toolbar is a row of its own and carries the bottom edge, so
+       the header must NOT also draw one — two borders read as a seam. */
+    header > #toolbar { order: 9; flex: 1 0 100%; margin: 0 -10px; }
     .brand { font-weight: 700; font-size: 15px; letter-spacing: -.01em; }
     .brand-red { color: var(--accent); }
     /* home confirm: rides the standard dialog/.sheet system (the global
@@ -352,6 +365,18 @@
      * renders as a success. This system has one meaning for red and a second
      * colour meaning "good" is not being introduced here. */
     .fb-sheet { max-width: 380px; }
+    /* The byline under the question. Muted and small on purpose: it answers
+       "who am I writing to", it is not a place to go. The domain is the only
+       link, because it is the only one that leads anywhere useful. */
+    .fb-owner {
+      display: flex; align-items: center; gap: 9px;
+      margin: -2px 0 14px;
+    }
+    .fb-owner img { width: 28px; height: 28px; border-radius: 50%; object-fit: cover; flex: none; }
+    .fb-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
+    .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
+    .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -484,12 +509,73 @@
     }
     .tool.active { background: rgba(220,38,38,.08); color: var(--accent); }
 
+    /* ---- MERGED CHROME: one row when the width can hold it ---------------
+       His ruling 2026-09-09: "buat desktop, pindahin tools2nya ke atas. karena
+       spacenya kosong, cuma bikin dua baris navbar kalo spacenya ga cukup aja".
+       So the two-row layout is the FALLBACK, not the default.
+
+       ⚠️ THE BREAKPOINT IS MEASURED, NOT CHOSEN — 900px, 2026-09-09.
+       `.spacer { flex: 1 }` is the slack in this row, so its width IS the
+       headroom. Measured in Chromium: 152px of slack at 1000, 52 at 900, 12 at
+       860, and ZERO at 848. **848 is the true minimum**; 900 is that plus a
+       stated ~50px so the row never sits flush against its own ends, because a
+       row with no breathing room reads as broken even while it technically
+       fits. If a tool is added or a label reworded, RE-MEASURE — a stale
+       breakpoint shows up as a cramped row, never as an error.
+
+       ⚠️ AND THE GAUGE TOOK THREE TRIES, which is the part worth keeping.
+       Per-tool `scrollWidth` reported "fits" at every width down to 760, twice,
+       because the tools were not the element losing width. A third attempt
+       queried `#spacer` — it is a CLASS, so the query returned null and the
+       check passed on null. Only the fourth gauge, the spacer's own geometry
+       through a selector proven to match, showed a number that moved.
+       [[a-watcher-must-be-proven-to-fire]] is the sibling rule.
+
+       ⚠️ AND CHECK THE CEILING AT BOTH SIDES OF IT. design-discipline §2: a
+       band that holds three destinations at 1280 holds four at 375 without
+       anyone editing it. Here the count is unchanged either way — File, the
+       tool cluster (ONE destination, grouped), and Unduh (the one primary) —
+       which is the whole reason this merge is legitimate rather than a
+       fourth thing competing on one line. */
+    @media (min-width: 900px) {
+      :root { --chrome-h: var(--header-merged-h); }
+      header {
+        min-height: var(--header-merged-h); flex-wrap: nowrap;
+        border-bottom: 1px solid var(--line);
+      }
+      /* The flex spacer is what pushes Unduh right in the two-row layout. On
+         the merged row the TOOLBAR grows into that space instead and centres
+         its own children, so a second grower would fight it and shove the
+         tools off-centre. One grower per row. */
+      header > .spacer { display: none; }
+      header > #toolbar {
+        order: 3; flex: 1 1 auto; margin: 0;
+        height: auto; background: none; border-bottom: 0; padding: 0;
+        overflow: visible;
+      }
+      /* Undo/redo/Unduh sit AFTER the tools on the merged row. The markup has
+         the toolbar last (it was appended), so the order is stated here rather
+         than implied by the DOM. */
+      header > #btn-undo, header > #btn-redo, header > #btn-download { order: 5; }
+      /* Icon ABOVE label needs 52px of vertical room. On one shared row the
+         label moves BESIDE the icon — same target size, half the height. */
+      .tool {
+        flex-direction: row; gap: 6px;
+        min-width: 0; height: 36px; padding: 0 9px; font-size: 12.5px;
+      }
+      .tool svg { width: 17px; height: 17px; }
+      /* The BETA cap was corner-pinned so it could not widen a tight toolbar.
+         On the merged row there is room beside the word, and a corner chip on a
+         36px control overlaps its own label. */
+      .tool .beta-tag { position: static; margin-left: 1px; }
+    }
+
     /* ---- format bar: contextual, only when text is in play ---- */
     /* Contextual bars OVERLAY the canvas (founder: the document must never
        jump when a bar appears/disappears) — frosted so the page shows through. */
     #format-bar {
       display: none; align-items: center; gap: 6px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; height: 46px; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -623,61 +709,33 @@
        above was always claiming. The words survive as aria-label + title, so
        a screen reader and a desktop hover both still say "Kontak saya" — the
        label moved, it was not deleted. */
+    /* ⚠️ THE TAB SAYS WHAT IT DOES (2026-09-09, his ruling: "icon ini diganti
+       jadi kata2 aja ya 'ada masukan?'"). It was a chat glyph opening a panel
+       of five social handles; the handles are gone — "gaada yang peduli" — and
+       the glyph went with them, because an icon that has to be tapped to learn
+       its meaning fails his own element test (design-discipline §2).
+
+       AND THE PANEL IS GONE, NOT REPOINTED. Once the tab itself reads "Ada
+       masukan?", a panel whose only content was a button reading "Ada masukan?"
+       is a step that asks the same question twice. The tab opens #fb-form
+       directly. Whose product this is now lives INSIDE that dialog, where it
+       answers "who am I writing to" at the moment the question occurs.
+
+       The string is not new: it is the footer's, ratified 2026-08-22, and
+       reusing it keeps one name for one act (EXCLUDE 2 — copy is his). */
     #contact-tab-btn {
       position: fixed; left: 10px; bottom: 14px; z-index: 30;
-      width: 40px; height: 40px; border-radius: 12px;
-      display: grid; place-items: center;
+      min-height: 40px; padding: 0 14px; border-radius: 12px;
+      display: inline-flex; align-items: center;
       background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      color: var(--muted);
+      color: var(--muted); font-size: 13px; font-weight: 600;
     }
-    #contact-tab-btn svg { width: 19px; height: 19px; display: block; }
-    #contact-tab-panel {
-      position: fixed; left: 10px; bottom: 62px; z-index: 30;
-      width: max-content; max-width: min(78vw, 260px);
-      background: var(--surface); box-shadow: 0 3px 14px rgba(0,0,0,.16);
-      border-radius: 12px; padding: 8px;
-      /* visibility (not just opacity): same reasoning as #support-card — a
-         dismissed panel must be GONE to hit-testing and screen readers. */
-      opacity: 0; visibility: hidden; pointer-events: none;
-      transform: translateY(10px); /* rests slightly low → reads as "slides up" on open */
-      transition: opacity .22s ease, transform .22s ease, visibility 0s linear .22s;
-    }
-    #contact-tab-panel.show {
-      opacity: 1; visibility: visible; pointer-events: auto;
-      transform: translateY(0); transition-delay: 0s;
-    }
-    /* One row per channel. min-height 40, not 44: this is a LIST inside an
-       already-opened panel, where rows are separated and mis-taps are cheap —
-       the 44 law guards isolated targets a finger hunts for, and the opening
-       tab is the one that has to meet it. Same reasoning text-runs.js records
-       for inflating a HIT box rather than a visual one. */
-    #contact-tab-panel a {
-      display: flex; align-items: center; gap: 10px;
-      min-height: 40px; padding: 0 10px; border-radius: 9px;
-      color: var(--ink); font-size: 13px; font-weight: 600; text-decoration: none;
-    }
-    #contact-tab-panel a:hover { background: var(--bg); }
-    /* The handle is the quiet half: the platform is what you scan for, the
-       handle is what you check once you have found it. */
-    #contact-tab-panel a b { font-weight: 600; }
-    #contact-tab-panel a span { color: var(--muted); font-weight: 500; margin-left: auto; }
-    #contact-tab-panel a svg { width: 16px; height: 16px; flex: none; color: var(--muted); }
-    /* The owner row. Deliberately NOT an <a> — it is not a sixth channel, it
-       is the answer to "whose handles are these". */
-    #contact-tab-panel .ct-owner {
-      display: flex; align-items: center; gap: 10px;
-      padding: 4px 10px 8px; margin-bottom: 4px;
-      border-bottom: 1px solid var(--line);
-    }
-    #contact-tab-panel .ct-owner img { width: 32px; height: 32px; border-radius: 50%; object-fit: cover; flex: none; }
-    #contact-tab-panel .ct-owner b { display: block; font-size: 13px; font-weight: 700; color: var(--ink); line-height: 1.25; }
-    #contact-tab-panel .ct-owner span { display: block; font-size: 11px; color: var(--muted); font-weight: 500; margin-left: 0; }
-    @media (prefers-reduced-motion: reduce) { #contact-tab-panel { transition: none; } }
+    #contact-tab-btn:hover { color: var(--ink); }
 
     /* ---- the landing (= the editor's empty state; design: draf 3b) ---- */
     /* Editor chrome yields while the landing is up; it has its own header. */
     body.is-empty header, body.is-empty #toolbar, body.is-empty #zoom-ctl,
-    body.is-empty #contact-tab-btn, body.is-empty #contact-tab-panel { display: none; }
+    body.is-empty #contact-tab-btn { display: none; }
     #empty {
       position: absolute; inset: 0; overflow-y: auto; overscroll-behavior: contain;
       /* The PAGE ground is white (ruled 2026-07-29). The body underneath is
@@ -1322,7 +1380,7 @@
     /* signature context strip ("Semua Hal.") */
     #sig-bar {
       display: none; align-items: center; gap: 8px; height: 46px;
-      position: absolute; top: calc(var(--header-h) + var(--toolbar-h)); left: 0; right: 0;
+      position: absolute; top: var(--chrome-h); left: 0; right: 0;
       z-index: 45; padding: 0 10px;
       background: rgba(255,255,255,.93); backdrop-filter: blur(6px);
       border-bottom: 1px solid var(--line); box-shadow: 0 4px 14px rgba(63,49,35,.07);
@@ -1604,8 +1662,16 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>
     </button>
     <button id="btn-download" disabled>Unduh</button>
-  </header>
-
+    <!-- ⚠️ THE TOOLBAR LIVES INSIDE <header> (2026-09-09, his ruling: "buat
+         desktop, pindahin tools2nya ke atas. karena spacenya kosong").
+         It is ONE element in TWO layouts, never two elements:
+           wide  → it sits on the header's own row, between File and Unduh
+           narrow→ header wraps and it takes its own row, exactly as before
+         A sibling cannot be pulled into a flex row by CSS, so the DOM move is
+         what makes the wide layout possible at all. Placement is by `order`,
+         so the markup order here is not the reading order — see the header
+         rules in the stylesheet, and --chrome-h, which is what everything
+         positioned BELOW the chrome measures against. -->
   <div id="toolbar" role="toolbar" aria-label="Alat">
     <!-- No "Pilih" button (founder ruling 2026-07-19): the neutral mode is a
          STATE, not a tool — nothing lit means nothing armed. Every armed tool
@@ -1635,6 +1701,8 @@
       Halaman
     </button>
   </div>
+  </header>
+
 
   <div id="format-bar" role="toolbar" aria-label="Format teks"></div>
   <div id="sig-bar" role="toolbar" aria-label="Aksi tanda tangan">
@@ -1997,44 +2065,20 @@
     <button id="z-in" aria-label="Perbesar">+</button>
     <button id="z-out" aria-label="Perkecil">−</button>
   </div>
-  <!-- Contact bookmark: quiet furniture tab, bottom-left, mirrors #zoom-ctl.
-       Two separate elements (button + panel), not one wrapper — see the CSS
-       comment for why.
+  <!-- The feedback tab: quiet furniture, bottom-left, mirrors #zoom-ctl.
+       It used to be a chat glyph opening a panel of five social handles. He
+       retired both on 2026-09-09 — "ilangin semua sosmed gue, gaada yang
+       peduli wkwk, ganti jadi feedback form aja" — so the tab now says what it
+       does and opens the general feedback dialog (#fb-form) directly.
 
-       ⚠️ THE HANDLES ARE NOT INVENTED HERE AND MUST NOT BE. They come from
-       `engine/wiki/machine/public-identity.md`, which is the machine's one
-       home for them, and each is verified against fkd/loker's own shipped
-       Kontak dialog. A handle typed from memory is a live link to someone
-       else's account. If a channel is missing from the wiki it is missing
-       here too — that is the design, not an oversight.
+       ⚠️ THE HANDLES ARE NOT COMMENTED OUT AND MUST NOT BE RESTORED FROM HERE.
+       They live in `engine/wiki/machine/public-identity.md`, which is the
+       machine's one home for them; a handle typed from memory is a live link
+       to someone else's account. This surface simply no longer carries them.
 
-       ⚠️ THREADS AND X CAME FROM HIM, NOT FROM THE MACHINE (2026-08-23). He
-       asked for "semua sosmed gue... threads x instagram, cari aja" — and
-       they were not there: not in the wiki page, not in loker's dialog, not
-       anywhere under ~/machine. The Instagram handle made threads/@ojan.lubis
-       a good guess and it turned out correct, which is exactly why it was not
-       shipped as one: a guessed handle that happens to resolve is a live link
-       to a stranger's account until someone confirms whose it is. He supplied
-       both, they are now in the wiki, and the wiki is what a future session
-       reads. -->
-  <button id="contact-tab-btn" aria-expanded="false" aria-controls="contact-tab-panel"
-          aria-label="Kontak saya" title="Kontak saya">
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 11.5a8.4 8.4 0 0 1-9 8.4 9 9 0 0 1-3.9-.9L3 20.5l1.5-4.5a8.4 8.4 0 0 1-.9-3.9 8.4 8.4 0 0 1 8.4-9 8.4 8.4 0 0 1 9 8.4Z"/></svg>
-  </button>
-  <div id="contact-tab-panel">
-    <!-- WHO the channels belong to. Added 2026-08-27: this panel listed five
-         handles and never said whose they were. Not a destination — a label on
-         the list below it. -->
-    <div class="ct-owner">
-      <img src="images/ojan.jpg" alt="Foto Ojan" width="32" height="32" loading="lazy">
-      <div><b>Ojan</b><span>Fauzan Ahladzikri</span></div>
-    </div>
-    <a href="https://tiktok.com/@okeojan" target="_blank" rel="noopener"><b>TikTok</b><span>@okeojan</span></a>
-    <a href="https://instagram.com/ojan.lubis" target="_blank" rel="noopener"><b>Instagram</b><span>ojan.lubis</span></a>
-    <a href="https://www.threads.com/@ojan.lubis" target="_blank" rel="noopener"><b>Threads</b><span>ojan.lubis</span></a>
-    <a href="https://x.com/okeojan" target="_blank" rel="noopener"><b>X</b><span>@okeojan</span></a>
-    <a href="https://ojanlubis.id" target="_blank" rel="noopener"><b>Website</b><span>ojanlubis.id</span></a>
-  </div>
+       Wired by js/v2/feedback-form.js, alongside the footer's own link — one
+       dialog, one code path, two doors. -->
+  <button id="contact-tab-btn">Ada masukan?</button>
   <div id="toast" role="status" aria-live="polite"></div>
 
   <!-- The general feedback channel, opened from the footer's "Ada masukan?".
@@ -2053,6 +2097,17 @@
     <div class="sheet fb-sheet">
       <div class="fb-body">
         <h2>Gimana PDFLokal?</h2>
+        <!-- WHO IS ASKING. Moved here 2026-09-09 from the retired contact
+             panel, where it labelled a list of handles. It is a BYLINE, not a
+             destination: the dialog's one primary is Kirim, and an identity
+             block competing with it would be a second thing to decide about
+             (design-discipline §2 — the ceiling counts destinations). Small,
+             muted, directly under the question so it answers "who am I writing
+             to" exactly when that occurs to someone. -->
+        <div class="fb-owner">
+          <img src="images/ojan.jpg" alt="" width="28" height="28" loading="lazy">
+          <div><b>Ojan</b><a href="https://mesindev.com" target="_blank" rel="noopener">mesindev.com</a></div>
+        </div>
         <div class="fb-thumbs" role="group" aria-label="Penilaian">
           <button type="button" id="fb-up" aria-pressed="false">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/></svg>

--- a/tanda-tangan-pdf.html
+++ b/tanda-tangan-pdf.html
@@ -377,6 +377,20 @@
     .fb-owner a { display: block; font-size: 11.5px; color: var(--muted); font-weight: 500; text-decoration: none; }
     .fb-owner a:hover { color: var(--ink); text-decoration: underline; }
 
+    /* The pasted screenshot, shown back at a size you can actually check. */
+    #fb-shot { position: relative; margin: 10px 0 0; }
+    #fb-shot img {
+      display: block; width: 100%; max-height: 180px; object-fit: contain;
+      border: 1px solid var(--line); border-radius: 8px; background: var(--bg);
+    }
+    #fb-shot-clear {
+      position: absolute; top: 6px; right: 6px;
+      width: 28px; height: 28px; border-radius: 8px; line-height: 1;
+      display: grid; place-items: center; font-size: 17px;
+      background: var(--surface); color: var(--ink);
+      box-shadow: 0 1px 6px rgba(0,0,0,.22);
+    }
+
     .fb-thumbs { display: flex; gap: var(--sp-8); }
     .fb-thumbs button {
       flex: 1 1 0;
@@ -2118,7 +2132,20 @@
             <span>Kurang</span>
           </button>
         </div>
-        <textarea id="fb-note" rows="3" placeholder="boleh minta feedbacknya di sini, supaya kita bisa improve terus pdflokal. (boleh dikosongin juga kok)"></textarea>
+        <!-- PASTE, NOT UPLOAD (his ruling 2026-09-09: "gausah ada tombolnya,
+             bilang aja diplaceholdernya"). No attach button anywhere, and
+             nothing here ever reaches into the editor for pixels — the only
+             image that can exist is one the user deliberately pasted. That is
+             the whole reason this is defensible against the product's own "no
+             uploads" claim, so a convenience button would not be a small
+             addition, it would remove the argument. -->
+        <textarea id="fb-note" rows="3" placeholder="tulis feedbacknya di sini, atau boleh paste screenshot"></textarea>
+        <!-- The pasted image, shown back before it can be sent. A screenshot
+             the sender never saw is a screenshot they did not really choose. -->
+        <div id="fb-shot" hidden>
+          <img id="fb-shot-img" alt="">
+          <button type="button" id="fb-shot-clear" aria-label="Hapus">×</button>
+        </div>
         <div class="fb-row">
           <button type="button" id="fb-cancel">Batal</button>
           <button type="button" id="fb-send" disabled>Kirim</button>

--- a/tests/chrome-merged-row.spec.js
+++ b/tests/chrome-merged-row.spec.js
@@ -1,0 +1,110 @@
+/*
+ * THE EDITOR CHROME — one row when the width holds it, two when it does not.
+ * ============================================================================
+ * RULED 2026-09-09: "buat desktop, pindahin tools2nya ke atas. karena spacenya
+ * kosong, cuma bikin dua baris navbar kalo spacenya ga cukup aja". So the
+ * two-row layout is the FALLBACK; one row is the default wherever it fits.
+ *
+ * ⚠️ WHAT MAKES THIS A TEST AND NOT A SCREENSHOT: the toolbar is ONE element in
+ * two layouts, never two elements. A duplicate tool row for desktop would drift
+ * — a tool added to one and not the other, an `active` state that only clears
+ * on one. The assertions below are about identity (same buttons, same count,
+ * same ids) as much as about geometry.
+ *
+ * ⚠️ THE BREAKPOINT IS MEASURED. `.spacer { flex: 1 }` is the slack in the
+ * merged row, and its width is the headroom: 152px at 1000, 52 at 900, 12 at
+ * 860, ZERO at 848. 900 is the true minimum plus a stated ~50px so the row
+ * never sits flush. If a tool is added or a label reworded, RE-MEASURE and move
+ * this file with the CSS — a stale breakpoint ships as a cramped row, never as
+ * an error, which is exactly the kind of defect nothing else here would catch.
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { expectFirstPage } from './helpers/render.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const BREAKPOINT = 900;
+
+async function openEditor(page) {
+  await page.goto('/');
+  await page.setInputFiles('#file-input', path.join(__dirname, 'fixtures', 'sample-2pages.pdf'));
+  await expectFirstPage(page);
+}
+
+// Is the toolbar on its own line, or sharing the header's?
+const rows = (page) => page.evaluate(() => {
+  const h = document.querySelector('header').getBoundingClientRect();
+  const t = document.querySelector('#toolbar').getBoundingClientRect();
+  return t.top >= h.top + 40 ? 2 : 1;
+});
+
+test.describe('editor chrome — the merged row', () => {
+  test('at or above the breakpoint the tools share the header row', async ({ page }) => {
+    await page.setViewportSize({ width: BREAKPOINT, height: 800 });
+    await openEditor(page);
+    expect(await rows(page)).toBe(1);
+  });
+
+  test('one pixel below it, the toolbar takes its own row again', async ({ page }) => {
+    // THE PAIR IS THE TEST. "It is one row at 1280" passes on a layout that is
+    // ALWAYS one row, which would put the tools on top of each other on a
+    // phone. Both sides of the same boundary, or neither proves anything.
+    await page.setViewportSize({ width: BREAKPOINT - 1, height: 800 });
+    await openEditor(page);
+    expect(await rows(page)).toBe(2);
+  });
+
+  test('a phone is unchanged — two rows, exactly as before', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 800 });
+    await openEditor(page);
+    expect(await rows(page)).toBe(2);
+  });
+
+  test('ONE toolbar in both layouts — the same buttons, never a desktop copy', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await openEditor(page);
+    const wide = await page.locator('#toolbar .tool').evaluateAll((els) => els.map((e) => e.dataset.tool || e.id));
+    expect(await page.locator('#toolbar').count()).toBe(1);
+
+    await page.setViewportSize({ width: 700, height: 800 });
+    await page.waitForTimeout(150);
+    const narrow = await page.locator('#toolbar .tool').evaluateAll((els) => els.map((e) => e.dataset.tool || e.id));
+    expect(await page.locator('#toolbar').count()).toBe(1);
+    expect(narrow).toEqual(wide);
+    expect(wide.length).toBeGreaterThan(3); // the list must not be empty for this to mean anything
+  });
+
+  test('nothing below the chrome is hidden underneath it', async ({ page }) => {
+    // --chrome-h replaced `calc(--header-h + --toolbar-h)` at every use site,
+    // because that sum stopped being true the moment the two could share a row.
+    // A wrong value here does not throw: the first page just sits under the
+    // bar. So it is measured, at both layouts.
+    for (const w of [1280, 700]) {
+      await page.setViewportSize({ width: w, height: 800 });
+      await openEditor(page);
+      const gap = await page.evaluate(() => {
+        const h = document.querySelector('header').getBoundingClientRect();
+        const p = document.querySelector('.pv-page').getBoundingClientRect();
+        return Math.round(p.top - h.bottom);
+      });
+      expect(gap, `viewport ${w}`).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  test('the tools are still reachable targets on the merged row', async ({ page }) => {
+    // The label moved beside the icon to fit a 52px row; the control must not
+    // have shrunk below a usable target in the process.
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await openEditor(page);
+    for (const t of await page.locator('#toolbar .tool').all()) {
+      const box = await t.boundingBox();
+      expect(box.height, await t.innerText()).toBeGreaterThanOrEqual(32);
+      expect(box.width, await t.innerText()).toBeGreaterThanOrEqual(44);
+    }
+    // and they still work
+    await page.click('[data-tool="whiteout"]');
+    await expect(page.locator('[data-tool="whiteout"]')).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/tests/core/feedback-delivery.test.mjs
+++ b/tests/core/feedback-delivery.test.mjs
@@ -80,7 +80,13 @@ test('DELIVERY: a valid 👎 reaches the insert, parameterized, with its note in
   // The note is a value, never text spliced into SQL. This is the one field a
   // user actually types, so it is the one that must never reach the statement.
   assert.equal(calls[0].text.includes('hurufnya'), false, 'the note was interpolated into the SQL');
-  assert.deepEqual(calls[0].params, [SESSION, 'abc1234', 'down', 'hurufnya jadi tebal', null, null]);
+  // ⚠️ THE WHOLE ARRAY, not a subset — and it went red for the right reason on
+  // 2026-09-09 when `screenshot` was added as the 7th parameter. A new column
+  // silently joining this insert is exactly what a full-array assertion is for,
+  // so it is updated deliberately here rather than loosened to a prefix match.
+  // The trailing nulls are sample_before, sample_after, screenshot: this body
+  // carries no image of any kind.
+  assert.deepEqual(calls[0].params, [SESSION, 'abc1234', 'down', 'hurufnya jadi tebal', null, null, null]);
   assert.equal(res.code, 204);
 });
 

--- a/tests/feedback-paste-shot.spec.js
+++ b/tests/feedback-paste-shot.spec.js
@@ -1,0 +1,115 @@
+/*
+ * THE PASTED SCREENSHOT on the general feedback form.
+ * ============================================================================
+ * RULED 2026-09-09. He approved an image on general feedback, then scoped how:
+ * "gausah ada tombolnya, bilang aja diplaceholdernya 'tulis feedbacknya di
+ * sini, atau boleh paste screenshot'".
+ *
+ * ⚠️ WHAT THESE TESTS ACTUALLY GUARD, and it is not the feature. The product's
+ * claim is that a document never leaves the device. The ONLY thing that makes
+ * an image defensible here is that the user performed a deliberate paste — so
+ * the tests below pin the ABSENCE of every other route: no attach button, no
+ * reach into the editor, nothing retained after Batal. A test that only proved
+ * "pasting works" would go green on a build that also uploaded automatically.
+ */
+import { test, expect } from '@playwright/test';
+
+const PNG_1x1 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+// Paste a real image the way a browser does: a DataTransfer carrying a File.
+// Synthesising the module's internal state instead would test nothing about
+// whether the paste path is wired at all.
+async function pasteImage(page) {
+  await page.evaluate(async (b64) => {
+    const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+    const file = new File([bytes], 'shot.png', { type: 'image/png' });
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    const note = document.getElementById('fb-note');
+    note.focus();
+    note.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
+  }, PNG_1x1);
+  await page.waitForSelector('#fb-shot:not([hidden])', { timeout: 5000 });
+}
+
+test.describe('feedback — the pasted screenshot', () => {
+  test('the placeholder is his, verbatim, and there is NO attach button', async ({ page }) => {
+    await page.goto('/');
+    await page.click('#fb-open');
+    await expect(page.locator('#fb-note')).toHaveAttribute(
+      'placeholder', 'tulis feedbacknya di sini, atau boleh paste screenshot',
+    );
+    // The absence IS the ruling. A file input anywhere in this dialog would be
+    // the convenience he declined, and the thing that turns a deliberate act
+    // into a default.
+    expect(await page.locator('#fb-form input[type="file"]').count()).toBe(0);
+  });
+
+  test('a pasted image is shown BACK before it can be sent, and can be removed', async ({ page }) => {
+    await page.goto('/');
+    await page.click('#fb-open');
+    await expect(page.locator('#fb-shot')).toBeHidden();
+
+    await pasteImage(page);
+    await expect(page.locator('#fb-shot')).toBeVisible();
+    const src = await page.locator('#fb-shot-img').getAttribute('src');
+    // Re-encoded, not passed through: a PNG went in, a JPEG must come out. That
+    // round trip is also what drops the source's metadata block.
+    expect(src.startsWith('data:image/jpeg;base64,')).toBe(true);
+
+    await page.click('#fb-shot-clear');
+    await expect(page.locator('#fb-shot')).toBeHidden();
+  });
+
+  test('THE SEND CARRIES IT — and the payload is the screenshot field, not a sample', async ({ page }) => {
+    const bodies = [];
+    await page.route('**/api/feedback', async (route) => {
+      bodies.push(JSON.parse(route.request().postData() || '{}'));
+      await route.fulfill({ status: 204, body: '' });
+    });
+    await page.goto('/');
+    await page.click('#fb-open');
+    await pasteImage(page);
+    await page.click('#fb-up');
+    await page.click('#fb-send');
+    await expect.poll(() => bodies.length).toBeGreaterThan(0);
+
+    const body = bodies[0];
+    expect(body.rating).toBe('up');
+    expect(typeof body.screenshot).toBe('string');
+    expect(body.screenshot.startsWith('data:image/jpeg;base64,')).toBe(true);
+    // ⚠️ THE CROP PAIR MUST NEVER APPEAR ON THIS PATH. It belongs to
+    // edit-feedback.js, has a different producer, a different validator and a
+    // different consent story. The day the two share a field is the day a crop
+    // can ride out on a route nobody audited.
+    expect(body.sample_before).toBeUndefined();
+    expect(body.sample_after).toBeUndefined();
+  });
+
+  test('CONTROL: no paste, no image field at all', async ({ page }) => {
+    const bodies = [];
+    await page.route('**/api/feedback', async (route) => {
+      bodies.push(JSON.parse(route.request().postData() || '{}'));
+      await route.fulfill({ status: 204, body: '' });
+    });
+    await page.goto('/');
+    await page.click('#fb-open');
+    await page.fill('#fb-note', 'tanpa gambar');
+    await page.click('#fb-down');
+    await page.click('#fb-send');
+    await expect.poll(() => bodies.length).toBeGreaterThan(0);
+    expect(bodies[0].screenshot).toBeUndefined();
+    expect(bodies[0].note).toBe('tanpa gambar');
+  });
+
+  test('Batal does not keep the image for the next time the form opens', async ({ page }) => {
+    // Re-opening with an attachment still loaded would be re-consenting on the
+    // user's behalf to something they had already backed out of.
+    await page.goto('/');
+    await page.click('#fb-open');
+    await pasteImage(page);
+    await page.click('#fb-cancel');
+    await page.click('#fb-open');
+    await expect(page.locator('#fb-shot')).toBeHidden();
+  });
+});

--- a/tests/kontak-channels.spec.js
+++ b/tests/kontak-channels.spec.js
@@ -1,26 +1,23 @@
 /*
- * THE CONTACT BOOKMARK — his five channels, and the size he ruled.
+ * THE FEEDBACK TAB — what replaced his five social channels.
  * ============================================================================
- * The floating tab bottom-left in the editor, and the panel it opens.
+ * REWRITTEN 2026-09-09 on his ruling: "ilangin semua sosmed gue, gaada yang
+ * peduli wkwk, ganti jadi feedback form aja". The floating tab bottom-left used
+ * to be a chat glyph opening a panel of five handles. Both are gone.
  *
- * WHY THE HANDLES ARE PINNED VERBATIM, which is unusual for this suite: every
- * href here is a live link that carries FAUZAN'S NAME. A typo does not 404 —
- * social platforms hand a near-miss username to whoever actually owns it, so
- * the failure mode is a working link to a stranger's account, shipped on his
- * product, indistinguishable from correct until someone clicks it. That is not
- * a copy test; it is the same class as a wrong bank number.
+ * ⚠️ WHY THIS FILE WAS REWRITTEN RATHER THAN DELETED, and it is the whole
+ * point. The old suite existed because a mistyped handle does not 404 — social
+ * platforms hand a near-miss username to whoever actually owns it, so the
+ * failure mode was a working link to a STRANGER'S account shipped under his
+ * name. Removing the links removes that risk only while they stay removed. So
+ * the guard inverts: it used to pin the five hrefs verbatim, and now it asserts
+ * that NO social handle appears on this surface at all. Deleting the file would
+ * have deleted the guard along with the thing it guarded, and an accidental
+ * restore — a revert, a copy-paste from an SEO page, a "the panel used to be
+ * nicer" — would have shipped silently.
  *
- * SOURCE OF TRUTH: engine/wiki/machine/public-identity.md. The handles are NOT
- * decided here and NOT decided in index.html — both read from that page, which
- * is the machine's one home for them. He is `okeojan` on TikTok and X,
- * `ojan.lubis` on Instagram and Threads. If this test and the wiki ever
- * disagree, the wiki wins and this file is the bug.
- *
- * ⚠️ AND IT PINS THE COUNT, deliberately. On 2026-08-23 the wiki page listed
- * THREE channels and he had to be asked for the other two — a list of three
- * reads identically whether three is the answer or three is what someone
- * happened to know. `toEqual` on the whole array (not `toContain` per link)
- * is what makes a silently-dropped channel fail here.
+ * SOURCE OF TRUTH for the handles is still engine/wiki/machine/public-identity.md.
+ * They are not decided here, they are simply not on this page any more.
  */
 import { test, expect } from '@playwright/test';
 import path from 'path';
@@ -29,14 +26,10 @@ import { expectFirstPage } from './helpers/render.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// Verbatim, in order, from the wiki table.
-const CHANNELS = [
-  'https://tiktok.com/@okeojan',
-  'https://instagram.com/ojan.lubis',
-  'https://www.threads.com/@ojan.lubis',
-  'https://x.com/okeojan',
-  'https://ojanlubis.id',
-];
+// The hosts he ships as himself, from the wiki. Present here ONLY so their
+// ABSENCE can be asserted — this list must never become a list of links again
+// without him saying so.
+const SOCIAL_HOSTS = ['tiktok.com', 'instagram.com', 'threads.com', 'x.com', 'ojanlubis.id'];
 
 async function openEditor(page) {
   await page.goto('/');
@@ -44,54 +37,61 @@ async function openEditor(page) {
   await expectFirstPage(page);
 }
 
-test.describe('the contact bookmark', () => {
-  test('the tab is small furniture, not a banner — 40x40, no wider than the zoom control', async ({ page }) => {
-    // RULED BY FAUZAN 2026-08-23: "chip kontak saya di sini kegedean, kecilin
-    // lagi". The labelled version was 44x131 — nearly 3x #zoom-ctl's footprint
-    // on the opposite corner, and on desktop it overlapped the document. The
-    // assertion is RELATIVE to #zoom-ctl rather than a bare pixel count,
-    // because "the two floating controls weigh the same" is the actual rule;
-    // a hardcoded 40 would go green if both were re-inflated together.
+test.describe('the feedback tab', () => {
+  test('the tab SAYS what it does — no glyph anyone has to tap to decode', async ({ page }) => {
+    // RULED 2026-09-09: "icon ini diganti jadi kata2 aja ya 'ada masukan?'".
+    // The string is the footer's, ratified 2026-08-22 — one name for one act.
+    await openEditor(page);
+    expect((await page.locator('#contact-tab-btn').innerText()).trim()).toBe('Ada masukan?');
+    expect(await page.locator('#contact-tab-btn svg').count()).toBe(0);
+  });
+
+  test('it stays furniture — no taller than the zoom control on the opposite corner', async ({ page }) => {
+    // HIS EARLIER RULING SURVIVES THE RELABEL (2026-08-23: "chip kontak saya di
+    // sini kegedean, kecilin lagi"). A labelled tab is wider than an icon by
+    // construction, so WIDTH can no longer be the test — HEIGHT is what "same
+    // weight as the other floating control" now means, and it is asserted
+    // relative to #zoom-ctl rather than as a pixel count, so re-inflating both
+    // together still goes red.
     await openEditor(page);
     const chip = await page.locator('#contact-tab-btn').boundingBox();
     const zoom = await page.locator('#zoom-ctl').boundingBox();
-    expect(chip.width).toBeLessThanOrEqual(zoom.width);
     expect(chip.height).toBeLessThanOrEqual(zoom.width);
-
-    // Icon-only, so the words have to survive somewhere a screen reader and a
-    // desktop hover can both still reach. Losing the label was the cost of the
-    // size; losing the NAME would be a different, worse change.
-    await expect(page.locator('#contact-tab-btn')).toHaveAttribute('aria-label', 'Kontak saya');
-    await expect(page.locator('#contact-tab-btn')).toHaveAttribute('title', 'Kontak saya');
-    expect((await page.locator('#contact-tab-btn').innerText()).trim()).toBe('');
   });
 
-  test('every channel he ships as himself is there, and no other', async ({ page }) => {
+  test('THE GUARD: no social handle is anywhere on this surface', async ({ page }) => {
+    await openEditor(page);
+    const hrefs = await page.locator('a[href]').evaluateAll((els) => els.map((e) => e.href));
+    // Guard the instrument before believing its verdict: a page with no links
+    // at all would pass this for free. [[assertions-over-empty-sets]]
+    expect(hrefs.length).toBeGreaterThan(0);
+    const found = hrefs.filter((h) => SOCIAL_HOSTS.some((host) => h.includes(host)));
+    expect(found, 'a social handle came back onto the editor surface').toEqual([]);
+    expect(await page.locator('#contact-tab-panel').count()).toBe(0);
+  });
+
+  test('it opens the feedback dialog, and the dialog says who is asking', async ({ page }) => {
     await openEditor(page);
     await page.click('#contact-tab-btn');
-    await expect(page.locator('#contact-tab-panel')).toBeVisible();
+    await expect(page.locator('#fb-form')).toBeVisible();
 
-    const hrefs = await page.locator('#contact-tab-panel a').evaluateAll(
-      (els) => els.map((e) => e.getAttribute('href')),
-    );
-    expect(hrefs).toEqual(CHANNELS);
-
-    // Every one opens away from the editor, and carries rel=noopener — a
+    // The byline that replaced the panel's owner row. mesindev.com is the only
+    // link, and it must open away from the editor with rel=noopener — a
     // target=_blank without it hands the opened tab a live handle on this one.
-    for (const a of await page.locator('#contact-tab-panel a').all()) {
-      const href = await a.getAttribute('href');
-      await expect(a, href).toHaveAttribute('target', '_blank');
-      expect(await a.getAttribute('rel'), href).toContain('noopener');
-    }
+    const link = page.locator('.fb-owner a');
+    await expect(link).toHaveAttribute('href', 'https://mesindev.com');
+    await expect(link).toHaveAttribute('target', '_blank');
+    expect(await link.getAttribute('rel')).toContain('noopener');
+    await expect(page.locator('.fb-owner b')).toHaveText('Ojan');
   });
 
-  test('the panel is really closed when it is closed', async ({ page }) => {
-    // visibility, not just opacity: an invisible-but-present panel still takes
-    // taps and still reads aloud, which is the bug #support-card already had.
-    await openEditor(page);
-    const first = page.locator('#contact-tab-panel a').first();
-    await expect(first).toBeHidden();
-    await page.click('#contact-tab-btn');
-    await expect(first).toBeVisible();
+  test('CONTROL: the footer link still opens the SAME dialog — two doors, one form', async ({ page }) => {
+    // The tab reuses #fb-open's own handler rather than getting a parallel one.
+    // If they ever diverge, one of these two paths stops working and this is
+    // where it shows.
+    await page.goto('/');
+    await page.click('#fb-open');
+    await expect(page.locator('#fb-form')).toBeVisible();
+    await expect(page.locator('.fb-owner b')).toHaveText('Ojan');
   });
 });

--- a/tests/mobile/feedback-form.spec.js
+++ b/tests/mobile/feedback-form.spec.js
@@ -97,16 +97,24 @@ test.describe('general feedback form — mobile', () => {
     expect(sent.length).toBe(0); // dismissing sent nothing at all
   });
 
-  test('the founder-ratified copy is exactly what ships (his words, 2026-08-03)', async ({ page }) => {
+  test('the founder-ratified copy is exactly what ships (2026-08-03, placeholder re-ruled 2026-09-09)', async ({ page }) => {
     // He ruled these six strings one at a time and rewrote two of them himself.
     // A ruling nobody checks is a green that cannot go red, so this asserts the
-    // two he authored VERBATIM — including the lowercase and his spelling of
+    // ones he authored VERBATIM — including the lowercase and his spelling of
     // "terimakasih", which are his and not typos to tidy. If a future pass
     // sentence-cases or "improves" them, this fails, which is the point.
+    //
+    // ⚠️ THE PLACEHOLDER CHANGED, AND THIS TEST IS WHY THAT WAS SAFE. It went
+    // RED on CI when the string moved, exactly as designed — the old value was
+    // his from 2026-08-03 and nothing may retire it quietly. He re-ruled it on
+    // 2026-09-09 when the form gained the pasted screenshot: "gausah ada
+    // tombolnya, bilang aja diplaceholdernya 'tulis feedbacknya di sini, atau
+    // boleh paste screenshot'". So the expectation is updated with a DATE and a
+    // quote, never silently. A red here always means ask him, never edit.
     await openForm(page);
     await expect(page.locator('#fb-note')).toHaveAttribute(
       'placeholder',
-      'boleh minta feedbacknya di sini, supaya kita bisa improve terus pdflokal. (boleh dikosongin juga kok)',
+      'tulis feedbacknya di sini, atau boleh paste screenshot',
     );
     await expect(page.locator('#fb-open')).toHaveText('Ada masukan?');
     await expect(page.locator('.fb-body h2')).toHaveText('Gimana PDFLokal?');


### PR DESCRIPTION
Three of his rulings from 2026-09-09. Opened so **CI** gates them — his laptop cannot currently produce a trustworthy gate (three local runs, each 60-70% over baseline, each red on a different set of wall-clock timeouts, all green in isolation).

⚠️ **These three commits were reported as pushed twice and were not.** After PR #133 merged, the session stayed on `main` and kept committing there, while `git push -q origin emeterai` pushed the stale local `emeterai` ref — a no-op that `-q` made silent. Nothing was on a remote until this branch. The gate had not seen any of it.

## 1 · Tools share the header row on desktop (`2006b20`)

> "buat desktop, pindahin tools2nya ke atas. karena spacenya kosong, cuma bikin dua baris navbar kalo spacenya ga cukup aja"

The toolbar moved **inside** `<header>` and is placed by `order`. One element in two layouts, never two — a duplicate desktop tool row would drift.

**The breakpoint is measured: 900px.** `.spacer { flex: 1 }` is the slack, so its width is the headroom — 152px at 1000, 52 at 900, 12 at 860, **zero at 848**. 848 is the true minimum; 900 is that plus ~50 so the row never sits flush.

The gauge took four tries. Per-tool `scrollWidth` twice, then a `#spacer` id that is actually a **class**, so the query returned null and the check passed on null. Each reported "fits" at every width down to 760.

## 2 · The feedback tab (`2006b20`)

> "ilangin semua sosmed gue, gaada yang peduli wkwk" + "icon ini diganti jadi kata2 aja ya 'ada masukan?'"

Glyph and five-handle panel both gone. The tab reads "Ada masukan?" — his own footer string, ratified 2026-08-22, so **zero new copy**. Identity moved into the dialog as a byline: Ojan / mesindev.com.

`kontak-channels.spec.js` is **rewritten, not deleted**. It existed because a mistyped handle does not 404 — it becomes a live link to a stranger's account under his name. The guard inverts: it now asserts no social handle appears on the surface at all.

## 3 · Paste a screenshot into the note (`b56ad49`, `6598833`)

> "gausah ada tombolnya, bilang aja diplaceholdernya 'tulis feedbacknya di sini, atau boleh paste screenshot'"

No attach button, and **a test asserts the absence** — the absence is what makes an image defensible against the "no uploads" claim. Shown back before sending, cleared on Batal, re-encoded to JPEG (which drops EXIF/GPS).

`core/feedback-shot.js` is its own module, not a widened `feedback-sample.js`: a matched PNG crop pair produced by our code and one user-chosen JPEG are different objects with different consent stories.

**DB:** `screenshot text` + a CHECK constraint, already applied to Neon. Additive, which the low-risk list rules INCLUDE.

`tests/core/feedback-delivery.test.mjs` went red for the right reason — its full-array assertion caught `screenshot` joining the insert. Updated deliberately, not loosened.

## 🤚 Flagged, not edited

`privasi.html`'s headline lists still say *"File PDF dan gambar kamu tidak pernah dikirim ke server manapun"* and *"Isi dokumen, teks, atau tanda tangan"*. Both were **already** overbroad because of the edit-beta crop path; this widens the gap. They are the moat claim, so they are his to word and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)